### PR TITLE
fix(grokpool): avoid typed-nil Transport panic when no proxy is set

### DIFF
--- a/internal/grokpool/manager.go
+++ b/internal/grokpool/manager.go
@@ -467,8 +467,16 @@ func (m *Manager) Transport() http.RoundTripper {
 	return m.transport
 }
 
-func clientForTransport(transport http.RoundTripper) *http.Client {
-	return &http.Client{Transport: transport, Timeout: 25 * time.Second}
+// clientForTransport builds an HTTP client for pool probes.
+// A nil *http.Transport must stay a true nil RoundTripper: assigning a typed-nil
+// *http.Transport into Client.Transport makes net/http treat Transport as set and
+// panic on request (nil pointer in alternateRoundTripper) when no proxy is configured.
+func clientForTransport(transport *http.Transport) *http.Client {
+	client := &http.Client{Timeout: 25 * time.Second}
+	if transport != nil {
+		client.Transport = transport
+	}
+	return client
 }
 
 func credentialID(credential grokauth.Credential) string {

--- a/internal/grokpool/manager_test.go
+++ b/internal/grokpool/manager_test.go
@@ -284,6 +284,35 @@ func TestInspectionUsesConfiguredHTTPProxy(t *testing.T) {
 	}
 }
 
+func TestClientForTransportNilDoesNotInstallTypedNil(t *testing.T) {
+	client := clientForTransport(nil)
+	if client.Transport != nil {
+		t.Fatalf("nil *http.Transport must leave Client.Transport unset, got %#v", client.Transport)
+	}
+
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manager.client == nil || manager.client.Transport != nil {
+		t.Fatalf("empty proxy should use default transport path, client=%#v", manager.client)
+	}
+	if manager.Transport() != nil {
+		t.Fatal("Manager.Transport() should stay nil when no proxy is configured")
+	}
+
+	// A typed-nil RoundTripper panics inside net/http; a true-nil Transport does not.
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:1/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := manager.client.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected connection error, not success")
+	}
+}
+
 func TestEnsureMigratesMissingCredentialWithoutResettingExistingResult(t *testing.T) {
 	manager, err := NewManager(t.TempDir())
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes a startup crash in Grok pool account inspection when `proxy_url` is empty (the common default).

### Problem

`netproxy.BuildTransport(")` returns a nil `*http.Transport`. `clientForTransport` previously did:

```go
&http.Client{Transport: transport, ...}
```

Passing a nil `*http.Transport` as `http.RoundTripper` creates a **typed-nil** interface. `net/http` then treats `Client.Transport` as non-nil and panics on the first request:

```text
panic: runtime error: invalid memory address or nil pointer dereference
net/http.(*Transport).alternateRoundTripper
grok_switch/internal/grokpool.(*Manager).doProbe
```

In practice this makes `grok_switch.exe` appear to "fail to open": it starts, enables inspection, then immediately crashes when probing accounts without a configured proxy.

### Fix

Align with `grokauth.Store.SetProxyURL`: only set `Client.Transport` when the `*http.Transport` is non-nil, so empty proxy uses `http.DefaultTransport`.

Also change `clientForTransport` to take `*http.Transport` so this cannot regress through a typed-nil `RoundTripper` assignment.

### Test plan

- [x] Added `TestClientForTransportNilDoesNotInstallTypedNil`
- [ ] `go test ./internal/grokpool/ ./internal/netproxy/`
- [ ] Manual: start with pool accounts + empty `proxy_url` + inspection enabled; process should stay up and UI should load

### Notes

`grokauth` already handled this correctly; only the pool manager probe client was affected.