### PR TITLE
feat: 注册机新增 GPTMail 与 YYDS Mail 邮箱服务商

### DIFF
--- a/internal/registrar/cloudflare.go
+++ b/internal/registrar/cloudflare.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -348,55 +347,6 @@ func firstMapString(object map[string]any, keys ...string) string {
 	return ""
 }
 
-func responseItems(value any) []map[string]any {
-	switch typed := value.(type) {
-	case []any:
-		items := make([]map[string]any, 0, len(typed))
-		for _, item := range typed {
-			if object, ok := item.(map[string]any); ok {
-				items = append(items, object)
-			}
-		}
-		return items
-	case map[string]any:
-		for _, key := range []string{"results", "hydra:member", "data", "messages", "mails"} {
-			if child, exists := typed[key]; exists {
-				if items := responseItems(child); len(items) > 0 {
-					return items
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func responseObject(value any) map[string]any {
-	object, ok := value.(map[string]any)
-	if !ok {
-		return nil
-	}
-	for _, key := range []string{"data", "result", "message", "mail"} {
-		if child, ok := object[key].(map[string]any); ok {
-			return child
-		}
-	}
-	return object
-}
-
-func messageID(message map[string]any) string {
-	for _, key := range []string{"id", "msgid", "messageId"} {
-		switch value := message[key].(type) {
-		case string:
-			if value != "" {
-				return value
-			}
-		case float64:
-			return strconv.FormatInt(int64(value), 10)
-		}
-	}
-	return ""
-}
-
 func messageRecipient(message map[string]any) string {
 	for _, key := range []string{"address", "to", "toEmail", "recipient"} {
 		switch value := message[key].(type) {
@@ -421,19 +371,3 @@ func messageRecipient(message map[string]any) string {
 	return ""
 }
 
-func messageChunks(message map[string]any) []string {
-	chunks := make([]string, 0, 10)
-	for _, key := range []string{"subject", "text", "raw", "content", "intro", "body", "snippet", "html", "textContent"} {
-		switch value := message[key].(type) {
-		case string:
-			chunks = append(chunks, value)
-		case []any:
-			for _, item := range value {
-				if text, ok := item.(string); ok {
-					chunks = append(chunks, text)
-				}
-			}
-		}
-	}
-	return chunks
-}

--- a/internal/registrar/gptmail.go
+++ b/internal/registrar/gptmail.go
@@ -1,0 +1,176 @@
+package registrar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// gptmailProvider talks to a GPTMail-compatible temporary mailbox service
+// (e.g. https://mail.chatgpt.org.uk). All endpoints require the X-API-Key
+// header; responses are uniformly { success, data, error }.
+type gptmailProvider struct {
+	mu     sync.Mutex
+	config Config
+	used   map[string]bool
+	client *http.Client
+	domain string
+}
+
+func newGptmailProvider(config Config, used map[string]bool, client *http.Client) (*gptmailProvider, error) {
+	if strings.TrimSpace(config.GptmailURL) == "" {
+		return nil, fmt.Errorf("GPTMail 需要 API Base URL")
+	}
+	if strings.TrimSpace(config.GptmailAPIKey) == "" {
+		return nil, fmt.Errorf("GPTMail 需要 API Key")
+	}
+	return &gptmailProvider{
+		config: config,
+		used:   used,
+		client: client,
+	}, nil
+}
+
+type gptmailEnvelope struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error"`
+	Data    any    `json:"data"`
+}
+
+func (p *gptmailProvider) request(ctx context.Context, method, endpoint string, payload any, out any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	parsed, err := url.Parse(strings.TrimRight(p.config.GptmailURL, "/") + endpoint)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, parsed.String(), strings.NewReader(string(raw)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", strings.TrimSpace(p.config.GptmailAPIKey))
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var envelope gptmailEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("GPTMail 返回无效 JSON: %w", err)
+	}
+	if !envelope.Success {
+		return fmt.Errorf("GPTMail: %s", envelope.Error)
+	}
+	rawData, err := json.Marshal(envelope.Data)
+	if err != nil {
+		return err
+	}
+	if out != nil {
+		if err := json.Unmarshal(rawData, out); err != nil {
+			return fmt.Errorf("GPTMail 返回结构不符: %w", err)
+		}
+	}
+	return nil
+}
+
+func (p *gptmailProvider) Allocate(ctx context.Context) (Mailbox, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for attempt := 0; attempt < 10; attempt++ {
+		var data struct {
+			Email string `json:"email"`
+		}
+		var payload any
+		if p.domain != "" {
+			payload = map[string]string{"domain": p.domain}
+		}
+		if err := p.request(ctx, http.MethodPost, "/api/generate-email", payload, &data); err != nil {
+			return nil, err
+		}
+		address := strings.ToLower(strings.TrimSpace(data.Email))
+		if address == "" || p.used[address] {
+			continue
+		}
+		p.used[address] = true
+		if at := strings.LastIndex(address, "@"); at >= 0 {
+			p.domain = address[at+1:]
+		}
+		return &gptmailMailbox{provider: p, address: address}, nil
+	}
+	return nil, fmt.Errorf("GPTMail 连续返回重复或空地址")
+}
+
+type gptmailMailbox struct {
+	provider *gptmailProvider
+	address  string
+}
+
+func (m *gptmailMailbox) Address() string { return m.address }
+
+func (m *gptmailMailbox) WaitCode(ctx context.Context, timeout time.Duration, log func(string)) (string, error) {
+	deadline := time.Now().Add(timeout)
+	seen := map[string]bool{}
+	for time.Now().Before(deadline) {
+		var data []struct {
+			ID      string `json:"id"`
+			Subject string `json:"subject"`
+			From    string `json:"from"`
+		}
+		query := url.Values{"email": {m.address}}
+		if err := m.provider.request(ctx, http.MethodGet, "/api/emails?"+query.Encode(), nil, &data); err != nil {
+			if log != nil {
+				log("GPTMail 收件请求失败，继续重试: " + err.Error())
+			}
+		} else {
+			for index := len(data) - 1; index >= 0; index-- {
+				message := data[index]
+				if message.ID == "" || seen[message.ID] {
+					continue
+				}
+				seen[message.ID] = true
+				var detail struct {
+					// Keep the raw JSON so the shared extractor can scan
+					// text/html bodies regardless of exact field names.
+					Raw map[string]any `json:"-"`
+				}
+				if err := m.provider.request(ctx, http.MethodGet, "/api/email/"+url.PathEscape(message.ID), nil, &detail.Raw); err != nil {
+					if log != nil {
+						log("GPTMail 邮件详情读取失败: " + err.Error())
+					}
+					continue
+				}
+				if code := extractVerificationCode(messageChunks(detail.Raw)...); code != "" {
+					if log != nil {
+						log("已从 GPTMail 邮件提取验证码")
+					}
+					return code, nil
+				}
+			}
+		}
+		if log != nil {
+			log("等待 GPTMail 验证码")
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(1500 * time.Millisecond):
+		}
+	}
+	return "", fmt.Errorf("GPTMail 在 %s 内未收到验证码", timeout)
+}

--- a/internal/registrar/gptmail.go
+++ b/internal/registrar/gptmail.go
@@ -127,35 +127,37 @@ func (m *gptmailMailbox) WaitCode(ctx context.Context, timeout time.Duration, lo
 	deadline := time.Now().Add(timeout)
 	seen := map[string]bool{}
 	for time.Now().Before(deadline) {
-		var data []struct {
-			ID      string `json:"id"`
-			Subject string `json:"subject"`
-			From    string `json:"from"`
-		}
+		var data any
 		query := url.Values{"email": {m.address}}
 		if err := m.provider.request(ctx, http.MethodGet, "/api/emails?"+query.Encode(), nil, &data); err != nil {
 			if log != nil {
 				log("GPTMail 收件请求失败，继续重试: " + err.Error())
 			}
 		} else {
-			for index := len(data) - 1; index >= 0; index-- {
-				message := data[index]
-				if message.ID == "" || seen[message.ID] {
+			messages := responseItems(data)
+			for index := len(messages) - 1; index >= 0; index-- {
+				message := messages[index]
+				id := messageID(message)
+				if id == "" || seen[id] {
 					continue
 				}
-				seen[message.ID] = true
-				var detail struct {
-					// Keep the raw JSON so the shared extractor can scan
-					// text/html bodies regardless of exact field names.
-					Raw map[string]any `json:"-"`
+				seen[id] = true
+				// List responses already carry a plain-text content snippet which
+				// usually contains the code; try it before fetching the detail.
+				if code := extractVerificationCode(messageChunks(message)...); code != "" {
+					if log != nil {
+						log("已从 GPTMail 邮件提取验证码")
+					}
+					return code, nil
 				}
-				if err := m.provider.request(ctx, http.MethodGet, "/api/email/"+url.PathEscape(message.ID), nil, &detail.Raw); err != nil {
+				var detail any
+				if err := m.provider.request(ctx, http.MethodGet, "/api/email/"+url.PathEscape(id), nil, &detail); err != nil {
 					if log != nil {
 						log("GPTMail 邮件详情读取失败: " + err.Error())
 					}
 					continue
 				}
-				if code := extractVerificationCode(messageChunks(detail.Raw)...); code != "" {
+				if code := extractVerificationCode(messageChunks(responseObject(detail))...); code != "" {
 					if log != nil {
 						log("已从 GPTMail 邮件提取验证码")
 					}

--- a/internal/registrar/gptmail_test.go
+++ b/internal/registrar/gptmail_test.go
@@ -1,0 +1,79 @@
+package registrar
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGptmailAllocateAndWaitCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "test-key" {
+			t.Fatalf("missing or wrong X-API-Key: %q", r.Header.Get("X-API-Key"))
+		}
+		switch r.URL.Path {
+		case "/api/generate-email":
+			writeTestJSON(w, map[string]any{
+				"success": true,
+				"data":    map[string]any{"email": "demo@example.org"},
+			})
+		case "/api/emails":
+			writeTestJSON(w, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"emails": []map[string]any{
+						{
+							"id":      "m79_abc123",
+							"subject": "SpaceXAI confirmation code: SVN-BSH",
+							"content": "below to validate your email address. SVN-BSH",
+						},
+					},
+				},
+			})
+		case "/api/email/m79_abc123":
+			writeTestJSON(w, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"id":           "m79_abc123",
+					"html_content": "<p>SVN-BSH</p>",
+					"content":      "",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	config := Config{
+		GptmailURL:    server.URL,
+		GptmailAPIKey: "test-key",
+	}
+	provider, err := newGptmailProvider(config, map[string]bool{}, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mailbox, err := provider.Allocate(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mailbox.Address(); got != "demo@example.org" {
+		t.Fatalf("address = %q, want demo@example.org", got)
+	}
+	code, err := mailbox.WaitCode(context.Background(), 5*time.Second, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != "SVN-BSH" {
+		t.Fatalf("code = %q, want SVN-BSH", code)
+	}
+}
+
+func TestGptmailRequiresConfig(t *testing.T) {
+	if _, err := newGptmailProvider(Config{}, map[string]bool{}, &http.Client{}); err == nil {
+		t.Fatal("expected error for missing URL/key")
+	}
+}

--- a/internal/registrar/mail.go
+++ b/internal/registrar/mail.go
@@ -9,6 +9,7 @@ import (
 	"mime"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -242,4 +243,70 @@ func decodeMIMEHeader(value string) string {
 		return value
 	}
 	return decoded
+}
+
+func responseItems(value any) []map[string]any {
+	switch typed := value.(type) {
+	case []any:
+		items := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			if object, ok := item.(map[string]any); ok {
+				items = append(items, object)
+			}
+		}
+		return items
+	case map[string]any:
+		for _, key := range []string{"results", "hydra:member", "data", "messages", "mails", "emails"} {
+			if child, exists := typed[key]; exists {
+				if items := responseItems(child); len(items) > 0 {
+					return items
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func responseObject(value any) map[string]any {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+	for _, key := range []string{"data", "result", "message", "mail"} {
+		if child, ok := object[key].(map[string]any); ok {
+			return child
+		}
+	}
+	return object
+}
+
+func messageID(message map[string]any) string {
+	for _, key := range []string{"id", "msgid", "messageId"} {
+		switch value := message[key].(type) {
+		case string:
+			if value != "" {
+				return value
+			}
+		case float64:
+			return strconv.FormatInt(int64(value), 10)
+		}
+	}
+	return ""
+}
+
+func messageChunks(message map[string]any) []string {
+	chunks := make([]string, 0, 10)
+	for _, key := range []string{"subject", "text", "raw", "content", "intro", "body", "snippet", "html", "html_content", "textContent", "email_address", "from_address"} {
+		switch value := message[key].(type) {
+		case string:
+			chunks = append(chunks, value)
+		case []any:
+			for _, item := range value {
+				if text, ok := item.(string); ok {
+					chunks = append(chunks, text)
+				}
+			}
+		}
+	}
+	return chunks
 }

--- a/internal/registrar/mail.go
+++ b/internal/registrar/mail.go
@@ -57,6 +57,10 @@ func newMailProvider(config Config, used map[string]bool) (MailProvider, error) 
 		return newCloudmailProvider(config, used, client)
 	case "cloudflare":
 		return newCloudflareProvider(config, used, client)
+	case "gptmail":
+		return newGptmailProvider(config, used, client)
+	case "yyds":
+		return newYydsProvider(config, used, client)
 	default:
 		return nil, fmt.Errorf("不支持的邮箱服务商: %s", config.EmailProvider)
 	}

--- a/internal/registrar/store.go
+++ b/internal/registrar/store.go
@@ -68,6 +68,10 @@ func normalizeConfig(config Config) Config {
 	config.CloudflareAccountsPath = normalizeAPIPath(config.CloudflareAccountsPath, defaults.CloudflareAccountsPath)
 	config.CloudflareTokenPath = normalizeAPIPath(config.CloudflareTokenPath, defaults.CloudflareTokenPath)
 	config.CloudflareMessagesPath = normalizeAPIPath(config.CloudflareMessagesPath, defaults.CloudflareMessagesPath)
+	config.GptmailURL = strings.TrimRight(strings.TrimSpace(config.GptmailURL), "/")
+	config.GptmailAPIKey = strings.TrimSpace(config.GptmailAPIKey)
+	config.YydsURL = strings.TrimRight(strings.TrimSpace(config.YydsURL), "/")
+	config.YydsAPIKey = strings.TrimSpace(config.YydsAPIKey)
 	if config.HotmailMaxAliases == 0 {
 		config.HotmailMaxAliases = defaults.HotmailMaxAliases
 	}
@@ -156,8 +160,22 @@ func validateConfig(config Config, forStart bool) error {
 		if config.CloudflareAuthMode != "none" && config.CloudflareAPIKey == "" {
 			return fmt.Errorf("Cloudflare 认证方式 %s 需要 API Key", config.CloudflareAuthMode)
 		}
+	case "gptmail":
+		if config.GptmailURL == "" {
+			return fmt.Errorf("GPTMail 模式需要 API Base URL")
+		}
+		if config.GptmailAPIKey == "" {
+			return fmt.Errorf("GPTMail 模式需要 API Key")
+		}
+	case "yyds":
+		if config.YydsURL == "" {
+			return fmt.Errorf("YYDS Mail 模式需要 API Base URL")
+		}
+		if config.YydsAPIKey == "" {
+			return fmt.Errorf("YYDS Mail 模式需要 API Key")
+		}
 	default:
-		return fmt.Errorf("当前内置模块只支持 hotmail、cloudmail 和 cloudflare")
+		return fmt.Errorf("当前内置模块只支持 hotmail、cloudmail、cloudflare、gptmail 和 yyds")
 	}
 	return nil
 }

--- a/internal/registrar/types.go
+++ b/internal/registrar/types.go
@@ -31,6 +31,10 @@ type Config struct {
 	CloudflareMessagesPath string `json:"cloudflare_path_messages"`
 	HotmailAccountsText    string `json:"hotmail_accounts_text"`
 	HotmailMaxAliases      int    `json:"hotmail_max_aliases"`
+	GptmailURL             string `json:"gptmail_url"`
+	GptmailAPIKey          string `json:"gptmail_api_key"`
+	YydsURL                string `json:"yyds_url"`
+	YydsAPIKey             string `json:"yyds_api_key"`
 	Count                  int    `json:"count"`
 	Workers                int    `json:"workers"`
 	MailTimeoutSeconds     int    `json:"mail_timeout_seconds"`

--- a/internal/registrar/yyds.go
+++ b/internal/registrar/yyds.go
@@ -1,0 +1,177 @@
+package registrar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// yydsProvider talks to the YYDS Mail service (https://maliapi.215.im/v1).
+// Auth is X-API-Key: AC-xxxxxx. The /v1/messages/next endpoint long-polls and
+// atomically returns the oldest unread message with a server-extracted
+// verificationCode, which makes the wait loop a single call per poll.
+type yydsProvider struct {
+	mu     sync.Mutex
+	config Config
+	used   map[string]bool
+	client *http.Client
+}
+
+func newYydsProvider(config Config, used map[string]bool, client *http.Client) (*yydsProvider, error) {
+	if strings.TrimSpace(config.YydsURL) == "" {
+		return nil, fmt.Errorf("YYDS Mail 需要 API Base URL")
+	}
+	if strings.TrimSpace(config.YydsAPIKey) == "" {
+		return nil, fmt.Errorf("YYDS Mail 需要 API Key")
+	}
+	return &yydsProvider{
+		config: config,
+		used:   used,
+		client: client,
+	}, nil
+}
+
+func (p *yydsProvider) request(ctx context.Context, method, endpoint string, payload any, out any) error {
+	var body io.Reader
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		body = strings.NewReader(string(raw))
+	}
+	parsed, err := url.Parse(strings.TrimRight(p.config.YydsURL, "/") + endpoint)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, parsed.String(), body)
+	if err != nil {
+		return err
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-API-Key", strings.TrimSpace(p.config.YydsAPIKey))
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("HTTP %s: %s", resp.Status, strings.TrimSpace(string(raw)))
+	}
+	var envelope struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+		Data    any    `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("YYDS Mail 返回无效 JSON: %w", err)
+	}
+	if !envelope.Success {
+		return fmt.Errorf("YYDS Mail: %s", envelope.Error)
+	}
+	if out != nil {
+		data, err := json.Marshal(envelope.Data)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("YYDS Mail 返回结构不符: %w", err)
+		}
+	}
+	return nil
+}
+
+func (p *yydsProvider) Allocate(ctx context.Context) (Mailbox, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for attempt := 0; attempt < 10; attempt++ {
+		local, err := randomText(10)
+		if err != nil {
+			return nil, err
+		}
+		payload := map[string]string{"localPart": local}
+		if domain := strings.TrimSpace(p.config.DefaultDomains); domain != "" {
+			payload["domain"] = domain // fixed domain; subdomain omitted → fixed-domain behavior
+		}
+		var data struct {
+			Address string `json:"address"`
+		}
+		if err := p.request(ctx, http.MethodPost, "/v1/accounts", payload, &data); err != nil {
+			return nil, err
+		}
+		address := strings.ToLower(strings.TrimSpace(data.Address))
+		if address == "" || p.used[address] {
+			continue
+		}
+		p.used[address] = true
+		return &yydsMailbox{provider: p, address: address}, nil
+	}
+	return nil, fmt.Errorf("YYDS Mail 连续返回重复或空地址")
+}
+
+type yydsMailbox struct {
+	provider *yydsProvider
+	address  string
+}
+
+func (m *yydsMailbox) Address() string { return m.address }
+
+func (m *yydsMailbox) WaitCode(ctx context.Context, timeout time.Duration, log func(string)) (string, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		remaining := time.Until(deadline)
+		wait := 30
+		// Long-poll window: never exceed the remaining deadline.
+		if remaining < 30*time.Second {
+			wait = int(remaining / time.Second)
+			if wait < 1 {
+				wait = 1
+			}
+		}
+		query := url.Values{"address": {m.address}, "wait": {fmt.Sprintf("%d", wait)}}
+		var data struct {
+			Message struct {
+				VerificationCode string `json:"verificationCode"`
+			} `json:"message"`
+		}
+		err := m.provider.request(ctx, http.MethodGet, "/v1/messages/next?"+query.Encode(), nil, &data)
+		if err != nil {
+			if log != nil {
+				log("YYDS Mail 收件请求失败，继续重试: " + err.Error())
+			}
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(1500 * time.Millisecond):
+			}
+			continue
+		}
+		if code := strings.TrimSpace(data.Message.VerificationCode); code != "" {
+			if log != nil {
+				log("已从 YYDS Mail 邮件提取验证码")
+			}
+			return code, nil
+		}
+		if log != nil {
+			log("等待 YYDS Mail 验证码")
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(1500 * time.Millisecond):
+		}
+	}
+	return "", fmt.Errorf("YYDS Mail 在 %s 内未收到验证码", timeout)
+}

--- a/internal/registrar/yyds.go
+++ b/internal/registrar/yyds.go
@@ -30,6 +30,14 @@ func newYydsProvider(config Config, used map[string]bool, client *http.Client) (
 	if strings.TrimSpace(config.YydsAPIKey) == "" {
 		return nil, fmt.Errorf("YYDS Mail 需要 API Key")
 	}
+	// Endpoints below are written starting with /v1 (e.g. /v1/accounts).
+	// Accept a base URL with or without the trailing /v1 so both
+	// https://maliapi.215.im and https://maliapi.215.im/v1 work.
+	baseURL := strings.TrimRight(strings.TrimSpace(config.YydsURL), "/")
+	if strings.HasSuffix(baseURL, "/v1") {
+		baseURL = strings.TrimSuffix(baseURL, "/v1")
+	}
+	config.YydsURL = baseURL
 	return &yydsProvider{
 		config: config,
 		used:   used,

--- a/internal/registrar/yyds_test.go
+++ b/internal/registrar/yyds_test.go
@@ -1,0 +1,97 @@
+package registrar
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestYydsAllocateAndWaitCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "AC-test" {
+			t.Fatalf("missing or wrong X-API-Key: %q", r.Header.Get("X-API-Key"))
+		}
+		if r.URL.Path == "/v1/accounts" && r.Method != http.MethodPost {
+			t.Fatalf("accounts method = %s, want POST", r.Method)
+		}
+		switch r.URL.Path {
+		case "/v1/accounts":
+			writeTestJSON(w, map[string]any{
+				"success": true,
+				"data":    map[string]any{"address": "my-prefix@a3f9c2.mail.example.com", "mode": "wildcard"},
+			})
+		case "/v1/messages/next":
+			writeTestJSON(w, map[string]any{
+				"success": true,
+				"data": map[string]any{
+					"message": map[string]any{
+						"verificationCode": "SVN-BSH",
+					},
+					"inboxAddress": "my-prefix@a3f9c2.mail.example.com",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	config := Config{
+		YydsURL:    server.URL,
+		YydsAPIKey: "AC-test",
+	}
+	provider, err := newYydsProvider(config, map[string]bool{}, &http.Client{Timeout: 10 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mailbox, err := provider.Allocate(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := mailbox.Address(); got != "my-prefix@a3f9c2.mail.example.com" {
+		t.Fatalf("address = %q", got)
+	}
+	code, err := mailbox.WaitCode(context.Background(), 5*time.Second, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code != "SVN-BSH" {
+		t.Fatalf("code = %q, want SVN-BSH", code)
+	}
+}
+
+func TestYydsRequiresConfig(t *testing.T) {
+	if _, err := newYydsProvider(Config{}, map[string]bool{}, &http.Client{}); err == nil {
+		t.Fatal("expected error for missing URL/key")
+	}
+}
+
+// A base URL that already ends with /v1 must not produce /v1/v1/... paths.
+func TestYydsBaseURLNormalization(t *testing.T) {
+	var hitPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitPath = r.URL.Path
+		writeTestJSON(w, map[string]any{
+			"success": true,
+			"data":    map[string]any{"address": "norm@example.test"},
+		})
+	}))
+	defer server.Close()
+
+	config := Config{
+		YydsURL:    server.URL + "/v1", // user-facing base including /v1
+		YydsAPIKey: "AC-test",
+	}
+	provider, err := newYydsProvider(config, map[string]bool{}, &http.Client{Timeout: 10 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Allocate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if hitPath != "/v1/accounts" {
+		t.Fatalf("path = %q, want /v1/accounts", hitPath)
+	}
+}

--- a/ui/app.js
+++ b/ui/app.js
@@ -4430,7 +4430,11 @@ function registrarConfigFromForm() {
     proxy_cooldown_seconds: Number($("registrarProxyCooldown")?.value || 120),
     register_engine: $("registrarEngine")?.value || "browser",
     email_provider: provider,
-    default_domains: (provider === "cloudflare" ? $("registrarCloudflareDomains").value : $("registrarDefaultDomains").value).trim(),
+    default_domains: (provider === "cloudflare"
+      ? $("registrarCloudflareDomains").value
+      : provider === "yyds"
+        ? ($("registrarYydsDomains")?.value || "").trim()
+        : $("registrarDefaultDomains").value).trim(),
     cloudmail_url: $("registrarCloudmailUrl").value.trim(),
     cloudmail_admin_email: $("registrarCloudmailAdminEmail").value.trim(),
     cloudmail_password: $("registrarCloudmailPassword").value,
@@ -4443,6 +4447,10 @@ function registrarConfigFromForm() {
     cloudflare_path_messages: $("registrarCloudflareMessagesPath").value.trim(),
     hotmail_accounts_text: $("registrarHotmailAccounts").value,
     hotmail_max_aliases: Number($("registrarHotmailAliases").value || 5),
+    gptmail_url: $("registrarGptmailUrl")?.value.trim() || "",
+    gptmail_api_key: $("registrarGptmailApiKey")?.value.trim() || "",
+    yyds_url: $("registrarYydsUrl")?.value.trim() || "",
+    yyds_api_key: $("registrarYydsApiKey")?.value.trim() || "",
     count: Number($("registrarCount").value || 1),
     workers: Number($("registrarWorkers").value || 1),
     mail_timeout_seconds: Number($("registrarMailTimeout").value || 180),
@@ -4476,6 +4484,11 @@ function renderRegistrar(stateData) {
     if ($("registrarCloudflareMessagesPath")) $("registrarCloudflareMessagesPath").value = config.cloudflare_path_messages || "/api/mails";
     if ($("registrarHotmailAccounts")) $("registrarHotmailAccounts").value = config.hotmail_accounts_text || "";
     if ($("registrarHotmailAliases")) $("registrarHotmailAliases").value = config.hotmail_max_aliases || 5;
+    if ($("registrarGptmailUrl")) $("registrarGptmailUrl").value = config.gptmail_url || "";
+    if ($("registrarGptmailApiKey")) $("registrarGptmailApiKey").value = config.gptmail_api_key || "";
+    if ($("registrarYydsUrl")) $("registrarYydsUrl").value = config.yyds_url || "";
+    if ($("registrarYydsApiKey")) $("registrarYydsApiKey").value = config.yyds_api_key || "";
+    if ($("registrarYydsDomains")) $("registrarYydsDomains").value = config.default_domains || "";
     if ($("registrarCount")) $("registrarCount").value = config.count || 1;
     if ($("registrarWorkers")) $("registrarWorkers").value = config.workers || 1;
     if ($("registrarMailTimeout")) $("registrarMailTimeout").value = config.mail_timeout_seconds || 180;
@@ -4501,6 +4514,8 @@ function updateRegistrarProviderFields() {
   if ($("registrarHotmailFields")) $("registrarHotmailFields").hidden = provider !== "hotmail";
   if ($("registrarCloudmailFields")) $("registrarCloudmailFields").hidden = provider !== "cloudmail";
   if ($("registrarCloudflareFields")) $("registrarCloudflareFields").hidden = !isCloudflare;
+  if ($("registrarGptmailFields")) $("registrarGptmailFields").hidden = provider !== "gptmail";
+  if ($("registrarYydsFields")) $("registrarYydsFields").hidden = provider !== "yyds";
   // Non-default email modes need advanced fields; expand so users notice.
   const advanced = $("registrarAdvanced");
   if (advanced && !isCloudflare && !advanced.open) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -796,6 +796,8 @@
                   <option value="cloudflare">Cloudflare 临时邮箱（推荐）</option>
                   <option value="hotmail">Hotmail / Outlook</option>
                   <option value="cloudmail">CloudMail</option>
+                  <option value="gptmail">GPTMail</option>
+                  <option value="yyds">YYDS Mail</option>
                 </select>
               </label>
 
@@ -849,6 +851,27 @@
                 </label>
                 <label class="field">邮件列表接口
                   <input id="registrarCloudflareMessagesPath" class="mono" value="/api/mails">
+                </label>
+              </div>
+
+              <div id="registrarGptmailFields" class="registrarProviderFields registrarProviderWide" hidden>
+                <label class="field registrarProviderWide">GPTMail API Base
+                  <input id="registrarGptmailUrl" class="mono" placeholder="https://mail.chatgpt.org.uk">
+                </label>
+                <label class="field registrarProviderWide">API Key
+                  <input id="registrarGptmailApiKey" type="password" autocomplete="off" placeholder="X-API-Key">
+                </label>
+              </div>
+
+              <div id="registrarYydsFields" class="registrarProviderFields registrarProviderWide" hidden>
+                <label class="field registrarProviderWide">YYDS Mail API Base
+                  <input id="registrarYydsUrl" class="mono" placeholder="https://maliapi.215.im/v1">
+                </label>
+                <label class="field registrarProviderWide">API Key
+                  <input id="registrarYydsApiKey" type="password" autocomplete="off" placeholder="AC-xxxxxx">
+                </label>
+                <label class="field registrarProviderWide">固定域名（可选，留空自动分配）
+                  <input id="registrarYydsDomains" class="mono" placeholder="mail.example.com">
                 </label>
               </div>
 


### PR DESCRIPTION
## 变更内容

注册机新增两个邮箱服务商：**GPTMail** 与 **YYDS Mail**，与现有 cloudflare/cloudmail/hotmail 模式并列可选。

## 实现方式

### GPTMail（`internal/registrar/gptmail.go`）
- 认证：`X-API-Key` 请求头
- 生成邮箱：`POST /api/generate-email`（首次生成后记住域名，后续优先用该域名生成）
- 收件：`GET /api/emails?email=...` 轮询列表，对新邮件按 id 去重后 `GET /api/email/{id}` 拉详情，用现有共享的 `extractVerificationCode` 提取验证码
- 配置字段：`gptmail_url`、`gptmail_api_key`

### YYDS Mail（`internal/registrar/yyds.go`）
- 认证：`X-API-Key`（`AC-xxxxxx`）
- 生成邮箱：`POST /v1/accounts`（`localPart` 随机前缀；配置了固定域名时携带 `domain`，否则交给服务端分配）
- 收件：`GET /v1/messages/next?address=...&wait=30` 官方推荐的长轮询接口，一次调用原子取走最旧未读邮件，直接读服务端提取的 `verificationCode`；轮询窗口自动适配剩余超时时间
- 配置字段：`yyds_url`、`yyds_api_key`（复用 `default_domains` 作为可选固定域名）

## 接入点
- `Config` 新增 4 个字段，`normalizeConfig` / `validateConfig` 同步校验（URL 与 Key 必填），`newMailProvider` 分发
- UI（`ui/index.html`、`ui/app.js`）：邮箱服务下拉新增两个选项，各自独立的配置字段区，provider 切换时显示/隐藏

## 验证
- `go build ./...`、`go vet`、`go test ./internal/registrar/` 全部通过
- `node --check ui/app.js` 通过