### PR TITLE
fix(grokpool): 导入新凭据不再触发全量巡检，避免搞坏已有账号

### DIFF
--- a/internal/grokpool/manager.go
+++ b/internal/grokpool/manager.go
@@ -145,6 +145,7 @@ func (m *Manager) importFiles(files []ImportFile, onlyMissing bool) (ImportResul
 	}
 	result := ImportResult{}
 	changed := 0
+	var importedIDs []string
 	for _, file := range files {
 		credentials, err := grokauth.ParseCredentials([]byte(file.Content))
 		if err != nil {
@@ -156,7 +157,8 @@ func (m *Manager) importFiles(files []ImportFile, onlyMissing bool) (ImportResul
 			if len(credentials) > 1 {
 				name = fmt.Sprintf("%s#%d", firstNonEmpty(name, "auth.json"), index+1)
 			}
-			if onlyMissing && m.hasCredential(credentialID(credential)) {
+			id := credentialID(credential)
+			if onlyMissing && m.hasCredential(id) {
 				result.Updated++
 				continue
 			}
@@ -170,23 +172,49 @@ func (m *Manager) importFiles(files []ImportFile, onlyMissing bool) (ImportResul
 			} else {
 				result.Imported++
 			}
+			importedIDs = append(importedIDs, id)
 			changed++
 		}
 	}
 	if result.Imported+result.Updated == 0 {
 		return result, fmt.Errorf("没有成功导入账号")
 	}
-	if changed > 0 {
-		m.mu.Lock()
-		if m.running {
-			m.rerunRequested = true
-		} else if m.state.Settings.Enabled {
-			m.nextRun = time.Now().UTC()
-		}
-		m.mu.Unlock()
-		m.signalWake()
+	// 只对新导入/更新的账号做单独巡检，不再触发全量巡检。
+	// 原来的 signalWake + nextRun=now 会遍历整个号池，网络波动时
+	// 容易把好账号误判为异常（reauth/delete），搞坏已有账号。
+	if changed > 0 && len(importedIDs) > 0 {
+		go m.inspectAccountsOnly(importedIDs)
 	}
 	return result, nil
+}
+
+// inspectAccountsOnly inspects a subset of accounts by ID without touching
+// the rest of the pool. Used after import to verify only the new/updated
+// credentials instead of running a full-pool sweep.
+func (m *Manager) inspectAccountsOnly(ids []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	for _, id := range ids {
+		if ctx.Err() != nil {
+			return
+		}
+		m.mu.Lock()
+		var account Account
+		found := false
+		for _, a := range m.state.Accounts {
+			if a.ID == id {
+				account = a
+				found = true
+				break
+			}
+		}
+		m.mu.Unlock()
+		if !found {
+			continue
+		}
+		result := m.inspectAccount(ctx, account)
+		m.recordInspection(result)
+	}
 }
 
 func (m *Manager) hasCredential(id string) bool {


### PR DESCRIPTION
## 问题

铸造（mint）或导入一个新账号后，`importFiles` 会立即触发 `signalWake()` + `nextRun = now`，导致**全量巡检**遍历号池中所有账号。巡检时如果遇到网络波动 / 代理不稳 / Cloudflare 挑战，好账号会被误判为 `reauth` / `delete`，凭据被标记为异常甚至删除。

用户反馈：铸造一个需要重新登录的账号后，号池里其他所有账号都被重新巡检了一遍，导致很多好账号也被搞坏了。

## 根因

```go
// manager.go importFiles() 原逻辑：
if changed > 0 {
    m.signalWake()          // ← 唤醒调度器
    m.nextRun = time.Now()  // ← 立即安排下一次巡检
}
```

导入 1 个凭据 → 立即全量巡检 → 遍历全部账号 → 网络波动时好账号被误杀。

## 修复

- 去掉 `importFiles` 中的 `signalWake()` + `nextRun = now` + `rerunRequested = true`
- 新增 `inspectAccountsOnly(ids []string)`，只对刚导入的账号做单独探测 + `recordInspection`
- 定时巡检不受影响（按设置的间隔正常运行）

```
之前：导入 1 个 → 全量巡检遍历所有账号 → 好账号可能被误杀
现在：导入 1 个 → 只巡检这 1 个 → 已有账号完全不受影响
```

## 安全性

- 每个账号的凭据文件（`accounts/<id>.json`）和 Store 完全隔离
- `inspectAccountsOnly` 与正在运行的全量巡检可安全并发（`recordInspection` 有 mutex 保护）
- `inspectAccount` 调用的 `accountStore(id).Token()` 是每个账号独立的