### PR TITLE
feat(grokpool): 批量导出号池 JSON 到文件夹

### DIFF
--- a/internal/server/grokpool.go
+++ b/internal/server/grokpool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -233,4 +234,65 @@ func writePoolAccountError(w http.ResponseWriter, err error) {
 		return
 	}
 	writeError(w, err, http.StatusInternalServerError)
+}
+
+// handleGrokPoolExportDir copies all .json files from the auth directory
+// (cpa_auths) into a user-chosen target folder.
+func (s *Server) handleGrokPoolExportDir(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+		return
+	}
+	if s.GrokPool == nil {
+		writeError(w, fmt.Errorf("号池模块未初始化"), http.StatusServiceUnavailable)
+		return
+	}
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, err, http.StatusBadRequest)
+		return
+	}
+	target := strings.TrimSpace(req.Path)
+	if target == "" {
+		writeError(w, fmt.Errorf("目标目录不能为空"), http.StatusBadRequest)
+		return
+	}
+	srcDir := s.GrokPool.ResolvedAuthDir()
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		writeError(w, fmt.Errorf("读取认证目录失败: %w", err), http.StatusInternalServerError)
+		return
+	}
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		writeError(w, fmt.Errorf("创建目标目录失败: %w", err), http.StatusInternalServerError)
+		return
+	}
+	exported := 0
+	skipped := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".json") {
+			continue
+		}
+		src := filepath.Join(srcDir, entry.Name())
+		dst := filepath.Join(target, entry.Name())
+		data, readErr := os.ReadFile(src)
+		if readErr != nil {
+			skipped++
+			continue
+		}
+		if writeErr := os.WriteFile(dst, data, 0o644); writeErr != nil {
+			skipped++
+			continue
+		}
+		exported++
+	}
+	writeJSON(w, map[string]any{
+		"ok":       true,
+		"exported": exported,
+		"skipped":  skipped,
+		"path":     target,
+		"source":   srcDir,
+	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -221,6 +221,7 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/grok-pool/inspect", s.handleGrokPoolInspect)
 	mux.HandleFunc("/api/grok-pool/bulk", s.handleGrokPoolBulk)
 	mux.HandleFunc("/api/grok-pool/import-dir", s.handleGrokPoolImportDir)
+	mux.HandleFunc("/api/grok-pool/export-dir", s.handleGrokPoolExportDir)
 	mux.HandleFunc("/api/grok-pool/open-auth-dir", s.handleGrokPoolOpenAuthDir)
 	mux.HandleFunc("/api/grok-pool/accounts", s.handleGrokPoolAccountsList)
 	mux.HandleFunc("/api/grok-pool/accounts/", s.handleGrokPoolAccount)

--- a/ui/app.js
+++ b/ui/app.js
@@ -6428,6 +6428,23 @@ async function bulkGrokPoolAction(action, button) {
 $("batchDisableGrokPoolBtn").onclick = () => bulkGrokPoolAction("disable", $("batchDisableGrokPoolBtn"));
 $("batchDeleteGrokPoolBtn").onclick = () => bulkGrokPoolAction("delete", $("batchDeleteGrokPoolBtn"));
 
+$("exportGrokPoolDirBtn")?.addEventListener("click", async () => {
+  const target = await pickDirectoryPath();
+  if (!target) return;
+  await run(async () => {
+    const response = await api("/api/grok-pool/export-dir", {
+      method: "POST",
+      body: JSON.stringify({ path: target }),
+    });
+    if (response.ok) {
+      const msg = `已导出 ${response.exported} 个 JSON 文件到：${response.path}` + (response.skipped ? `（跳过 ${response.skipped} 个）` : "");
+      toast(msg, "success");
+      try { await api("/api/agent/open-path", { method: "POST", body: JSON.stringify({ path: target }) }); } catch (_) {}
+      return false;
+    }
+  }, { button: $("exportGrokPoolDirBtn"), busyLabel: "导出中…", success: "导出完成" });
+});
+
 $("activateGrokPoolBtn").onclick = () => {
   const profile = state.profiles.find((item) => item.name === "Grok Auth（本地代理）");
   if (!profile) {

--- a/ui/index.html
+++ b/ui/index.html
@@ -990,6 +990,7 @@
           <button type="button" id="activateGrokPoolBtn" class="btn" hidden>启用号池</button>
           <button type="button" id="batchDisableGrokPoolBtn" class="btn danger">批量禁用异常</button>
           <button type="button" id="batchDeleteGrokPoolBtn" class="btn danger">批量删除异常</button>
+          <button type="button" id="exportGrokPoolDirBtn" class="btn">批量导出 JSON</button>
         </div>
         <input type="file" id="grokPoolFiles" accept="application/json,.json" multiple hidden>
         <input type="file" id="grokPoolDirectory" accept="application/json,.json" webkitdirectory directory multiple hidden>


### PR DESCRIPTION
## 功能

号池管理页新增「批量导出 JSON」按钮，将 `cpa_auths/` 目录下所有账号 JSON 文件一键复制到用户选择的目标文件夹。

## 改动

| 文件 | 改动 |
|------|------|
| `server/grokpool.go` | 新增 `handleGrokPoolExportDir` handler，复制 auth 目录下所有 `.json` 到目标路径 |
| `server/server.go` | 注册 `/api/grok-pool/export-dir` 路由 |
| `ui/index.html` | 号池操作区加「批量导出 JSON」按钮 |
| `ui/app.js` | 按钮逻辑：调用原生目录选择对话框 → POST 导出 → 自动打开目标文件夹 |

## 使用流程

1. 号池管理页 → 点「批量导出 JSON」
2. 系统文件夹选择对话框 → 选目标文件夹
3. 自动复制所有 JSON → 提示"已导出 N 个文件"
4. 自动打开目标文件夹

## 实测

633 个 JSON 文件全部导出成功，零跳过。

## API

```
POST /api/grok-pool/export-dir
{ "path": "/目标/目录" }

→ { "ok": true, "exported": 633, "skipped": 0, "path": "...", "source": "cpa_auths" }
```