### PR TITLE
feat: 默认模型升级 grok-4.6，拉取模型直连官方并按官方列表重建

### DIFF
--- a/internal/grokpool/inspect.go
+++ b/internal/grokpool/inspect.go
@@ -188,7 +188,7 @@ func (m *Manager) inspectAccount(ctx context.Context, account Account) Account {
 		result.ExpiresAt = status.ExpiresAt
 	}
 
-	model := "grok-4.5"
+	model := "grok-4.6"
 	modelsResp, modelsErr := m.doProbe(ctx, http.MethodGet, m.upstreamURL+"/models", token, nil)
 	if modelsErr == nil && modelsResp.StatusCode >= 200 && modelsResp.StatusCode < 300 {
 		model = pickModel(modelsResp.Body)
@@ -400,7 +400,7 @@ func pickModel(body string) string {
 			ids = append(ids, id)
 		}
 	}
-	for _, preferred := range []string{"grok-4.5-build-free", "grok-4.5", "grok-4", "grok-3-mini"} {
+	for _, preferred := range []string{"grok-4.6", "grok-4.6-build-free", "grok-4", "grok-3-mini"} {
 		for _, id := range ids {
 			if id == preferred {
 				return id
@@ -410,7 +410,7 @@ func pickModel(body string) string {
 	if len(ids) > 0 {
 		return ids[0]
 	}
-	return "grok-4.5"
+	return "grok-4.6"
 }
 
 func stringField(value any) string {

--- a/internal/server/grokauth.go
+++ b/internal/server/grokauth.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,10 +21,17 @@ import (
 
 const grokAuthProfileName = "Grok Auth（本地代理）"
 
+// grok-4.5 已被上游下线（/models 只返回 grok-4.6），存量 Profile 仍钉在
+// 旧默认值上时由 migrateGrokAuthModel* 自动升级到 grok-4.6。
+const (
+	currentGrokAuthChatModel = "grok-4.6"
+	retiredGrokAuthChatModel = "grok-4.5"
+)
+
 var defaultGrokAuthModels = []profiles.ModelDef{
 	{
-		Name:                  "grok-4.5",
-		Model:                 "grok-4.5",
+		Name:                  currentGrokAuthChatModel,
+		Model:                 currentGrokAuthChatModel,
 		APIBackend:            "responses",
 		SupportsBackendSearch: true,
 		ContextWindow:         500000,
@@ -228,6 +236,224 @@ func (s *Server) handleGrokProxy(w http.ResponseWriter, r *http.Request) {
 	proxy.ServeHTTP(w, proxyRequest)
 }
 
+// grokAuthModelsFetch is the payload returned by /api/models/fetch when the
+// target is the local-proxy Grok Auth profile: the official model list drives
+// both the suggestion chips and the enabled model definitions.
+type grokAuthModelsFetch struct {
+	Models         []string
+	EnabledModels  []profiles.ModelDef
+	DefaultModel   string
+	WebSearchModel string
+	Explore        string
+	Plan           string
+	Warning        string
+}
+
+type officialGrokModelInfo struct {
+	ID                    string
+	APIBackend            string
+	ContextWindow         int64
+	SupportsReasoningFlag bool
+	ReasoningEfforts      []string
+}
+
+// fetchOfficialGrokAuthModels queries the xAI upstream /models directly with a
+// pool token and rebuilds the local-proxy profile from that response, so the
+// profile no longer depends on the hardcoded default model set. Entries that
+// the official list no longer returns (e.g. the plan composer) are preserved
+// unless they reference the retired grok-4.5.
+func (s *Server) fetchOfficialGrokAuthModels(ctx context.Context, profile profiles.Profile) (grokAuthModelsFetch, error) {
+	token, err := s.officialGrokToken(ctx)
+	if err != nil {
+		return grokAuthModelsFetch{}, err
+	}
+	client := &http.Client{Timeout: 20 * time.Second}
+	if s.GrokPool != nil {
+		if transport := s.GrokPool.Transport(); transport != nil {
+			client.Transport = transport
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, grokauth.UpstreamURL()+"/models", nil)
+	if err != nil {
+		return grokAuthModelsFetch{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-XAI-Token-Auth", "xai-grok-cli")
+	req.Header.Set("x-grok-client-version", "0.2.93")
+	req.Header.Set("User-Agent", "xai-grok-workspace/0.2.93")
+	resp, err := client.Do(req)
+	if err != nil {
+		return grokAuthModelsFetch{}, fmt.Errorf("请求官方模型列表失败: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return grokAuthModelsFetch{}, fmt.Errorf("读取官方模型列表失败: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return grokAuthModelsFetch{}, fmt.Errorf("官方模型列表返回 %s: %s", resp.Status, truncateTextServer(string(raw), 200))
+	}
+	official := parseOfficialGrokModels(raw)
+	if len(official) == 0 {
+		return grokAuthModelsFetch{}, fmt.Errorf("官方 /models 未返回任何模型")
+	}
+
+	apiKey, configured, err := s.proxyAPIKey()
+	if err != nil {
+		return grokAuthModelsFetch{}, err
+	}
+	if !configured {
+		return grokAuthModelsFetch{}, fmt.Errorf("尚未导入 Grok auth JSON 或号池账号")
+	}
+
+	defs := make([]profiles.ModelDef, 0, len(official)+len(profile.Models))
+	seen := map[string]bool{}
+	for _, item := range official {
+		if seen[item.ID] {
+			continue
+		}
+		seen[item.ID] = true
+		def := profiles.ModelDef{
+			Name:                    item.ID,
+			Model:                   item.ID,
+			APIBackend:              firstNonEmptyServer(item.APIBackend, "responses"),
+			SupportsBackendSearch:   true,
+			SupportsReasoningEffort: item.SupportsReasoningFlag,
+			ReasoningEfforts:        item.ReasoningEfforts,
+			ContextWindow:           500000,
+			MaxCompletionTokens:     65536,
+		}
+		if item.ContextWindow > 0 {
+			def.ContextWindow = item.ContextWindow
+		}
+		defs = append(defs, def)
+	}
+	for _, existing := range profile.Models {
+		id := firstNonEmptyServer(existing.Model, existing.Name)
+		if id == "" || seen[id] || id == retiredGrokAuthChatModel {
+			continue
+		}
+		seen[id] = true
+		defs = append(defs, existing)
+	}
+
+	profile.Models = cloneModelDefs(defs, s.localGrokAuthURL(), apiKey)
+	names := modelNames(profile.Models)
+	profile.AvailableModels = uniqueModelNames(names)
+	profile.DefaultModel = reconcileGrokAuthModelRef(profile.DefaultModel, names)
+	profile.WebSearchModel = reconcileGrokAuthModelRef(profile.WebSearchModel, names)
+	profile.SubagentsModels.Explore = reconcileGrokAuthModelRef(profile.SubagentsModels.Explore, names)
+	profile.SubagentsModels.Plan = reconcileGrokAuthModelRef(profile.SubagentsModels.Plan, names)
+
+	result := grokAuthModelsFetch{
+		Models:         profile.AvailableModels,
+		EnabledModels:  profile.Models,
+		DefaultModel:   profile.DefaultModel,
+		WebSearchModel: profile.WebSearchModel,
+		Explore:        profile.SubagentsModels.Explore,
+		Plan:           profile.SubagentsModels.Plan,
+	}
+	updated, err := s.Profiles.Update(profile.ID, profile)
+	if err != nil {
+		return grokAuthModelsFetch{}, err
+	}
+	s.changed()
+	if updated.IsActive {
+		if _, activateErr := s.Switcher.Activate(updated.ID); activateErr != nil {
+			result.Warning = "模型列表已按官方更新，但重写 config.toml 失败：" + activateErr.Error()
+		}
+	}
+	return result, nil
+}
+
+func (s *Server) officialGrokToken(ctx context.Context) (string, error) {
+	if s.poolConfigured() {
+		token, _, err := s.GrokPool.NextToken(ctx, "models-fetch")
+		if err == nil {
+			return token, nil
+		}
+		if !s.singleGrokAuthConfigured() {
+			return "", fmt.Errorf("获取号池 token 失败: %w", err)
+		}
+	}
+	if s.singleGrokAuthConfigured() {
+		token, err := s.GrokAuth.Token(ctx)
+		if err != nil {
+			return "", fmt.Errorf("刷新单账号 token 失败: %w", err)
+		}
+		return token, nil
+	}
+	return "", fmt.Errorf("尚未导入 Grok auth JSON 或号池账号")
+}
+
+func parseOfficialGrokModels(body []byte) []officialGrokModelInfo {
+	var payload struct {
+		Data []struct {
+			ID                      string `json:"id"`
+			Model                   string `json:"model"`
+			APIBackend              string `json:"api_backend"`
+			ContextWindow           int64  `json:"context_window"`
+			SupportsReasoningEffort bool   `json:"supports_reasoning_effort"`
+			ReasoningEfforts        []struct {
+				ID    string `json:"id"`
+				Value string `json:"value"`
+			} `json:"reasoning_efforts"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil
+	}
+	out := make([]officialGrokModelInfo, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		id := firstNonEmptyServer(item.ID, item.Model)
+		if id == "" {
+			continue
+		}
+		info := officialGrokModelInfo{
+			ID:                    id,
+			APIBackend:            strings.TrimSpace(item.APIBackend),
+			ContextWindow:         item.ContextWindow,
+			SupportsReasoningFlag: item.SupportsReasoningEffort,
+		}
+		for _, effort := range item.ReasoningEfforts {
+			if value := firstNonEmptyServer(effort.ID, effort.Value); value != "" {
+				info.ReasoningEfforts = append(info.ReasoningEfforts, value)
+			}
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+// reconcileGrokAuthModelRef keeps a model reference valid after the model list
+// was rebuilt from the official response: retired grok-4.5 is migrated, and a
+// reference that no longer exists falls back to the first available model.
+func reconcileGrokAuthModelRef(ref string, available []string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	ref = migrateGrokAuthModelID(ref)
+	for _, name := range available {
+		if name == ref {
+			return ref
+		}
+	}
+	if len(available) > 0 {
+		return available[0]
+	}
+	return ref
+}
+
+func truncateTextServer(text string, limit int) string {
+	text = strings.TrimSpace(text)
+	if len(text) > limit {
+		return text[:limit] + "…"
+	}
+	return text
+}
+
 func (s *Server) ensureGrokAuthProfile() error {
 	if s.ActualPort == 0 {
 		return nil
@@ -267,10 +493,10 @@ func (s *Server) upsertGrokAuthProfile() (profiles.Profile, error) {
 		BaseURL:         baseURL,
 		APIKey:          apiKey,
 		AvailableModels: modelNames(defaultGrokAuthModels),
-		DefaultModel:    "grok-4.5",
-		WebSearchModel:  "grok-4.5",
+		DefaultModel:    currentGrokAuthChatModel,
+		WebSearchModel:  currentGrokAuthChatModel,
 		SubagentsModels: profiles.SubagentsModels{
-			Explore: "grok-4.5",
+			Explore: currentGrokAuthChatModel,
 			Plan:    "grok-composer-2.5-fast",
 		},
 		Models: cloneModelDefs(defaultGrokAuthModels, baseURL, apiKey),
@@ -278,12 +504,12 @@ func (s *Server) upsertGrokAuthProfile() (profiles.Profile, error) {
 	if existing == nil {
 		return s.Profiles.Create(profile)
 	}
-	profile.DefaultModel = firstNonEmptyServer(existing.DefaultModel, profile.DefaultModel)
-	profile.WebSearchModel = firstNonEmptyServer(existing.WebSearchModel, profile.WebSearchModel)
-	profile.SubagentsModels.Explore = firstNonEmptyServer(existing.SubagentsModels.Explore, profile.SubagentsModels.Explore)
+	profile.DefaultModel = migrateGrokAuthModelID(firstNonEmptyServer(existing.DefaultModel, profile.DefaultModel))
+	profile.WebSearchModel = migrateGrokAuthModelID(firstNonEmptyServer(existing.WebSearchModel, profile.WebSearchModel))
+	profile.SubagentsModels.Explore = migrateGrokAuthModelID(firstNonEmptyServer(existing.SubagentsModels.Explore, profile.SubagentsModels.Explore))
 	profile.SubagentsModels.Plan = firstNonEmptyServer(existing.SubagentsModels.Plan, profile.SubagentsModels.Plan)
 	if len(existing.Models) > 0 {
-		profile.Models = cloneModelDefs(existing.Models, baseURL, apiKey)
+		profile.Models = cloneModelDefs(migrateGrokAuthModelDefs(existing.Models), baseURL, apiKey)
 		profile.AvailableModels = uniqueModelNames(append(existing.AvailableModels, modelNames(profile.Models)...))
 	}
 	updated, err := s.Profiles.Update(existing.ID, profile)
@@ -391,6 +617,25 @@ func (s *Server) singleGrokAuthConfigured() bool {
 	}
 	status, err := s.GrokAuth.Status()
 	return err == nil && status.Configured
+}
+
+func migrateGrokAuthModelID(id string) string {
+	if id == retiredGrokAuthChatModel {
+		return currentGrokAuthChatModel
+	}
+	return id
+}
+
+func migrateGrokAuthModelDefs(models []profiles.ModelDef) []profiles.ModelDef {
+	out := make([]profiles.ModelDef, 0, len(models))
+	for _, model := range models {
+		if model.Model == retiredGrokAuthChatModel || (model.Model == "" && model.Name == retiredGrokAuthChatModel) {
+			out = append(out, defaultGrokAuthModels[0])
+			continue
+		}
+		out = append(out, model)
+	}
+	return out
 }
 
 func cloneModelDefs(models []profiles.ModelDef, baseURL, apiKey string) []profiles.ModelDef {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -606,6 +606,29 @@ func (s *Server) handleFetchModels(w http.ResponseWriter, r *http.Request) {
 	if req.ProfileID != "" {
 		profile, err := s.Profiles.Get(req.ProfileID)
 		if err == nil {
+			// The local-proxy Grok Auth profile always syncs straight from the
+			// official xAI upstream and rebuilds its model list from that
+			// response; the generic gateway fetch does not apply here.
+			if profile.Name == grokAuthProfileName {
+				result, err := s.fetchOfficialGrokAuthModels(r.Context(), profile)
+				if err != nil {
+					writeError(w, err, http.StatusBadGateway)
+					return
+				}
+				payload := map[string]any{
+					"models":           result.Models,
+					"enabled_models":   result.EnabledModels,
+					"default_model":    result.DefaultModel,
+					"websearch_model":  result.WebSearchModel,
+					"subagents_models": map[string]string{"explore": result.Explore, "plan": result.Plan},
+					"official":         true,
+				}
+				if result.Warning != "" {
+					payload["warning"] = result.Warning
+				}
+				writeJSON(w, payload)
+				return
+			}
 			if req.BaseURL == "" {
 				req.BaseURL = profile.BaseURL
 			}
@@ -1009,13 +1032,15 @@ func extractModels(payload any) []string {
 	walk = func(v any) {
 		switch x := v.(type) {
 		case map[string]any:
-			if id, ok := x["id"].(string); ok && id != "" && !seen[id] {
-				seen[id] = true
-				out = append(out, id)
+			// Prefer the machine ID; only fall back to the display name so
+			// gateways that expose both don't leak "Grok 4.6" as a model ID.
+			candidate, _ := x["id"].(string)
+			if candidate == "" {
+				candidate, _ = x["name"].(string)
 			}
-			if name, ok := x["name"].(string); ok && name != "" && !seen[name] {
-				seen[name] = true
-				out = append(out, name)
+			if candidate != "" && !seen[candidate] {
+				seen[candidate] = true
+				out = append(out, candidate)
 			}
 			for key, child := range x {
 				if key == "data" || key == "models" {

--- a/ui/app.js
+++ b/ui/app.js
@@ -6161,11 +6161,28 @@ $("fetchModelsBtn").onclick = () => run(async () => {
     }),
   });
   state.availableModels = unique(result.models);
-  renderModelSelect();
+  if (Array.isArray(result.enabled_models) && result.enabled_models.length) {
+    applyOfficialGrokModels(result);
+  } else {
+    renderModelSelect();
+  }
   if ($("connectBlock")) $("connectBlock").open = true;
-  showConnectionStatus(true, `已获取 ${result.models.length} 个模型`);
-  toast(`获取到 ${result.models.length} 个模型`, "success");
+  const detail = result.official ? "（已按官方列表更新已启用模型）" : "";
+  showConnectionStatus(true, `已获取 ${result.models.length} 个模型${detail}`);
+  if (result.warning) toast(result.warning, "error");
+  toast(`获取到 ${result.models.length} 个模型${detail}`, "success");
 }, { button: $("fetchModelsBtn"), busyLabel: "拉取中…" });
+
+function applyOfficialGrokModels(result) {
+  $("modelsBody").innerHTML = "";
+  result.enabled_models.forEach((model) => addModelCard(model));
+  syncEnabledModelList();
+  if (result.default_model) $("defaultModel").value = result.default_model;
+  if (result.websearch_model) $("webSearchModel").value = result.websearch_model;
+  if (result.subagents_models?.explore) $("subagentsExploreModel").value = result.subagents_models.explore;
+  if (result.subagents_models?.plan) $("subagentsPlanModel").value = result.subagents_models.plan;
+  renderModelSelect();
+}
 
 $("profileForm").onsubmit = (event) => {
   event.preventDefault();


### PR DESCRIPTION
## 背景

实测官方上游 `/models` 现在只返回 `grok-4.6`（`grok-4.5` / `grok-4.5-build-free` 均已下线，`grok-composer-2.5-fast` 被上游别名到 grok-4.5），而工具内默认模型与巡检探测仍钉在 grok-4.5；「拉取模型」也只更新建议列表，已启用模型仍是硬编码的旧默认。

## 改动

- **默认模型 4.5 → 4.6**：`defaultGrokAuthModels`、Profile 默认值、巡检探测模型与 `pickModel` 优选列表（`grok-4.6` / `grok-4.6-build-free` / `grok-4` / `grok-3-mini`）全量切换；启动迁移把存量 Profile 里钉在 grok-4.5 的引用升级到 grok-4.6
- **拉取模型直连官方**：Grok Auth（本地代理）Profile 的拉取改为用号池 token 直接请求官方 `/models`（复用号池代理设置，单账号自动回退），并按官方响应重建已启用模型列表，采用官方元数据（`context_window`、`api_backend`、`supports_reasoning_effort`、`reasoning_efforts` 含 xhigh）；官方列表已不含的模型（plan composer）保留，grok-4.5 一律抛弃；失效的默认/联网/子代理引用自动修正；Profile 处于启用状态时立即重写 config.toml
- **前端**：拉取成功后按官方结果重建已启用模型卡片与默认模型下拉框
- **修复** `extractModels` 把模型显示名（如 "Grok 4.6"）误当作模型 ID 收集

## 验证

- `go test ./...` 14 个包全部通过
- 隔离环境（独立 HOME/端口/单账号）端到端实测：启动迁移 → 官方拉取返回带 xhigh/high/medium/low 档位的 grok-4.6 → config.toml 正确写入

> 注：后续还有一个「子模型跟随主模型」的 PR 基于本分支，建议先合本 PR。