### PR TITLE
feat: 联网/explore/plan 子模型默认跟随主模型，仅手动选择时固定

### DIFF
--- a/internal/config/tomlio.go
+++ b/internal/config/tomlio.go
@@ -218,7 +218,7 @@ func SnippetForProfile(profile profiles.Profile, opts ...ApplyOpts) (string, err
 	b.WriteString("\n")
 	b.WriteString("[models]\n")
 	b.WriteString("default = " + quote(profile.DefaultModel) + "\n")
-	b.WriteString("web_search = " + quote(profile.WebSearchModel) + "\n")
+	b.WriteString("web_search = " + quote(profile.EffectiveWebSearchModel()) + "\n")
 	b.WriteString("default_reasoning_effort = " + quote(profile.DefaultReasoningEffort) + "\n\n")
 	if snippet := formatSubagentsModelsSnippet(profile); snippet != "" {
 		b.WriteString(snippet)
@@ -253,7 +253,7 @@ func ApplyProfile(doc map[string]any, profile profiles.Profile, opts ...ApplyOpt
 
 	models := ensureTable(doc, "models")
 	models["default"] = profile.DefaultModel
-	models["web_search"] = profile.WebSearchModel
+	models["web_search"] = profile.EffectiveWebSearchModel()
 	models["default_reasoning_effort"] = profile.DefaultReasoningEffort
 
 	applySubagentsModelsToDoc(doc, profile)
@@ -722,7 +722,7 @@ func rewriteSection(lines []string, section string, profile profiles.Profile, op
 		}
 	case "models":
 		values["default"] = quote(profile.DefaultModel)
-		values["web_search"] = quote(profile.WebSearchModel)
+		values["web_search"] = quote(profile.EffectiveWebSearchModel())
 		values["default_reasoning_effort"] = quote(profile.DefaultReasoningEffort)
 	}
 	managed := []string{}

--- a/internal/profiles/model.go
+++ b/internal/profiles/model.go
@@ -71,7 +71,7 @@ func (p Profile) Matches(other Profile) bool {
 	if p.BaseURL != other.BaseURL ||
 		!runtimeDefaultMatches(p, other.DefaultModel) ||
 		p.DefaultReasoningEffort != other.DefaultReasoningEffort ||
-		p.WebSearchModel != other.WebSearchModel ||
+		!webSearchModelMatches(p, other) ||
 		p.SubagentsModels.Explore != other.SubagentsModels.Explore ||
 		p.SubagentsModels.Plan != other.SubagentsModels.Plan ||
 		!imageGenerationMatches(p.ImageGeneration, other.ImageGeneration) {
@@ -113,6 +113,31 @@ func runtimeDefaultMatches(profile Profile, actual string) bool {
 		return !IsMediaModel(model)
 	}
 	return false
+}
+
+// EffectiveWebSearchModel resolves the web-search model written to config.toml:
+// an empty (follow) value tracks the main model so config never ends up with
+// web_search = ”.
+func (p Profile) EffectiveWebSearchModel() string {
+	if strings.TrimSpace(p.WebSearchModel) == "" {
+		return p.DefaultModel
+	}
+	return p.WebSearchModel
+}
+
+func webSearchModelMatches(p, other Profile) bool {
+	if p.WebSearchModel == other.WebSearchModel {
+		return true
+	}
+	// "Follow the main model" profiles accept whatever enabled model the
+	// runtime default switched to; a pinned model must match exactly.
+	if strings.TrimSpace(p.WebSearchModel) != "" {
+		return false
+	}
+	if other.WebSearchModel == "" || other.WebSearchModel == other.DefaultModel {
+		return true
+	}
+	return runtimeDefaultMatches(p, other.WebSearchModel)
 }
 
 func modelKey(m ModelDef) string {

--- a/internal/profiles/model_test.go
+++ b/internal/profiles/model_test.go
@@ -77,3 +77,35 @@ func TestMatchesAllowsRuntimeSwitchToEnabledChatModel(t *testing.T) {
 		t.Fatal("the built-in image alias should not become the chat default")
 	}
 }
+
+func TestWebSearchFollowsMainModel(t *testing.T) {
+	base := Profile{
+		BaseURL:      "https://api.example.com/v1",
+		APIKey:       "sk-test",
+		DefaultModel: "chat-a",
+		Models: []ModelDef{
+			{Name: "chat-a", Model: "chat-a"},
+			{Name: "chat-b", Model: "chat-b"},
+		},
+	}
+	if got := base.EffectiveWebSearchModel(); got != "chat-a" {
+		t.Fatalf("empty web search should follow the main model, got %q", got)
+	}
+	pinned := base
+	pinned.WebSearchModel = "chat-b"
+	if got := pinned.EffectiveWebSearchModel(); got != "chat-b" {
+		t.Fatalf("a manual web-search pick must stay, got %q", got)
+	}
+
+	// Runtime /model switch: the config keeps the previously written
+	// web_search value while the stored profile tracks the main model.
+	runtime := base
+	runtime.DefaultModel = "chat-b"
+	runtime.WebSearchModel = "chat-a"
+	if !base.Matches(runtime) {
+		t.Fatal("a follow-main-model profile must accept the runtime default switch")
+	}
+	if pinned.Matches(runtime) {
+		t.Fatal("a pinned web-search model must not be silently replaced")
+	}
+}

--- a/internal/server/grokauth.go
+++ b/internal/server/grokauth.go
@@ -342,9 +342,9 @@ func (s *Server) fetchOfficialGrokAuthModels(ctx context.Context, profile profil
 	names := modelNames(profile.Models)
 	profile.AvailableModels = uniqueModelNames(names)
 	profile.DefaultModel = reconcileGrokAuthModelRef(profile.DefaultModel, names)
-	profile.WebSearchModel = reconcileGrokAuthModelRef(profile.WebSearchModel, names)
-	profile.SubagentsModels.Explore = reconcileGrokAuthModelRef(profile.SubagentsModels.Explore, names)
-	profile.SubagentsModels.Plan = reconcileGrokAuthModelRef(profile.SubagentsModels.Plan, names)
+	profile.WebSearchModel = followMainGrokAuthModel(reconcileGrokAuthModelRef(profile.WebSearchModel, names))
+	profile.SubagentsModels.Explore = followMainGrokAuthModel(reconcileGrokAuthModelRef(profile.SubagentsModels.Explore, names))
+	profile.SubagentsModels.Plan = followMainGrokAuthModel(reconcileGrokAuthModelRef(profile.SubagentsModels.Plan, names))
 
 	result := grokAuthModelsFetch{
 		Models:         profile.AvailableModels,
@@ -494,20 +494,16 @@ func (s *Server) upsertGrokAuthProfile() (profiles.Profile, error) {
 		APIKey:          apiKey,
 		AvailableModels: modelNames(defaultGrokAuthModels),
 		DefaultModel:    currentGrokAuthChatModel,
-		WebSearchModel:  currentGrokAuthChatModel,
-		SubagentsModels: profiles.SubagentsModels{
-			Explore: currentGrokAuthChatModel,
-			Plan:    "grok-composer-2.5-fast",
-		},
+		// 联网 / explore / plan 默认留空：跟随主模型，仅在手动选择后固定。
 		Models: cloneModelDefs(defaultGrokAuthModels, baseURL, apiKey),
 	}
 	if existing == nil {
 		return s.Profiles.Create(profile)
 	}
 	profile.DefaultModel = migrateGrokAuthModelID(firstNonEmptyServer(existing.DefaultModel, profile.DefaultModel))
-	profile.WebSearchModel = migrateGrokAuthModelID(firstNonEmptyServer(existing.WebSearchModel, profile.WebSearchModel))
-	profile.SubagentsModels.Explore = migrateGrokAuthModelID(firstNonEmptyServer(existing.SubagentsModels.Explore, profile.SubagentsModels.Explore))
-	profile.SubagentsModels.Plan = firstNonEmptyServer(existing.SubagentsModels.Plan, profile.SubagentsModels.Plan)
+	profile.WebSearchModel = followMainGrokAuthModel(migrateGrokAuthModelID(existing.WebSearchModel))
+	profile.SubagentsModels.Explore = followMainGrokAuthModel(migrateGrokAuthModelID(existing.SubagentsModels.Explore))
+	profile.SubagentsModels.Plan = followMainGrokAuthModel(existing.SubagentsModels.Plan)
 	if len(existing.Models) > 0 {
 		profile.Models = cloneModelDefs(migrateGrokAuthModelDefs(existing.Models), baseURL, apiKey)
 		profile.AvailableModels = uniqueModelNames(append(existing.AvailableModels, modelNames(profile.Models)...))
@@ -617,6 +613,18 @@ func (s *Server) singleGrokAuthConfigured() bool {
 	}
 	status, err := s.GrokAuth.Status()
 	return err == nil && status.Configured
+}
+
+// followMainGrokAuthModel drops sub-model references that were pinned by the
+// old hardcoded template (the chat model itself or the plan composer) so they
+// follow the main model again; any other value is a manual pick and is kept.
+func followMainGrokAuthModel(ref string) string {
+	switch strings.TrimSpace(ref) {
+	case "", retiredGrokAuthChatModel, currentGrokAuthChatModel, "grok-composer-2.5-fast":
+		return ""
+	default:
+		return strings.TrimSpace(ref)
+	}
 }
 
 func migrateGrokAuthModelID(id string) string {

--- a/ui/app.js
+++ b/ui/app.js
@@ -5415,7 +5415,7 @@ function syncEnabledModelList(preferred) {
   const names = unique(readEnabledModelNames().filter((name) => !isMediaModelID(name)));
   const fields = [
     { id: "defaultModel", emptyLabel: "（请先启用模型）", required: false },
-    { id: "webSearchModel", emptyLabel: "（可选）", required: false },
+    { id: "webSearchModel", emptyLabel: "（跟随主模型）", required: false },
     { id: "subagentsExploreModel", emptyLabel: "（继承主模型）", required: false },
     { id: "subagentsPlanModel", emptyLabel: "（继承主模型）", required: false },
   ];

--- a/ui/index.html
+++ b/ui/index.html
@@ -152,7 +152,7 @@
               </label>
               <label class="field">联网搜索模型
                 <select id="webSearchModel" class="mono">
-                  <option value="">（可选）</option>
+                  <option value="">（跟随主模型）</option>
                 </select>
               </label>
               <label class="field">explore 子代理模型


### PR DESCRIPTION
## 背景

此前 Grok Auth Profile 的 plan 子代理被硬编码为 `grok-composer-2.5-fast`，联网/explore 也固定写死，导致"主模型选了 A、plan 却是 B"。需求：所有子模型默认跟随主模型，仅手动选择后固定。

## 改动

- **模板去钉**：Grok Auth Profile 模板不再写死任何子模型引用，联网/explore/plan 默认留空（跟随主模型）；`followMainGrokAuthModel` 在启动迁移与官方拉取时把存量 Profile 里属于旧模板默认值（grok-4.5 / grok-4.6 / composer）的引用清空为跟随，其余值视为手动选择保留
- **写入语义**：新增 `EffectiveWebSearchModel`，写 config.toml 时把空的联网模型解析为主模型（避免 `web_search = ''`），三处写入点统一；explore/plan 为空时不写 `[subagents.models]`，由 Grok CLI 继承主模型
- **漂移比较**：`Matches` 改为跟随感知——运行时 `/model` 切到已启用模型不误判漂移，手动固定的子模型被改动才算漂移（新增 `TestWebSearchFollowsMainModel`）
- **前端**：联网搜索模型空选项文案统一为「（跟随主模型）」

## 效果

`config.toml` 实测：`default = 'grok-4.6'`、`web_search = 'grok-4.6'`（跟随），不再出现 `[subagents.models]` 段；切换主模型后所有子模型自动跟随。

## 验证

- `go test ./...` 14 个包全部通过
- 隔离环境端到端实测（启动迁移、官方拉取、config.toml 生成）

> 注：本 PR 基于 #14 分支堆叠（base 暂设为该分支），#14 合并后 GitHub 会自动将 base 切回 main。