### PR TITLE
feat: 号池会话粘性绑定 + Grok 上游代理重写

### DIFF
--- a/internal/grokauth/cli_identity.go
+++ b/internal/grokauth/cli_identity.go
@@ -1,0 +1,152 @@
+package grokauth
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	// CLIProxyHost is the hostname that requires official CLI identity headers.
+	CLIProxyHost = "cli-chat-proxy.grok.com"
+
+	// CLIStableVersion is the known-good minimum client version accepted by
+	// cli-chat-proxy. Inbound versions below this are replaced.
+	CLIStableVersion = "0.2.93"
+
+	// CLIClientVersion is the pinned identity advertised when the inbound
+	// request has no usable x-grok-client-version. Keep aligned with sub2api
+	// / x.ai CLI chat-proxy.
+	CLIClientVersion = "0.2.114"
+
+	// CLITokenAuth is required by cli-chat-proxy for Grok Build OAuth tokens.
+	CLITokenAuth = "xai-grok-cli"
+
+	// CLIClientIdentifier is the x-grok-client-identifier used by Grok shell/CLI.
+	CLIClientIdentifier = "grok-shell"
+
+	// CLIClientMode is the interactive CLI surface expected by some probes.
+	CLIClientMode = "interactive"
+)
+
+// ResolveCLIVersion returns a supported CLI client version. A valid inbound
+// version at or above CLIStableVersion is preserved so a newer Grok CLI is
+// not downgraded; anything else falls back to the pinned CLIClientVersion.
+func ResolveCLIVersion(inbound string) string {
+	inbound = strings.TrimSpace(inbound)
+	if isSupportedCLIVersion(inbound) {
+		return inbound
+	}
+	return CLIClientVersion
+}
+
+func isSupportedCLIVersion(version string) bool {
+	major, minor, patch, ok := parseDottedVersion(version)
+	if !ok {
+		return false
+	}
+	minMajor, minMinor, minPatch, _ := parseDottedVersion(CLIStableVersion)
+	if major != minMajor {
+		return major > minMajor
+	}
+	if minor != minMinor {
+		return minor > minMinor
+	}
+	return patch >= minPatch
+}
+
+func parseDottedVersion(version string) (int, int, int, bool) {
+	parts := strings.Split(strings.TrimSpace(version), ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	major, err1 := strconv.Atoi(parts[0])
+	minor, err2 := strconv.Atoi(parts[1])
+	patch, err3 := strconv.Atoi(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return 0, 0, 0, false
+	}
+	if major < 0 || minor < 0 || patch < 0 {
+		return 0, 0, 0, false
+	}
+	return major, minor, patch, true
+}
+
+// CLIUserAgent builds the workspace-style User-Agent for a CLI client version.
+func CLIUserAgent(version string) string {
+	if strings.TrimSpace(version) == "" {
+		version = CLIClientVersion
+	}
+	return "xai-grok-workspace/" + version
+}
+
+func looksLikeGrokUserAgent(ua string) bool {
+	ua = strings.ToLower(strings.TrimSpace(ua))
+	if ua == "" {
+		return false
+	}
+	return strings.Contains(ua, "xai-grok-workspace/") ||
+		strings.Contains(ua, "grok-shell/") ||
+		strings.Contains(ua, "grok-pager/")
+}
+
+var grokPassthroughHeaders = []string{
+	"x-grok-conv-id",
+	"x-grok-session-id",
+	"x-grok-req-id",
+	"x-grok-agent-id",
+	"x-grok-turn-id",
+	"x-grok-doom-loop-check",
+	"openai-beta",
+}
+
+// ApplyCLIProxyHeaders stamps cli-chat-proxy identity onto an outbound request.
+// Inbound Grok CLI headers are preserved when present and valid; missing
+// routing/identity headers are filled so OpenAI-compatible clients still hit
+// the correct upstream backend.
+func ApplyCLIProxyHeaders(out http.Header, inbound http.Header, model string) {
+	if out == nil {
+		return
+	}
+	if inbound == nil {
+		inbound = make(http.Header)
+	}
+	version := ResolveCLIVersion(inbound.Get("x-grok-client-version"))
+	out.Set("X-XAI-Token-Auth", CLITokenAuth)
+	out.Set("x-grok-client-version", version)
+	out.Set("X-Grok-Client-Version", version)
+
+	if identifier := strings.TrimSpace(inbound.Get("x-grok-client-identifier")); identifier != "" {
+		out.Set("x-grok-client-identifier", identifier)
+	} else {
+		out.Set("x-grok-client-identifier", CLIClientIdentifier)
+	}
+
+	if mode := strings.TrimSpace(firstNonEmpty(inbound.Get("x-grok-client-mode"), inbound.Get("X-Grok-Client-Mode"))); mode != "" {
+		out.Set("x-grok-client-mode", mode)
+	} else {
+		out.Set("x-grok-client-mode", CLIClientMode)
+		out.Set("X-Grok-Client-Mode", CLIClientMode)
+	}
+
+	if ua := strings.TrimSpace(inbound.Get("User-Agent")); looksLikeGrokUserAgent(ua) {
+		out.Set("User-Agent", ua)
+	} else {
+		out.Set("User-Agent", CLIUserAgent(version))
+	}
+
+	override := strings.TrimSpace(inbound.Get("x-grok-model-override"))
+	if override == "" {
+		override = strings.TrimSpace(model)
+	}
+	if override != "" {
+		out.Set("x-grok-model-override", override)
+	}
+
+	for _, key := range grokPassthroughHeaders {
+		if value := strings.TrimSpace(inbound.Get(key)); value != "" && out.Get(key) == "" {
+			out.Set(key, value)
+		}
+	}
+	out.Del("x-api-key")
+}

--- a/internal/grokauth/cli_identity_test.go
+++ b/internal/grokauth/cli_identity_test.go
@@ -1,0 +1,65 @@
+package grokauth
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestResolveCLIVersionPreservesSupportedInbound(t *testing.T) {
+	if got := ResolveCLIVersion("0.2.114"); got != "0.2.114" {
+		t.Fatalf("ResolveCLIVersion(0.2.114) = %q", got)
+	}
+	if got := ResolveCLIVersion("0.2.93"); got != "0.2.93" {
+		t.Fatalf("ResolveCLIVersion(0.2.93) = %q", got)
+	}
+	if got := ResolveCLIVersion(""); got != CLIClientVersion {
+		t.Fatalf("ResolveCLIVersion(empty) = %q, want %q", got, CLIClientVersion)
+	}
+	if got := ResolveCLIVersion("0.2.1"); got != CLIClientVersion {
+		t.Fatalf("ResolveCLIVersion(old) = %q, want %q", got, CLIClientVersion)
+	}
+}
+
+func TestApplyCLIProxyHeadersFillsIdentityAndModelOverride(t *testing.T) {
+	out := make(http.Header)
+	ApplyCLIProxyHeaders(out, nil, "grok-4.6")
+	if out.Get("X-XAI-Token-Auth") != CLITokenAuth {
+		t.Fatalf("token auth = %q", out.Get("X-XAI-Token-Auth"))
+	}
+	if out.Get("x-grok-client-version") != CLIClientVersion {
+		t.Fatalf("client version = %q", out.Get("x-grok-client-version"))
+	}
+	if out.Get("x-grok-client-identifier") != CLIClientIdentifier {
+		t.Fatalf("identifier = %q", out.Get("x-grok-client-identifier"))
+	}
+	if out.Get("x-grok-model-override") != "grok-4.6" {
+		t.Fatalf("model override = %q", out.Get("x-grok-model-override"))
+	}
+	if out.Get("User-Agent") != CLIUserAgent(CLIClientVersion) {
+		t.Fatalf("user-agent = %q", out.Get("User-Agent"))
+	}
+}
+
+func TestApplyCLIProxyHeadersPreservesInboundGrokHeaders(t *testing.T) {
+	inbound := make(http.Header)
+	inbound.Set("x-grok-client-version", "0.2.120")
+	inbound.Set("x-grok-client-identifier", "grok-shell")
+	inbound.Set("User-Agent", "xai-grok-workspace/0.2.120")
+	inbound.Set("x-grok-model-override", "grok-build")
+	inbound.Set("x-grok-conv-id", "conv-1")
+	inbound.Set("x-grok-doom-loop-check", "1")
+	out := make(http.Header)
+	ApplyCLIProxyHeaders(out, inbound, "grok-4.6")
+	if out.Get("x-grok-client-version") != "0.2.120" {
+		t.Fatalf("version overwritten: %q", out.Get("x-grok-client-version"))
+	}
+	if out.Get("User-Agent") != "xai-grok-workspace/0.2.120" {
+		t.Fatalf("ua overwritten: %q", out.Get("User-Agent"))
+	}
+	if out.Get("x-grok-model-override") != "grok-build" {
+		t.Fatalf("override overwritten: %q", out.Get("x-grok-model-override"))
+	}
+	if out.Get("x-grok-conv-id") != "conv-1" || out.Get("x-grok-doom-loop-check") != "1" {
+		t.Fatalf("passthrough missing: %#v", out)
+	}
+}

--- a/internal/grokpool/manager.go
+++ b/internal/grokpool/manager.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -30,6 +29,7 @@ func NewManager(dir string) (*Manager, error) {
 		done:        make(chan struct{}),
 		stores:      make(map[string]*grokauth.Store),
 		watchHashes: make(map[string]string),
+		sticky:      make(map[string]stickyBinding),
 	}
 	if err := m.load(); err != nil {
 		return nil, err
@@ -515,34 +515,8 @@ func (m *Manager) Authorized(r *http.Request) bool {
 }
 
 func (m *Manager) NextToken(ctx context.Context, sessionID string) (string, string, error) {
-	m.mu.Lock()
-	accounts := make([]Account, 0, len(m.state.Accounts))
-	for _, account := range m.state.Accounts {
-		if accountAvailable(account) {
-			accounts = append(accounts, account)
-		}
-	}
-	m.mu.Unlock()
-	if len(accounts) == 0 {
-		return "", "", fmt.Errorf("Grok 号池没有可用账号")
-	}
-	sort.SliceStable(accounts, func(i, j int) bool { return accounts[i].ID < accounts[j].ID })
-	start := int(m.roundRobin.Add(1)-1) % len(accounts)
-	if strings.TrimSpace(sessionID) != "" {
-		hash := sha256.Sum256([]byte(sessionID))
-		start = int(hash[0]) % len(accounts)
-	}
-	var failures []string
-	for offset := 0; offset < len(accounts); offset++ {
-		account := accounts[(start+offset)%len(accounts)]
-		token, err := m.accountStore(account.ID).Token(ctx)
-		if err == nil {
-			return token, account.ID, nil
-		}
-		failures = append(failures, firstNonEmpty(account.Email, account.ID)+": "+err.Error())
-		m.recordTokenFailure(account.ID, err)
-	}
-	return "", "", fmt.Errorf("号池账号 token 均不可用: %s", strings.Join(failures, "; "))
+	token, accountID, _, err := m.NextTokenSticky(ctx, sessionID, "")
+	return token, accountID, err
 }
 
 func (m *Manager) recordTokenFailure(id string, tokenErr error) {

--- a/internal/grokpool/sticky.go
+++ b/internal/grokpool/sticky.go
@@ -1,0 +1,159 @@
+package grokpool
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	stickyTTL = time.Hour
+	// stickySweepThreshold 触发过期绑定的全量清扫；正常情况下条目由
+	// lookup 惰性删除，但从未再次被查到的 resp_/sess_ 绑定只能靠这里回收，
+	// 否则长期运行的实例会随每个成功响应无限累积。
+	stickySweepThreshold = 4096
+)
+
+type stickyBinding struct {
+	AccountID string
+	ExpiresAt time.Time
+}
+
+func (m *Manager) lookupStickyLocked(key string, now time.Time) string {
+	if m.sticky == nil || strings.TrimSpace(key) == "" {
+		return ""
+	}
+	binding, ok := m.sticky[key]
+	if !ok {
+		return ""
+	}
+	if now.After(binding.ExpiresAt) || binding.AccountID == "" {
+		delete(m.sticky, key)
+		return ""
+	}
+	return binding.AccountID
+}
+
+func (m *Manager) bindStickyLocked(key, accountID string, now time.Time) {
+	if strings.TrimSpace(key) == "" || strings.TrimSpace(accountID) == "" {
+		return
+	}
+	if m.sticky == nil {
+		m.sticky = make(map[string]stickyBinding)
+	}
+	if len(m.sticky) >= stickySweepThreshold {
+		m.sweepStickyLocked(now)
+	}
+	m.sticky[key] = stickyBinding{AccountID: accountID, ExpiresAt: now.Add(stickyTTL)}
+}
+
+// sweepStickyLocked 删除全部过期绑定；仅在绑定数达到 stickySweepThreshold
+// 时调用，把长期运行实例的内存占用限制在 TTL 内的活跃会话量级。
+func (m *Manager) sweepStickyLocked(now time.Time) {
+	for key, binding := range m.sticky {
+		if now.After(binding.ExpiresAt) || binding.AccountID == "" {
+			delete(m.sticky, key)
+		}
+	}
+}
+
+// BindSession pins a conversation/session identifier to an account after a
+// successful upstream response. Subsequent turns with the same id stay on that
+// account so previous_response_id and encrypted reasoning remain valid.
+func (m *Manager) BindSession(sessionID, accountID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bindStickyLocked("sess:"+strings.TrimSpace(sessionID), accountID, time.Now())
+}
+
+// BindResponse pins a Responses API id to the account that produced it.
+func (m *Manager) BindResponse(responseID, accountID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bindStickyLocked("resp:"+strings.TrimSpace(responseID), accountID, time.Now())
+}
+
+func (m *Manager) accountAvailableByIDLocked(id string) bool {
+	for _, account := range m.state.Accounts {
+		if account.ID == id {
+			return accountAvailable(account)
+		}
+	}
+	return false
+}
+
+// NextTokenSticky selects a pool token with persisted affinity.
+// previousResponseID is the strongest pin (encrypted reasoning / response
+// continuation). sessionID covers Grok CLI conversation headers. lostContinuation
+// is true when previous_response_id was bound to an account that is no longer
+// available — callers should drop previous_response_id before sending to a
+// replacement account.
+func (m *Manager) NextTokenSticky(ctx context.Context, sessionID, previousResponseID string) (token, accountID string, lostContinuation bool, err error) {
+	sessionID = strings.TrimSpace(sessionID)
+	previousResponseID = strings.TrimSpace(previousResponseID)
+
+	m.mu.Lock()
+	now := time.Now()
+	preferred := ""
+	if previousResponseID != "" {
+		if id := m.lookupStickyLocked("resp:"+previousResponseID, now); id != "" {
+			if m.accountAvailableByIDLocked(id) {
+				preferred = id
+			} else {
+				lostContinuation = true
+			}
+		}
+	}
+	if preferred == "" && sessionID != "" {
+		if id := m.lookupStickyLocked("sess:"+sessionID, now); id != "" && m.accountAvailableByIDLocked(id) {
+			preferred = id
+		}
+	}
+	accounts := make([]Account, 0, len(m.state.Accounts))
+	for _, account := range m.state.Accounts {
+		if accountAvailable(account) {
+			accounts = append(accounts, account)
+		}
+	}
+	m.mu.Unlock()
+
+	if len(accounts) == 0 {
+		return "", "", lostContinuation, fmtNoAccount()
+	}
+	sort.SliceStable(accounts, func(i, j int) bool { return accounts[i].ID < accounts[j].ID })
+
+	ordered := make([]Account, 0, len(accounts))
+	if preferred != "" {
+		for _, account := range accounts {
+			if account.ID == preferred {
+				ordered = append(ordered, account)
+				break
+			}
+		}
+	}
+	start := int(m.roundRobin.Add(1)-1) % len(accounts)
+	for offset := 0; offset < len(accounts); offset++ {
+		account := accounts[(start+offset)%len(accounts)]
+		if preferred != "" && account.ID == preferred {
+			continue
+		}
+		ordered = append(ordered, account)
+	}
+
+	var failures []string
+	for _, account := range ordered {
+		got, tokenErr := m.accountStore(account.ID).Token(ctx)
+		if tokenErr == nil {
+			return got, account.ID, lostContinuation, nil
+		}
+		failures = append(failures, firstNonEmpty(account.Email, account.ID)+": "+tokenErr.Error())
+		m.recordTokenFailure(account.ID, tokenErr)
+	}
+	return "", "", lostContinuation, fmt.Errorf("号池账号 token 均不可用: %s", strings.Join(failures, "; "))
+}
+
+func fmtNoAccount() error {
+	return fmt.Errorf("Grok 号池没有可用账号")
+}

--- a/internal/grokpool/sticky_test.go
+++ b/internal/grokpool/sticky_test.go
@@ -1,0 +1,117 @@
+package grokpool
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestStickySessionPinsTheSameAccount(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := manager.Import([]ImportFile{
+		{Name: "a.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-a","expired":%q,"email":"a@example.com"}`, expiry)},
+		{Name: "b.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-b","expired":%q,"email":"b@example.com"}`, expiry)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	firstToken, firstID, lost, err := manager.NextTokenSticky(t.Context(), "conv-keep", "")
+	if err != nil || lost || firstToken == "" || firstID == "" {
+		t.Fatalf("first NextTokenSticky() = %q %q lost=%v err=%v", firstToken, firstID, lost, err)
+	}
+	manager.BindSession("conv-keep", firstID)
+
+	for i := 0; i < 8; i++ {
+		token, id, lost, err := manager.NextTokenSticky(t.Context(), "conv-keep", "")
+		if err != nil || lost {
+			t.Fatalf("repeat %d: %v lost=%v", i, err, lost)
+		}
+		if id != firstID || token != firstToken {
+			t.Fatalf("repeat %d switched account %q -> %q", i, firstID, id)
+		}
+	}
+
+	_, otherID, _, err := manager.NextTokenSticky(t.Context(), "conv-other", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherID == "" {
+		t.Fatal("empty other account")
+	}
+}
+
+func TestPreviousResponseIDPinsAccountAndReportsLostContinuation(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := manager.Import([]ImportFile{
+		{Name: "a.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-a","expired":%q,"email":"a@example.com"}`, expiry)},
+		{Name: "b.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-b","expired":%q,"email":"b@example.com"}`, expiry)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, firstID, _, err := manager.NextTokenSticky(t.Context(), "sess-1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.BindResponse("resp_keep", firstID)
+
+	token, id, lost, err := manager.NextTokenSticky(t.Context(), "different-session", "resp_keep")
+	if err != nil || lost {
+		t.Fatalf("previous_response sticky failed: token=%q id=%q lost=%v err=%v", token, id, lost, err)
+	}
+	if id != firstID {
+		t.Fatalf("previous_response_id did not pin account: got %q want %q", id, firstID)
+	}
+
+	if _, err := manager.SetDisabled(firstID, true); err != nil {
+		t.Fatal(err)
+	}
+	_, nextID, lost, err := manager.NextTokenSticky(t.Context(), "different-session", "resp_keep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lost {
+		t.Fatal("expected lostContinuation when pinned account is disabled")
+	}
+	if nextID == firstID {
+		t.Fatal("disabled sticky account was still selected")
+	}
+}
+
+func TestBindSessionSweepsExpiredBindings(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	manager.mu.Lock()
+	for i := 0; i < stickySweepThreshold+10; i++ {
+		key := fmt.Sprintf("resp:%d", i)
+		if i%2 == 0 {
+			manager.sticky[key] = stickyBinding{AccountID: "acc", ExpiresAt: now.Add(-time.Minute)}
+		} else {
+			manager.sticky[key] = stickyBinding{AccountID: "acc", ExpiresAt: now.Add(time.Hour)}
+		}
+	}
+	manager.bindStickyLocked("resp:trigger", "acc", now)
+	liveCount := 0
+	for key, binding := range manager.sticky {
+		if now.After(binding.ExpiresAt) {
+			t.Fatalf("expired binding %q survived sweep", key)
+		}
+		liveCount++
+	}
+	manager.mu.Unlock()
+
+	// 一半过期 + 新写入 1 条；清扫后应只剩活跃条目。
+	if want := stickySweepThreshold/2 + 6; liveCount != want {
+		t.Fatalf("after sweep live = %d, want %d", liveCount, want)
+	}
+}

--- a/internal/grokpool/types.go
+++ b/internal/grokpool/types.go
@@ -134,6 +134,7 @@ type Manager struct {
 	runWG          sync.WaitGroup
 	roundRobin     atomic.Uint64
 	stores         map[string]*grokauth.Store
+	sticky         map[string]stickyBinding
 
 	// Auth-dir hot-load state (in-memory fingerprints; re-scanned after restart).
 	watchHashes     map[string]string

--- a/internal/server/grok_proxy.go
+++ b/internal/server/grok_proxy.go
@@ -1,0 +1,475 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"grok_switch/internal/grokauth"
+)
+
+const grokProxyMaxBody = 32 << 20
+
+var grokHopHeaders = map[string]bool{
+	"connection":          true,
+	"keep-alive":          true,
+	"proxy-authenticate":  true,
+	"proxy-authorization": true,
+	"te":                  true,
+	"trailers":            true,
+	"transfer-encoding":   true,
+	"upgrade":             true,
+	"host":                true,
+}
+
+type grokRequestHints struct {
+	Model              string
+	PreviousResponseID string
+	PromptCacheKey     string
+	HasToolOutput      bool
+}
+
+// isWebSocketUpgrade 识别 WebSocket 升级请求。手写转发会剥离 hop-by-hop 头
+// （含 Connection/Upgrade），无法像旧的 httputil.ReverseProxy 一样隧道化
+// WS；这类请求必须显式拒绝，避免客户端对着挂死的连接排障。
+func isWebSocketUpgrade(r *http.Request) bool {
+	if !strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
+		return false
+	}
+	for _, value := range r.Header.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(token), "upgrade") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *Server) grokUpstreamBase() string {
+	if strings.TrimSpace(s.GrokUpstream) != "" {
+		return strings.TrimRight(strings.TrimSpace(s.GrokUpstream), "/")
+	}
+	return strings.TrimRight(grokauth.UpstreamURL(), "/")
+}
+
+func (s *Server) grokProxyAuthorized(r *http.Request) bool {
+	if s.GrokPool != nil && s.GrokPool.Authorized(r) {
+		return true
+	}
+	return s.GrokAuth != nil && s.GrokAuth.Authorized(r)
+}
+
+func (s *Server) grokProxyToken(ctx context.Context, r *http.Request, body []byte) (token, accountID string, lostContinuation bool, err error) {
+	hints := parseGrokRequestHints(body)
+	sessionID := firstNonEmptyServer(
+		r.Header.Get("x-grok-conv-id"),
+		r.Header.Get("x-grok-session-id"),
+		r.Header.Get("x-session-id"),
+		r.Header.Get("x-grok-agent-id"),
+		hints.PromptCacheKey,
+	)
+	if s.GrokPool != nil && s.GrokPool.Authorized(r) {
+		token, accountID, lostContinuation, err = s.GrokPool.NextTokenSticky(ctx, sessionID, hints.PreviousResponseID)
+		if err != nil && s.singleGrokAuthConfigured() {
+			accountID = ""
+			lostContinuation = false
+			token, err = s.GrokAuth.Token(ctx)
+		}
+		return token, accountID, lostContinuation, err
+	}
+	if s.GrokAuth != nil && s.GrokAuth.Authorized(r) {
+		token, err = s.GrokAuth.Token(ctx)
+		return token, "", false, err
+	}
+	return "", "", false, fmt.Errorf("无效的本地 API Key")
+}
+
+func (s *Server) rememberGrokProxySticky(r *http.Request, body []byte, accountID, responseID string) {
+	if s.GrokPool == nil || accountID == "" {
+		return
+	}
+	hints := parseGrokRequestHints(body)
+	sessionID := firstNonEmptyServer(
+		r.Header.Get("x-grok-conv-id"),
+		r.Header.Get("x-grok-session-id"),
+		r.Header.Get("x-session-id"),
+		r.Header.Get("x-grok-agent-id"),
+		hints.PromptCacheKey,
+	)
+	if sessionID != "" {
+		s.GrokPool.BindSession(sessionID, accountID)
+	}
+	if responseID != "" {
+		s.GrokPool.BindResponse(responseID, accountID)
+	}
+}
+
+func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, token, accountID string, body []byte, lostContinuation bool) {
+	hints := parseGrokRequestHints(body)
+	attemptBody := body
+	if lostContinuation && !hints.HasToolOutput {
+		if next, ok := dropPreviousResponseID(attemptBody); ok {
+			attemptBody = next
+		}
+	}
+
+	for attempt := 0; attempt < 2; attempt++ {
+		resp, err := s.doGrokUpstream(r, token, attemptBody, hints.Model)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				writeError(w, fmt.Errorf("Grok 上游请求失败: %w", err), http.StatusBadGateway)
+			}
+			return
+		}
+
+		if resp.StatusCode >= 400 {
+			raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			_ = resp.Body.Close()
+			if s.GrokPool != nil && accountID != "" {
+				s.GrokPool.ObserveResponse(accountID, resp.StatusCode, string(raw))
+			}
+			if attempt == 0 {
+				if isGrokInvalidEncryptedContent(resp.StatusCode, raw) {
+					if next, ok := stripEncryptedReasoning(attemptBody); ok {
+						attemptBody = next
+						continue
+					}
+				}
+				if isPreviousResponseNotFound(resp.StatusCode, raw) && !hints.HasToolOutput {
+					if next, ok := dropPreviousResponseID(attemptBody); ok {
+						attemptBody = next
+						continue
+					}
+				}
+			}
+			copyHeaderSkippingHop(w.Header(), resp.Header)
+			w.WriteHeader(resp.StatusCode)
+			_, _ = w.Write(raw)
+			return
+		}
+
+		copyHeaderSkippingHop(w.Header(), resp.Header)
+		w.WriteHeader(resp.StatusCode)
+		responseID := copyGrokUpstreamBody(w, resp)
+		_ = resp.Body.Close()
+		if resp.StatusCode < 300 {
+			s.rememberGrokProxySticky(r, body, accountID, responseID)
+		}
+		return
+	}
+}
+
+func (s *Server) doGrokUpstream(r *http.Request, token string, body []byte, model string) (*http.Response, error) {
+	suffix := strings.TrimPrefix(r.URL.Path, "/grok/v1")
+	if suffix == "" {
+		suffix = "/"
+	}
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, s.grokUpstreamBase()+suffix, reader)
+	if err != nil {
+		return nil, err
+	}
+	if r.URL.RawQuery != "" {
+		req.URL.RawQuery = r.URL.RawQuery
+	}
+	copyHeaderSkippingHop(req.Header, r.Header)
+	req.Header.Del("Authorization")
+	req.Header.Del("x-api-key")
+	grokauth.ApplyCLIProxyHeaders(req.Header, r.Header, model)
+	req.Header.Set("Authorization", "Bearer "+token)
+	if len(body) > 0 && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if body != nil {
+		req.ContentLength = int64(len(body))
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
+	}
+	req.Host = req.URL.Host
+
+	client := &http.Client{}
+	if s.GrokPool != nil {
+		if transport := s.GrokPool.Transport(); transport != nil {
+			client.Transport = transport
+		}
+	}
+	return client.Do(req)
+}
+
+func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) string {
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 32*1024)
+	var collected []byte
+	collectCap := 1 << 16
+	responseID := ""
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			_, _ = w.Write(buf[:n])
+			if flusher != nil {
+				flusher.Flush()
+			}
+			if len(collected) < collectCap {
+				need := collectCap - len(collected)
+				if need > n {
+					need = n
+				}
+				collected = append(collected, buf[:need]...)
+				if responseID == "" {
+					responseID = extractGrokResponseID(collected)
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	if responseID == "" {
+		responseID = extractGrokResponseID(collected)
+	}
+	return responseID
+}
+
+func parseGrokRequestHints(body []byte) grokRequestHints {
+	var hints grokRequestHints
+	if len(body) == 0 {
+		return hints
+	}
+	var raw map[string]any
+	if json.Unmarshal(body, &raw) != nil {
+		return hints
+	}
+	hints.Model = stringValue(raw["model"])
+	hints.PreviousResponseID = stringValue(raw["previous_response_id"])
+	hints.PromptCacheKey = stringValue(raw["prompt_cache_key"])
+	hints.HasToolOutput = grokInputHasToolOutput(raw["input"])
+	return hints
+}
+
+func grokInputHasToolOutput(input any) bool {
+	switch typed := input.(type) {
+	case []any:
+		for _, item := range typed {
+			obj, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			typ := strings.ToLower(stringValue(obj["type"]))
+			if typ == "function_call_output" || typ == "custom_tool_call_output" || typ == "item_reference" {
+				return true
+			}
+		}
+	case map[string]any:
+		typ := strings.ToLower(stringValue(typed["type"]))
+		if typ == "function_call_output" || typ == "custom_tool_call_output" {
+			return true
+		}
+	}
+	return false
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func dropPreviousResponseID(body []byte) ([]byte, bool) {
+	if len(body) == 0 || !bytes.Contains(body, []byte("previous_response_id")) {
+		return body, false
+	}
+	var raw map[string]any
+	if json.Unmarshal(body, &raw) != nil {
+		return body, false
+	}
+	if _, ok := raw["previous_response_id"]; !ok {
+		return body, false
+	}
+	delete(raw, "previous_response_id")
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
+func stripEncryptedReasoning(body []byte) ([]byte, bool) {
+	if len(body) == 0 || !bytes.Contains(body, []byte("encrypted_content")) {
+		return body, false
+	}
+	var raw map[string]any
+	if json.Unmarshal(body, &raw) != nil {
+		return body, false
+	}
+	input, ok := raw["input"].([]any)
+	if !ok {
+		return body, false
+	}
+	changed := false
+	next := make([]any, 0, len(input))
+	for _, item := range input {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			next = append(next, item)
+			continue
+		}
+		if strings.TrimSpace(stringValue(obj["type"])) != "reasoning" {
+			next = append(next, item)
+			continue
+		}
+		if _, has := obj["encrypted_content"]; has {
+			delete(obj, "encrypted_content")
+			changed = true
+		}
+		if grokReasoningHasSummary(obj) {
+			next = append(next, obj)
+		} else {
+			changed = true
+		}
+	}
+	if !changed {
+		return body, false
+	}
+	raw["input"] = next
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
+func grokReasoningHasSummary(obj map[string]any) bool {
+	summary, ok := obj["summary"].([]any)
+	if !ok {
+		return strings.TrimSpace(stringValue(obj["summary"])) != ""
+	}
+	for _, part := range summary {
+		partObj, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(stringValue(partObj["text"])) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func isGrokInvalidEncryptedContent(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	code, message := grokErrorCodeMessage(body)
+	if strings.EqualFold(code, "invalid_encrypted_content") {
+		return true
+	}
+	normalized := strings.ToLower(strings.TrimSpace(message))
+	if normalized == "" {
+		return false
+	}
+	if code != "" && !strings.EqualFold(code, "invalid-argument") {
+		return false
+	}
+	if code == "" && !strings.Contains(normalized, "decrypt") {
+		return false
+	}
+	return strings.Contains(normalized, "encrypted_content") &&
+		(strings.Contains(normalized, "decrypt") || strings.Contains(normalized, "unmodified"))
+}
+
+func isPreviousResponseNotFound(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest && statusCode != http.StatusNotFound {
+		return false
+	}
+	code, message := grokErrorCodeMessage(body)
+	blob := strings.ToLower(code + " " + message + " " + string(body))
+	// Match both "previous_response_id" and "previous response ..." phrasing;
+	// xAI ZDR accounts reject continuation with "Previous response cannot be
+	// used for this organization due to Zero Data Retention".
+	compact := strings.ReplaceAll(strings.ReplaceAll(blob, "_", ""), " ", "")
+	if !strings.Contains(compact, "previousresponse") {
+		return false
+	}
+	return strings.Contains(compact, "notfound") || strings.Contains(blob, "not_found") ||
+		strings.Contains(blob, "unknown") || strings.Contains(blob, "invalid") ||
+		strings.Contains(blob, "cannot be used") || strings.Contains(blob, "zero data retention")
+}
+
+func grokErrorCodeMessage(body []byte) (string, string) {
+	var payload map[string]any
+	if json.Unmarshal(body, &payload) != nil {
+		return "", string(body)
+	}
+	code := stringValue(payload["code"])
+	switch errNode := payload["error"].(type) {
+	case string:
+		if code == "" {
+			return "", errNode
+		}
+		return code, errNode
+	case map[string]any:
+		if code == "" {
+			code = stringValue(errNode["code"])
+		}
+		return code, firstNonEmptyServer(stringValue(errNode["message"]), stringValue(errNode["error"]))
+	default:
+		return code, stringValue(payload["message"])
+	}
+}
+
+func extractGrokResponseID(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	for _, line := range bytes.Split(raw, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("data:")) {
+			line = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		}
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var payload map[string]any
+		if json.Unmarshal(line, &payload) != nil {
+			continue
+		}
+		if id := grokResponseIDFromMap(payload); id != "" {
+			return id
+		}
+	}
+	var payload map[string]any
+	if json.Unmarshal(raw, &payload) == nil {
+		return grokResponseIDFromMap(payload)
+	}
+	return ""
+}
+
+func grokResponseIDFromMap(payload map[string]any) string {
+	if id := stringValue(payload["id"]); strings.HasPrefix(id, "resp_") {
+		return id
+	}
+	if nested, ok := payload["response"].(map[string]any); ok {
+		if id := stringValue(nested["id"]); strings.HasPrefix(id, "resp_") {
+			return id
+		}
+	}
+	return ""
+}
+
+func copyHeaderSkippingHop(dst, src http.Header) {
+	for key, values := range src {
+		if grokHopHeaders[strings.ToLower(key)] {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+}

--- a/internal/server/grok_proxy_test.go
+++ b/internal/server/grok_proxy_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsPreviousResponseNotFoundMatchesZDRRejection(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"zdr rejection", 404, `{"code":"not-found","error":"Previous response cannot be used for this organization due to Zero Data Retention"}`, true},
+		{"not found", 400, `{"error":{"code":"previous_response_not_found","message":"Unknown previous response"}}`, true},
+		{"not found plain", 404, `{"code":"previous_response_not_found"}`, true},
+		{"unrelated 400", 400, `{"error":{"message":"invalid model"}}`, false},
+		{"unrelated 404", 404, `{"error":"model not found"}`, false},
+		{"200", 200, `{"id":"resp_1"}`, false},
+	}
+	for _, tc := range cases {
+		if got := isPreviousResponseNotFound(tc.status, []byte(tc.body)); got != tc.want {
+			t.Errorf("%s: isPreviousResponseNotFound(%d, %s) = %v, want %v", tc.name, tc.status, tc.body, got, tc.want)
+		}
+	}
+}
+
+func TestIsGrokInvalidEncryptedContent(t *testing.T) {
+	if !isGrokInvalidEncryptedContent(400, []byte(`{"code":"invalid_encrypted_content"}`)) {
+		t.Fatal("code invalid_encrypted_content not detected")
+	}
+	if !isGrokInvalidEncryptedContent(400, []byte(`{"code":"invalid-argument","error":"Could not decrypt the provided encrypted_content."}`)) {
+		t.Fatal("decrypt message not detected")
+	}
+	if isGrokInvalidEncryptedContent(400, []byte(`{"error":"bad tool"}`)) {
+		t.Fatal("unrelated 400 misdetected")
+	}
+	if isGrokInvalidEncryptedContent(500, []byte(`{"code":"invalid_encrypted_content"}`)) {
+		t.Fatal("non-400 misdetected")
+	}
+}
+
+func TestStripEncryptedReasoningRemovesEncryptedItems(t *testing.T) {
+	body := []byte(`{"model":"grok-4.6","previous_response_id":"r1","input":[{"type":"reasoning","encrypted_content":"abc"},{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}`)
+	next, changed := stripEncryptedReasoning(body)
+	if !changed {
+		t.Fatal("stripEncryptedReasoning reported no change")
+	}
+	if want := "abc"; containsBytes(next, want) {
+		t.Fatalf("encrypted_content still present: %s", next)
+	}
+	if !containsBytes(next, "hi") {
+		t.Fatalf("user message dropped: %s", next)
+	}
+}
+
+func TestDropPreviousResponseID(t *testing.T) {
+	body := []byte(`{"model":"grok-4.6","previous_response_id":"resp-1","input":"hello"}`)
+	next, ok := dropPreviousResponseID(body)
+	if !ok {
+		t.Fatal("dropPreviousResponseID reported no change")
+	}
+	if containsBytes(next, "resp-1") {
+		t.Fatalf("previous_response_id still present: %s", next)
+	}
+	if !containsBytes(next, "hello") {
+		t.Fatalf("input lost: %s", next)
+	}
+}
+
+func TestParseGrokRequestHintsDetectsToolOutput(t *testing.T) {
+	hints := parseGrokRequestHints([]byte(`{"model":"grok-4.6","previous_response_id":"r1","input":[{"type":"function_call_output","call_id":"c1","output":"ok"}]}`))
+	if !hints.HasToolOutput {
+		t.Fatal("function_call_output not detected")
+	}
+	if hints.PreviousResponseID != "r1" || hints.Model != "grok-4.6" {
+		t.Fatalf("hints = %#v", hints)
+	}
+	plain := parseGrokRequestHints([]byte(`{"model":"grok-4.6","input":[{"type":"message","role":"user"}]}`))
+	if plain.HasToolOutput {
+		t.Fatal("plain input misdetected as tool output")
+	}
+}
+
+func TestIsWebSocketUpgrade(t *testing.T) {
+	cases := []struct {
+		name   string
+		header http.Header
+		want   bool
+	}{
+		{"standard upgrade", http.Header{"Upgrade": []string{"websocket"}, "Connection": []string{"Upgrade"}}, true},
+		{"case insensitive", http.Header{"Upgrade": []string{"WebSocket"}, "Connection": []string{"keep-alive, Upgrade"}}, true},
+		{"upgrade without connection token", http.Header{"Upgrade": []string{"websocket"}, "Connection": []string{"keep-alive"}}, false},
+		{"connection only", http.Header{"Connection": []string{"Upgrade"}}, false},
+		{"plain request", http.Header{"User-Agent": []string{"xai-grok-workspace/0.2.114"}}, false},
+	}
+	for _, tc := range cases {
+		r := &http.Request{Header: tc.header}
+		if got := isWebSocketUpgrade(r); got != tc.want {
+			t.Errorf("%s: isWebSocketUpgrade = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func containsBytes(haystack []byte, needle string) bool {
+	return len(needle) > 0 && indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack []byte, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/server/grokauth.go
+++ b/internal/server/grokauth.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -163,29 +161,35 @@ func (s *Server) handleGrokAuthRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGrokProxy(w http.ResponseWriter, r *http.Request) {
-	var token string
-	var poolAccountID string
-	var err error
-	authorized := false
-	if s.GrokPool != nil && s.GrokPool.Authorized(r) {
-		sessionID := firstNonEmptyServer(r.Header.Get("x-grok-conv-id"), r.Header.Get("x-session-id"))
-		token, poolAccountID, err = s.GrokPool.NextToken(r.Context(), sessionID)
-		if err != nil && s.singleGrokAuthConfigured() {
-			poolAccountID = ""
-			token, err = s.GrokAuth.Token(r.Context())
-		}
-		authorized = true
-	} else if s.GrokAuth != nil && s.GrokAuth.Authorized(r) {
-		token, err = s.GrokAuth.Token(r.Context())
-		authorized = true
-	}
-	if !authorized {
+	if !s.grokProxyAuthorized(r) {
 		w.Header().Set("WWW-Authenticate", `Bearer realm="grok_switch"`)
 		writeError(w, fmt.Errorf("无效的本地 API Key"), http.StatusUnauthorized)
 		return
 	}
+
+	var body []byte
+	if r.Body != nil && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
+		raw, readErr := io.ReadAll(io.LimitReader(r.Body, grokProxyMaxBody+1))
+		_ = r.Body.Close()
+		if readErr != nil {
+			writeError(w, fmt.Errorf("读取请求体失败: %w", readErr), http.StatusBadRequest)
+			return
+		}
+		if len(raw) > grokProxyMaxBody {
+			writeError(w, fmt.Errorf("请求体过大"), http.StatusRequestEntityTooLarge)
+			return
+		}
+		body = raw
+		restoreRequestBody(r, body)
+	}
+
+	token, poolAccountID, lostContinuation, err := s.grokProxyToken(r.Context(), r, body)
 	if err != nil {
 		writeError(w, err, http.StatusBadGateway)
+		return
+	}
+	if isWebSocketUpgrade(r) {
+		writeError(w, fmt.Errorf("本地 Grok 代理不支持 WebSocket 升级请求，请使用 REST/SSE 接口"), http.StatusNotImplemented)
 		return
 	}
 	// 生图能力全局开关：开启且账号池可用时接管内置 image_gen / image_edit
@@ -218,55 +222,7 @@ func (s *Server) handleGrokProxy(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	target, err := url.Parse(grokauth.UpstreamURL())
-	if err != nil {
-		writeError(w, err, http.StatusInternalServerError)
-		return
-	}
-
-	proxyRequest := r.Clone(r.Context())
-	suffix := strings.TrimPrefix(r.URL.Path, "/grok/v1")
-	if suffix == "" {
-		suffix = "/"
-	}
-	proxyRequest.URL.Path = suffix
-	proxyRequest.URL.RawPath = ""
-
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	if s.GrokPool != nil {
-		if transport := s.GrokPool.Transport(); transport != nil {
-			proxy.Transport = transport
-		}
-	}
-	originalDirector := proxy.Director
-	proxy.Director = func(out *http.Request) {
-		originalDirector(out)
-		out.Host = target.Host
-		out.Header.Del("x-api-key")
-		out.Header.Set("Authorization", "Bearer "+token)
-		out.Header.Set("X-XAI-Token-Auth", "xai-grok-cli")
-		out.Header.Set("x-grok-client-version", "0.2.93")
-		out.Header.Set("User-Agent", "xai-grok-workspace/0.2.93")
-	}
-	proxy.FlushInterval = -1
-	proxy.ModifyResponse = func(response *http.Response) error {
-		if s.GrokPool == nil || poolAccountID == "" || response.StatusCode < 400 {
-			return nil
-		}
-		raw, readErr := io.ReadAll(io.LimitReader(response.Body, 1<<20))
-		if readErr != nil {
-			return nil
-		}
-		response.Body = io.NopCloser(io.MultiReader(bytes.NewReader(raw), response.Body))
-		s.GrokPool.ObserveResponse(poolAccountID, response.StatusCode, string(raw))
-		return nil
-	}
-	proxy.ErrorHandler = func(writer http.ResponseWriter, request *http.Request, proxyErr error) {
-		if !errors.Is(proxyErr, context.Canceled) {
-			writeError(writer, fmt.Errorf("Grok 上游请求失败: %w", proxyErr), http.StatusBadGateway)
-		}
-	}
-	proxy.ServeHTTP(w, proxyRequest)
+	s.forwardGrokUpstream(w, r, token, poolAccountID, body, lostContinuation)
 }
 
 // isImageGenProxyPath 判断是否为内置 image_gen 工具的图片生成请求

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,13 +54,15 @@ type Server struct {
 	UpdateChecker *updatecheck.Checker
 	UpdateState   *updatecheck.PreferenceStore
 	ActualPort    int
-	onChanged     func()
-	listenerMu    sync.Mutex
-	listener      net.Listener
-	bindHost      string
-	httpServer    *http.Server
-	loginMu       sync.Mutex
-	loginFails    map[string]loginFailure
+	// GrokUpstream optionally overrides cli-chat-proxy for tests.
+	GrokUpstream string
+	onChanged    func()
+	listenerMu   sync.Mutex
+	listener     net.Listener
+	bindHost     string
+	httpServer   *http.Server
+	loginMu      sync.Mutex
+	loginFails   map[string]loginFailure
 
 	reloginMu   sync.Mutex
 	reloginSeq  int64


### PR DESCRIPTION
## Summary

Fixes #20

号池按请求轮换账号时，多轮对话的 `previous_response_id` 与加密推理内容会因换号失效，上游直接报错。本 PR 为号池引入会话粘性，并把 `/grok/v1` 上游转发重写为可控的手写实现：

- **grokpool 粘性绑定**：`BindSession` / `BindResponse` 把会话 ID 与 `resp_*` ID 钉在账号上（TTL 1 小时）；`NextTokenSticky` 优先复用绑定账号；绑定账号不可用时返回 `lostContinuation`，代理层据此丢弃续接引用换号。粘性表达到阈值（4096）时全量清扫过期绑定，防止长期运行内存无限增长
- **手写上游转发**（替代 `httputil.ReverseProxy`）：解析请求提示（model / previous_response_id / prompt_cache_key / 工具输出检测）；上游报 `invalid_encrypted_content` 或 previous response not found（含 ZDR 拒绝）时自动剔除对应内容重试一次；流式回传的同时提取 `resp_` ID 回写粘性绑定；请求体 32MB 上限
- **CLI 身份头统一**（`grokauth/cli_identity.go`）：入站版本 ≥0.2.93 保留、否则钉 0.2.114；workspace UA；`x-grok-*` 路由头透传——OpenAI 兼容客户端不再需要自己伪造身份头
- **加固**：WebSocket 升级请求显式返回 501（手写转发不支持隧道化，避免静默挂死）；`Server.GrokUpstream` 支持测试覆盖上游地址

## Test plan

- [x] `go build ./...` 通过
- [x] `go vet ./internal/... .` 通过
- [x] `go test ./internal/... .` 全绿（新增 `sticky_test.go` 含粘性命中 / lostContinuation / 过期清扫三组用例；`grok_proxy_test.go` 含 ZDR 识别 / 加密内容剔除 / 续接丢弃 / 提示解析 / WS 识别用例）
- [x] `go test -tags=wailsgui .` 通过
- [x] `gofmt -l .` 输出为空