### PR TITLE
feat: 号池透明故障转移 + 流内错误健康观测

### DIFF
--- a/internal/grokpool/inspect.go
+++ b/internal/grokpool/inspect.go
@@ -141,6 +141,25 @@ func (m *Manager) ObserveResponse(id string, status int, body string) {
 	}
 	parsed := extractProbeError(body)
 	classified := classify(status, parsed.Code, parsed.Message, false)
+	m.recordObservation(id, classified, parsed, status)
+}
+
+// ObserveStreamError 记录 HTTP 200 响应中流式错误事件暴露的账号健康信号
+// （如免费额度耗尽、认证失效），让坏号即时隔离而不必等下一轮巡检。
+// 无法识别的错误归类为 unknown，不落库，避免把网络噪音当成账号问题。
+func (m *Manager) ObserveStreamError(id string, body string) {
+	if strings.TrimSpace(id) == "" || strings.TrimSpace(body) == "" {
+		return
+	}
+	parsed := extractProbeError(body)
+	classified := classify(0, parsed.Code, parsed.Message, false)
+	if classified.Name == "unknown" {
+		return
+	}
+	m.recordObservation(id, classified, parsed, 0)
+}
+
+func (m *Manager) recordObservation(id string, classified classification, parsed probeError, status int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for i := range m.state.Accounts {
@@ -151,7 +170,9 @@ func (m *Manager) ObserveResponse(id string, status int, body string) {
 		account.Classification = classified.Name
 		account.Action = classified.Action
 		account.Reason = classified.Reason
-		account.HTTPStatus = status
+		if status > 0 {
+			account.HTTPStatus = status
+		}
 		account.ErrorCode = parsed.Code
 		account.ErrorMessage = parsed.Message
 		account.LastInspected = time.Now().UTC()

--- a/internal/grokpool/sticky.go
+++ b/internal/grokpool/sticky.go
@@ -91,6 +91,13 @@ func (m *Manager) accountAvailableByIDLocked(id string) bool {
 // available — callers should drop previous_response_id before sending to a
 // replacement account.
 func (m *Manager) NextTokenSticky(ctx context.Context, sessionID, previousResponseID string) (token, accountID string, lostContinuation bool, err error) {
+	return m.NextTokenStickyExcluding(ctx, sessionID, previousResponseID, nil)
+}
+
+// NextTokenStickyExcluding 与 NextTokenSticky 相同，但跳过 exclude 中的账号
+// （透明故障转移：本轮请求里已经失败过的号不再复用）。被排除的续接绑定
+// 视为 lostContinuation；全部候选被排除时返回与无可用账号相同的错误。
+func (m *Manager) NextTokenStickyExcluding(ctx context.Context, sessionID, previousResponseID string, exclude map[string]bool) (token, accountID string, lostContinuation bool, err error) {
 	sessionID = strings.TrimSpace(sessionID)
 	previousResponseID = strings.TrimSpace(previousResponseID)
 
@@ -99,20 +106,23 @@ func (m *Manager) NextTokenSticky(ctx context.Context, sessionID, previousRespon
 	preferred := ""
 	if previousResponseID != "" {
 		if id := m.lookupStickyLocked("resp:"+previousResponseID, now); id != "" {
-			if m.accountAvailableByIDLocked(id) {
-				preferred = id
-			} else {
+			if exclude[id] || !m.accountAvailableByIDLocked(id) {
 				lostContinuation = true
+			} else {
+				preferred = id
 			}
 		}
 	}
 	if preferred == "" && sessionID != "" {
-		if id := m.lookupStickyLocked("sess:"+sessionID, now); id != "" && m.accountAvailableByIDLocked(id) {
+		if id := m.lookupStickyLocked("sess:"+sessionID, now); id != "" && !exclude[id] && m.accountAvailableByIDLocked(id) {
 			preferred = id
 		}
 	}
 	accounts := make([]Account, 0, len(m.state.Accounts))
 	for _, account := range m.state.Accounts {
+		if exclude[account.ID] {
+			continue
+		}
 		if accountAvailable(account) {
 			accounts = append(accounts, account)
 		}

--- a/internal/grokpool/sticky_test.go
+++ b/internal/grokpool/sticky_test.go
@@ -115,3 +115,65 @@ func TestBindSessionSweepsExpiredBindings(t *testing.T) {
 		t.Fatalf("after sweep live = %d, want %d", liveCount, want)
 	}
 }
+
+func TestNextTokenStickyExcludingSkipsFailedAccounts(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := manager.Import([]ImportFile{
+		{Name: "a.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-a","expired":%q,"email":"a@example.com"}`, expiry)},
+		{Name: "b.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-b","expired":%q,"email":"b@example.com"}`, expiry)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	status := manager.Status()
+	if len(status.Accounts) != 2 {
+		t.Fatalf("accounts = %d", len(status.Accounts))
+	}
+	firstID := status.Accounts[0].ID
+	secondID := status.Accounts[1].ID
+
+	token, id, lost, err := manager.NextTokenStickyExcluding(t.Context(), "", "", map[string]bool{firstID: true})
+	if err != nil || lost || token == "" {
+		t.Fatalf("NextTokenStickyExcluding() = %q %q lost=%v err=%v", token, id, lost, err)
+	}
+	if id != secondID {
+		t.Fatalf("excluded account still selected: got %q want %q", id, secondID)
+	}
+
+	if _, _, _, err := manager.NextTokenStickyExcluding(t.Context(), "", "", map[string]bool{firstID: true, secondID: true}); err == nil {
+		t.Fatal("expected error when every account is excluded")
+	}
+}
+
+func TestNextTokenStickyExcludingReportsLostContinuationForExcludedPin(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := manager.Import([]ImportFile{
+		{Name: "a.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-a","expired":%q,"email":"a@example.com"}`, expiry)},
+		{Name: "b.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-b","expired":%q,"email":"b@example.com"}`, expiry)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, pinnedID, _, err := manager.NextTokenSticky(t.Context(), "sess-x", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.BindResponse("resp_fail", pinnedID)
+
+	_, nextID, lost, err := manager.NextTokenStickyExcluding(t.Context(), "sess-x", "resp_fail", map[string]bool{pinnedID: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lost {
+		t.Fatal("expected lostContinuation when pinned response account is excluded")
+	}
+	if nextID == pinnedID {
+		t.Fatal("excluded pinned account was selected")
+	}
+}

--- a/internal/server/grok_proxy.go
+++ b/internal/server/grok_proxy.go
@@ -8,12 +8,20 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"grok_switch/internal/grokauth"
 )
 
 const grokProxyMaxBody = 32 << 20
+
+// 单次客户端请求的最多上游尝试次数：非池模式保留一次同账号内容修复重试；
+// 池模式额外允许跨账号故障转移（最多换 2 个号）。
+const (
+	grokProxyMaxAttemptsSingle = 2
+	grokProxyMaxAttemptsPool   = 3
+)
 
 var grokHopHeaders = map[string]bool{
 	"connection":          true,
@@ -67,13 +75,7 @@ func (s *Server) grokProxyAuthorized(r *http.Request) bool {
 
 func (s *Server) grokProxyToken(ctx context.Context, r *http.Request, body []byte) (token, accountID string, lostContinuation bool, err error) {
 	hints := parseGrokRequestHints(body)
-	sessionID := firstNonEmptyServer(
-		r.Header.Get("x-grok-conv-id"),
-		r.Header.Get("x-grok-session-id"),
-		r.Header.Get("x-session-id"),
-		r.Header.Get("x-grok-agent-id"),
-		hints.PromptCacheKey,
-	)
+	sessionID := grokSessionKey(r, hints)
 	if s.GrokPool != nil && s.GrokPool.Authorized(r) {
 		token, accountID, lostContinuation, err = s.GrokPool.NextTokenSticky(ctx, sessionID, hints.PreviousResponseID)
 		if err != nil && s.singleGrokAuthConfigured() {
@@ -90,24 +92,40 @@ func (s *Server) grokProxyToken(ctx context.Context, r *http.Request, body []byt
 	return "", "", false, fmt.Errorf("无效的本地 API Key")
 }
 
-func (s *Server) rememberGrokProxySticky(r *http.Request, body []byte, accountID, responseID string) {
-	if s.GrokPool == nil || accountID == "" {
-		return
-	}
-	hints := parseGrokRequestHints(body)
-	sessionID := firstNonEmptyServer(
+// grokSessionKey 提取请求的会话亲和键：优先 Grok CLI 的会话头，其次
+// OpenAI 兼容客户端写在 prompt_cache_key 里的会话标识。
+func grokSessionKey(r *http.Request, hints grokRequestHints) string {
+	return firstNonEmptyServer(
 		r.Header.Get("x-grok-conv-id"),
 		r.Header.Get("x-grok-session-id"),
 		r.Header.Get("x-session-id"),
 		r.Header.Get("x-grok-agent-id"),
 		hints.PromptCacheKey,
 	)
-	if sessionID != "" {
+}
+
+func (s *Server) rememberGrokProxySticky(r *http.Request, body []byte, accountID, responseID string) {
+	if s.GrokPool == nil || accountID == "" {
+		return
+	}
+	hints := parseGrokRequestHints(body)
+	if sessionID := grokSessionKey(r, hints); sessionID != "" {
 		s.GrokPool.BindSession(sessionID, accountID)
 	}
 	if responseID != "" {
 		s.GrokPool.BindResponse(responseID, accountID)
 	}
+}
+
+// grokShouldFailover 判断上游状态码是否值得换号重试：认证失效、额度/权限
+// 拒绝、限流与服务端故障都可能是单账号问题；400 类由同账号内容修复处理，
+// 404 通常是模型级确定性错误，换号无意义。
+func grokShouldFailover(statusCode int) bool {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	}
+	return statusCode >= 500
 }
 
 func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, token, accountID string, body []byte, lostContinuation bool) {
@@ -119,7 +137,15 @@ func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, tok
 		}
 	}
 
-	for attempt := 0; attempt < 2; attempt++ {
+	poolMode := s.GrokPool != nil && accountID != ""
+	maxAttempts := grokProxyMaxAttemptsSingle
+	if poolMode {
+		maxAttempts = grokProxyMaxAttemptsPool
+	}
+	excluded := make(map[string]bool)
+	sessionKey := grokSessionKey(r, hints)
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		resp, err := s.doGrokUpstream(r, token, attemptBody, hints.Model)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
@@ -131,22 +157,44 @@ func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, tok
 		if resp.StatusCode >= 400 {
 			raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 			_ = resp.Body.Close()
-			if s.GrokPool != nil && accountID != "" {
+			if poolMode {
 				s.GrokPool.ObserveResponse(accountID, resp.StatusCode, string(raw))
 			}
-			if attempt == 0 {
-				if isGrokInvalidEncryptedContent(resp.StatusCode, raw) {
-					if next, ok := stripEncryptedReasoning(attemptBody); ok {
-						attemptBody = next
-						continue
-					}
+			// 同账号内容修复：加密推理失效 / 续接引用丢失时剔除后重发。
+			if isGrokInvalidEncryptedContent(resp.StatusCode, raw) {
+				if next, ok := stripEncryptedReasoning(attemptBody); ok {
+					attemptBody = next
+					continue
 				}
-				if isPreviousResponseNotFound(resp.StatusCode, raw) && !hints.HasToolOutput {
+			}
+			if isPreviousResponseNotFound(resp.StatusCode, raw) && !hints.HasToolOutput {
+				if next, ok := dropPreviousResponseID(attemptBody); ok {
+					attemptBody = next
+					continue
+				}
+			}
+			// 跨账号透明故障转移：换健康号重发，客户端无感。全部尝试都
+			// 发生在向客户端写出任何字节之前，重试是安全的。
+			if poolMode && attempt+1 < maxAttempts && grokShouldFailover(resp.StatusCode) {
+				excluded[accountID] = true
+				nextToken, nextID, _, pickErr := s.GrokPool.NextTokenStickyExcluding(r.Context(), sessionKey, hints.PreviousResponseID, excluded)
+				if pickErr != nil || nextID == "" {
+					// 没有备选账号：透传原始上游错误。
+					copyHeaderSkippingHop(w.Header(), resp.Header)
+					w.WriteHeader(resp.StatusCode)
+					_, _ = w.Write(raw)
+					return
+				}
+				fmt.Fprintf(os.Stderr, "grok_switch: grok 代理故障转移 (HTTP %d)，更换账号重试\n", resp.StatusCode)
+				token = nextToken
+				accountID = nextID
+				// 新账号不认识旧续接引用，能安全丢弃就先丢，省一次往返。
+				if !hints.HasToolOutput {
 					if next, ok := dropPreviousResponseID(attemptBody); ok {
 						attemptBody = next
-						continue
 					}
 				}
+				continue
 			}
 			copyHeaderSkippingHop(w.Header(), resp.Header)
 			w.WriteHeader(resp.StatusCode)
@@ -156,8 +204,11 @@ func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, tok
 
 		copyHeaderSkippingHop(w.Header(), resp.Header)
 		w.WriteHeader(resp.StatusCode)
-		responseID := copyGrokUpstreamBody(w, resp)
+		responseID, streamError := copyGrokUpstreamBody(w, resp)
 		_ = resp.Body.Close()
+		if poolMode && streamError != "" {
+			s.GrokPool.ObserveStreamError(accountID, streamError)
+		}
 		if resp.StatusCode < 300 {
 			s.rememberGrokProxySticky(r, body, accountID, responseID)
 		}
@@ -204,12 +255,16 @@ func (s *Server) doGrokUpstream(r *http.Request, token string, body []byte, mode
 	return client.Do(req)
 }
 
-func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) string {
+// copyGrokUpstreamBody 流式回传上游响应，同时从已收集前缀里提取
+// resp_ ID 与流内错误事件负载。流内错误（HTTP 200 但事件报错）返回给
+// 调用方做账号健康观测；正常完成时第二个返回值为空串。
+func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) (string, string) {
 	flusher, _ := w.(http.Flusher)
 	buf := make([]byte, 32*1024)
 	var collected []byte
 	collectCap := 1 << 16
 	responseID := ""
+	streamError := ""
 	for {
 		n, err := resp.Body.Read(buf)
 		if n > 0 {
@@ -226,6 +281,9 @@ func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) string {
 				if responseID == "" {
 					responseID = extractGrokResponseID(collected)
 				}
+				if streamError == "" {
+					streamError = extractGrokStreamError(collected)
+				}
 			}
 		}
 		if err != nil {
@@ -235,7 +293,44 @@ func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) string {
 	if responseID == "" {
 		responseID = extractGrokResponseID(collected)
 	}
-	return responseID
+	if streamError == "" {
+		streamError = extractGrokStreamError(collected)
+	}
+	return responseID, streamError
+}
+
+// extractGrokStreamError 在已收集的响应前缀里找 SSE 错误事件
+// （type=error / response.failed），返回可归类的错误负载文本。
+func extractGrokStreamError(raw []byte) string {
+	for _, line := range bytes.Split(raw, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("data:")) {
+			line = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		}
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var payload map[string]any
+		if json.Unmarshal(line, &payload) != nil {
+			continue
+		}
+		switch strings.ToLower(stringValue(payload["type"])) {
+		case "error", "response.failed":
+		default:
+			continue
+		}
+		code, message := grokErrorCodeFromMap(payload)
+		if nested, ok := payload["response"].(map[string]any); ok {
+			nestedCode, nestedMessage := grokErrorCodeFromMap(nested)
+			code = firstNonEmptyServer(code, nestedCode)
+			message = firstNonEmptyServer(message, nestedMessage)
+		}
+		if combined := strings.TrimSpace(code + " " + message); combined != "" {
+			return truncateTextServer(combined, 1000)
+		}
+		return truncateTextServer(string(line), 1000)
+	}
+	return ""
 }
 
 func parseGrokRequestHints(body []byte) grokRequestHints {
@@ -407,6 +502,10 @@ func grokErrorCodeMessage(body []byte) (string, string) {
 	if json.Unmarshal(body, &payload) != nil {
 		return "", string(body)
 	}
+	return grokErrorCodeFromMap(payload)
+}
+
+func grokErrorCodeFromMap(payload map[string]any) (string, string) {
 	code := stringValue(payload["code"])
 	switch errNode := payload["error"].(type) {
 	case string:

--- a/internal/server/grok_proxy_test.go
+++ b/internal/server/grok_proxy_test.go
@@ -1,8 +1,17 @@
 package server
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"grok_switch/internal/grokauth"
+	"grok_switch/internal/grokpool"
 )
 
 func TestIsPreviousResponseNotFoundMatchesZDRRejection(t *testing.T) {
@@ -121,4 +130,232 @@ func indexOf(haystack []byte, needle string) int {
 		}
 	}
 	return -1
+}
+
+func TestGrokShouldFailover(t *testing.T) {
+	cases := map[int]bool{
+		http.StatusUnauthorized:        true,
+		http.StatusPaymentRequired:     true,
+		http.StatusForbidden:           true,
+		http.StatusTooManyRequests:     true,
+		http.StatusInternalServerError: true,
+		http.StatusBadGateway:          true,
+		http.StatusServiceUnavailable:  true,
+		http.StatusBadRequest:          false,
+		http.StatusNotFound:            false,
+		http.StatusOK:                  false,
+	}
+	for status, want := range cases {
+		if got := grokShouldFailover(status); got != want {
+			t.Errorf("grokShouldFailover(%d) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+func TestExtractGrokStreamError(t *testing.T) {
+	failed := extractGrokStreamError([]byte("data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"free-usage-exhausted\",\"message\":\"used all free usage\"}}}\n"))
+	if !strings.Contains(failed, "free-usage-exhausted") {
+		t.Fatalf("response.failed not extracted: %q", failed)
+	}
+	plain := extractGrokStreamError([]byte("data: {\"type\":\"error\",\"error\":\"boom\"}\n"))
+	if plain != "boom" {
+		t.Fatalf("plain error event = %q", plain)
+	}
+	if got := extractGrokStreamError([]byte("data: {\"type\":\"response.created\"}\n")); got != "" {
+		t.Fatalf("normal event misdetected: %q", got)
+	}
+	if got := extractGrokStreamError([]byte(": keep-alive\n\n")); got != "" {
+		t.Fatalf("comment line misdetected: %q", got)
+	}
+}
+
+// isGrokProxyCall 区分代理链路请求与号池后台巡检探测：两者在测试里共用
+// 被替换的 http.DefaultTransport，巡检固定写 0.2.93 客户端版本，代理链路
+// 统一钉在 grokauth.CLIClientVersion。
+func isGrokProxyCall(request *http.Request) bool {
+	return request.Header.Get("x-grok-client-version") == grokauth.CLIClientVersion
+}
+
+// probeOKResponse 给后台巡检探测返回健康结果，保持账号可用且不污染断言。
+func probeOKResponse(request *http.Request) (*http.Response, error) {
+	body := `{"data":[{"id":"grok-4.6"}]}`
+	if request.Method == http.MethodPost {
+		body = `{"id":"resp_probe","status":"completed"}`
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+// waitForInitialInspection 等待 Import 触发的后台巡检全部落库，
+// 避免巡检结果异步覆盖测试断言的账号状态。
+func waitForInitialInspection(t *testing.T, pool *grokpool.Manager, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		accounts := pool.Status().Accounts
+		done := 0
+		for _, account := range accounts {
+			if !account.LastInspected.IsZero() {
+				done++
+			}
+		}
+		if len(accounts) >= want && done >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("background inspection did not finish for %d accounts", want)
+}
+
+func newFailoverTestPool(t *testing.T, tokens ...string) *grokpool.Manager {
+	t.Helper()
+	dir := t.TempDir()
+	pool, err := grokpool.NewManager(filepath.Join(dir, "pool"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	files := make([]grokpool.ImportFile, 0, len(tokens))
+	for i, token := range tokens {
+		files = append(files, grokpool.ImportFile{
+			Name:    fmt.Sprintf("acc-%d.json", i),
+			Content: fmt.Sprintf(`{"type":"xai","access_token":%q,"expired":%q,"email":"acc-%d@example.com"}`, token, expiry, i),
+		})
+	}
+	if _, err := pool.Import(files); err != nil {
+		t.Fatal(err)
+	}
+	return pool
+}
+
+func newProxiedGrokRequest(pool *grokpool.Manager, body string) *http.Request {
+	request := httptest.NewRequest(http.MethodPost, "/grok/v1/responses", strings.NewReader(body))
+	request.Header.Set("Authorization", "Bearer "+pool.Status().LocalAPIKey)
+	return request
+}
+
+func TestGrokProxyFailsOverToNextPoolAccountOnRateLimit(t *testing.T) {
+	pool := newFailoverTestPool(t, "pool-a", "pool-b")
+
+	var upstreamAuths []string
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		if !isGrokProxyCall(request) {
+			return probeOKResponse(request)
+		}
+		upstreamAuths = append(upstreamAuths, request.Header.Get("Authorization"))
+		if len(upstreamAuths) == 1 {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Status:     "429 Too Many Requests",
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"code":"rate_limited","error":"Too Many Requests"}`)),
+				Request:    request,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_ok"}`)),
+			Request:    request,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+	waitForInitialInspection(t, pool, pool.Status().Summary.Total)
+
+	server := &Server{GrokPool: pool}
+	recorder := httptest.NewRecorder()
+	server.handleGrokProxy(recorder, newProxiedGrokRequest(pool, `{"model":"grok-4.6","input":"hi"}`))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("proxy status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if len(upstreamAuths) != 2 || upstreamAuths[0] == upstreamAuths[1] {
+		t.Fatalf("upstream calls = %v, want two different bearer tokens", upstreamAuths)
+	}
+
+	// 成功后粘性绑定应落到新账号：连续两次按 resp_ok 取号必须命中同一账号。
+	_, firstBound, _, err := pool.NextTokenSticky(t.Context(), "", "resp_ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, secondBound, _, err := pool.NextTokenSticky(t.Context(), "", "resp_ok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstBound == "" || firstBound != secondBound {
+		t.Fatalf("resp_ok binding unstable after failover: %q vs %q", firstBound, secondBound)
+	}
+}
+
+func TestGrokProxyPassesThroughWhenNoAlternativeAccount(t *testing.T) {
+	pool := newFailoverTestPool(t, "pool-only")
+
+	upstreamCalls := 0
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		if !isGrokProxyCall(request) {
+			return probeOKResponse(request)
+		}
+		upstreamCalls++
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"code":"rate_limited","error":"Too Many Requests"}`)),
+			Request:    request,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+	waitForInitialInspection(t, pool, pool.Status().Summary.Total)
+
+	server := &Server{GrokPool: pool}
+	recorder := httptest.NewRecorder()
+	server.handleGrokProxy(recorder, newProxiedGrokRequest(pool, `{"model":"grok-4.6","input":"hi"}`))
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("proxy status = %d, want passthrough 429", recorder.Code)
+	}
+	if upstreamCalls != 1 {
+		t.Fatalf("upstream calls = %d, want 1 (no alternative account)", upstreamCalls)
+	}
+}
+
+func TestGrokProxyObservesStreamErrorClassification(t *testing.T) {
+	pool := newFailoverTestPool(t, "pool-exhausted")
+
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		if !isGrokProxyCall(request) {
+			return probeOKResponse(request)
+		}
+		body := "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"code\":\"free-usage-exhausted\",\"message\":\"You have used all the included free usage\"}}}\n\n"
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    request,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+	waitForInitialInspection(t, pool, pool.Status().Summary.Total)
+
+	server := &Server{GrokPool: pool}
+	recorder := httptest.NewRecorder()
+	server.handleGrokProxy(recorder, newProxiedGrokRequest(pool, `{"model":"grok-4.6","input":"hi"}`))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("proxy status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	status := pool.Status()
+	if len(status.Accounts) != 1 || status.Accounts[0].Classification != "quota_exhausted" {
+		t.Fatalf("classification after stream error = %#v", status.Accounts)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #23

让号池对客户端真正表现为"一个稳定端点"：

- **透明故障转移**：池模式下，上游返回 401 / 402 / 403 / 429 / 5xx 时自动换下一个健康账号重发（每次客户端请求最多 3 次尝试、最多换 2 个号），所有重试都发生在向客户端写出任何字节之前。`grokpool` 新增 `NextTokenStickyExcluding`，已失败账号在本轮请求中不再复用
- **续接安全**：换号时主动丢弃失效的 `previous_response_id`（请求含工具输出时保守保留，避免孤儿 function_call_output）；成功后粘性绑定自动落到新账号，后续轮次继续命中它
- **无备选时透传**：池中只剩一个可用账号或全部失败时，原样透传上游错误与状态码，不吞错
- **流内错误观测**：流式回传时扫描响应前缀中的 SSE 错误事件（`type=error` / `response.failed`），HTTP 200 但流内报错（如 free-usage-exhausted）也能即时归类到对应账号健康度，坏号无需等下一轮巡检；无法识别的错误不落库，避免把网络噪音当账号问题

单账号（非池）模式行为不变：仅保留原有的同账号内容修复重试。

## Test plan

- [x] `TestNextTokenStickyExcludingSkipsFailedAccounts` / `...ReportsLostContinuationForExcludedPin`：排除选号与续接钉定语义
- [x] `TestGrokProxyFailsOverToNextPoolAccountOnRateLimit`：首个账号 429 → 自动换号 → 客户端拿到 200，两次上游请求使用不同 Bearer，且 `resp_ok` 粘性绑定稳定落在新账号
- [x] `TestGrokProxyPassesThroughWhenNoAlternativeAccount`：无备选账号时不重试、透传 429
- [x] `TestGrokProxyObservesStreamErrorClassification`：200 流内 free-usage-exhausted → 账号立即变为 quota_exhausted
- [x] `go vet` / `gofmt -l` 干净；`go test -tags=wailsgui .` 通过
- [x] e2e mock 按 `x-grok-client-version` 区分巡检探测与代理流量，并等待后台巡检落库后再断言（无真实网络依赖、无竞态）

注：本机全量测试中 `TestImagineEngineFresh` / `TestImagineGenerateOne` 失败为预存环境问题（活体测试用真实账号撞限流，已在干净 main 上复现确认；CI 无本地账号数据会自动 skip），与本 PR 无关。