### PR TITLE
feat: 会话粘性持久化 + 号池耗尽可操作错误 + 换号可观测头

### DIFF
--- a/internal/grokpool/manager.go
+++ b/internal/grokpool/manager.go
@@ -22,6 +22,7 @@ func NewManager(dir string) (*Manager, error) {
 		dir:         dir,
 		indexPath:   filepath.Join(dir, "pool.json"),
 		accountsDir: filepath.Join(dir, "accounts"),
+		stickyPath:  filepath.Join(dir, "sticky.json"),
 		client:      &http.Client{Timeout: 25 * time.Second},
 		upstreamURL: grokauth.UpstreamURL(),
 		wake:        make(chan struct{}, 1),
@@ -34,6 +35,7 @@ func NewManager(dir string) (*Manager, error) {
 	if err := m.load(); err != nil {
 		return nil, err
 	}
+	m.loadSticky()
 	normalizedProxy, transport, err := netproxy.BuildTransport(m.state.Settings.ProxyURL)
 	if err != nil {
 		return nil, fmt.Errorf("读取号池代理设置: %w", err)
@@ -57,6 +59,8 @@ func (m *Manager) Start() {
 	m.mu.Unlock()
 	go m.scheduler()
 	go m.watchLoop()
+	m.runWG.Add(1)
+	go m.stickyFlushLoop()
 	m.signalWake()
 }
 
@@ -85,6 +89,10 @@ func (m *Manager) Close() {
 	}
 	<-m.done
 	m.runWG.Wait()
+	// 兜底：刷盘循环停止后若仍有绑定写入（如关闭中的最后几个请求），补一次落盘。
+	if err := m.flushSticky(); err != nil {
+		fmt.Fprintf(os.Stderr, "grok_switch: flush sticky bindings on close: %v\n", err)
+	}
 }
 
 func (m *Manager) Status() Status {

--- a/internal/grokpool/sticky.go
+++ b/internal/grokpool/sticky.go
@@ -2,7 +2,9 @@ package grokpool
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -14,11 +16,20 @@ const (
 	// lookup 惰性删除，但从未再次被查到的 resp_/sess_ 绑定只能靠这里回收，
 	// 否则长期运行的实例会随每个成功响应无限累积。
 	stickySweepThreshold = 4096
+	// stickyFlushInterval 限制粘性绑定落盘频率：绑定随每个成功响应产生，
+	// 不能每条都写盘，靠脏标记 + 周期刷盘 + 关闭时刷盘兜底。
+	stickyFlushInterval = 15 * time.Second
 )
 
+// stickyBinding 的字段带 JSON 标签，便于直接持久化到 sticky.json。
 type stickyBinding struct {
-	AccountID string
-	ExpiresAt time.Time
+	AccountID string    `json:"account_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type stickyPersistFile struct {
+	Version  int                      `json:"version"`
+	Bindings map[string]stickyBinding `json:"bindings"`
 }
 
 func (m *Manager) lookupStickyLocked(key string, now time.Time) string {
@@ -31,6 +42,7 @@ func (m *Manager) lookupStickyLocked(key string, now time.Time) string {
 	}
 	if now.After(binding.ExpiresAt) || binding.AccountID == "" {
 		delete(m.sticky, key)
+		m.stickyDirty = true
 		return ""
 	}
 	return binding.AccountID
@@ -47,14 +59,96 @@ func (m *Manager) bindStickyLocked(key, accountID string, now time.Time) {
 		m.sweepStickyLocked(now)
 	}
 	m.sticky[key] = stickyBinding{AccountID: accountID, ExpiresAt: now.Add(stickyTTL)}
+	m.stickyDirty = true
 }
 
 // sweepStickyLocked 删除全部过期绑定；仅在绑定数达到 stickySweepThreshold
 // 时调用，把长期运行实例的内存占用限制在 TTL 内的活跃会话量级。
 func (m *Manager) sweepStickyLocked(now time.Time) {
+	removed := false
 	for key, binding := range m.sticky {
 		if now.After(binding.ExpiresAt) || binding.AccountID == "" {
 			delete(m.sticky, key)
+			removed = true
+		}
+	}
+	if removed {
+		m.stickyDirty = true
+	}
+}
+
+// loadSticky 从数据目录恢复粘性绑定（应用重启/自动更新后进行中的会话
+// 不掉线），过期条目在加载时剪除。文件缺失或损坏按无绑定处理。
+func (m *Manager) loadSticky() {
+	raw, err := os.ReadFile(m.stickyPath)
+	if err != nil {
+		return
+	}
+	var file stickyPersistFile
+	if json.Unmarshal(raw, &file) != nil {
+		return
+	}
+	now := time.Now()
+	bindings := make(map[string]stickyBinding, len(file.Bindings))
+	for key, binding := range file.Bindings {
+		if strings.TrimSpace(key) == "" || binding.AccountID == "" || now.After(binding.ExpiresAt) {
+			continue
+		}
+		bindings[key] = binding
+	}
+	m.mu.Lock()
+	if m.sticky == nil {
+		m.sticky = bindings
+	} else {
+		for key, binding := range bindings {
+			m.sticky[key] = binding
+		}
+	}
+	m.stickyDirty = false
+	m.mu.Unlock()
+}
+
+// flushSticky 把脏标记的绑定快照原子写盘；并发绑定期间拿到的快照可能
+// 略旧，由下一轮刷盘补齐。写失败时恢复脏标记等待重试。
+func (m *Manager) flushSticky() error {
+	m.mu.Lock()
+	if !m.stickyDirty {
+		m.mu.Unlock()
+		return nil
+	}
+	bindings := make(map[string]stickyBinding, len(m.sticky))
+	for key, binding := range m.sticky {
+		bindings[key] = binding
+	}
+	m.stickyDirty = false
+	path := m.stickyPath
+	m.mu.Unlock()
+
+	data, err := json.Marshal(stickyPersistFile{Version: poolVersion, Bindings: bindings})
+	if err != nil {
+		return err
+	}
+	if err := atomicWrite(path, append(data, '\n')); err != nil {
+		m.mu.Lock()
+		m.stickyDirty = true
+		m.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+// stickyFlushLoop 周期把脏绑定落盘；停止时做最后一次刷盘。
+func (m *Manager) stickyFlushLoop() {
+	defer m.runWG.Done()
+	ticker := time.NewTicker(stickyFlushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stop:
+			_ = m.flushSticky()
+			return
+		case <-ticker.C:
+			_ = m.flushSticky()
 		}
 	}
 }
@@ -119,18 +213,22 @@ func (m *Manager) NextTokenStickyExcluding(ctx context.Context, sessionID, previ
 		}
 	}
 	accounts := make([]Account, 0, len(m.state.Accounts))
+	unavailable := make(map[string]int)
 	for _, account := range m.state.Accounts {
 		if exclude[account.ID] {
 			continue
 		}
-		if accountAvailable(account) {
-			accounts = append(accounts, account)
+		if !accountAvailable(account) {
+			unavailable[stickyUnavailableReason(account)]++
+			continue
 		}
+		accounts = append(accounts, account)
 	}
+	total := len(m.state.Accounts)
 	m.mu.Unlock()
 
 	if len(accounts) == 0 {
-		return "", "", lostContinuation, fmtNoAccount()
+		return "", "", lostContinuation, fmtNoAvailableAccount(total, unavailable, len(exclude))
 	}
 	sort.SliceStable(accounts, func(i, j int) bool { return accounts[i].ID < accounts[j].ID })
 
@@ -164,6 +262,43 @@ func (m *Manager) NextTokenStickyExcluding(ctx context.Context, sessionID, previ
 	return "", "", lostContinuation, fmt.Errorf("号池账号 token 均不可用: %s", strings.Join(failures, "; "))
 }
 
-func fmtNoAccount() error {
-	return fmt.Errorf("Grok 号池没有可用账号")
+// stickyUnavailableReason 把不可用账号归到用户可读的原因桶；
+// 手动停用优先于健康分类（两者可能同时成立，停用是用户显式意图）。
+func stickyUnavailableReason(account Account) string {
+	if account.Disabled {
+		return "已手动停用"
+	}
+	switch account.Classification {
+	case "quota_exhausted":
+		return "免费额度耗尽"
+	case "reauth":
+		return "待重新登录"
+	case "permission_denied":
+		return "对话权限被拒"
+	default:
+		return "暂不可用"
+	}
+}
+
+// fmtNoAvailableAccount 生成可操作的池耗尽错误：区分空池与全部不可用，
+// 给出原因分布；故障转移耗尽候选时额外提示本轮已尝试全部可用账号。
+func fmtNoAvailableAccount(total int, unavailable map[string]int, excluded int) error {
+	if total == 0 {
+		return fmt.Errorf("Grok 号池为空，请先在号池页导入 Grok auth 账号")
+	}
+	parts := make([]string, 0, len(unavailable))
+	for _, reason := range []string{"已手动停用", "免费额度耗尽", "待重新登录", "对话权限被拒", "暂不可用"} {
+		if count := unavailable[reason]; count > 0 {
+			parts = append(parts, fmt.Sprintf("%d 个%s", count, reason))
+		}
+	}
+	message := fmt.Sprintf("Grok 号池没有可用账号：共 %d 个账号", total)
+	if len(parts) > 0 {
+		message += "（" + strings.Join(parts, "、") + "）"
+	}
+	message += "，请补充新账号或运行巡检"
+	if excluded > 0 {
+		message += fmt.Sprintf("；本轮请求已尝试全部 %d 个可用账号", excluded)
+	}
+	return fmt.Errorf("%s", message)
 }

--- a/internal/grokpool/sticky_test.go
+++ b/internal/grokpool/sticky_test.go
@@ -2,6 +2,7 @@ package grokpool
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -175,5 +176,88 @@ func TestNextTokenStickyExcludingReportsLostContinuationForExcludedPin(t *testin
 	}
 	if nextID == pinnedID {
 		t.Fatal("excluded pinned account was selected")
+	}
+}
+
+func TestStickyBindingsSurviveRestart(t *testing.T) {
+	dir := t.TempDir()
+	m1, err := NewManager(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := m1.Import([]ImportFile{
+		{Name: "a.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-a","expired":%q,"email":"a@example.com"}`, expiry)},
+		{Name: "b.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-b","expired":%q,"email":"b@example.com"}`, expiry)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, boundID, _, err := m1.NextTokenSticky(t.Context(), "sess-restart", "")
+	if err != nil || boundID == "" {
+		t.Fatalf("NextTokenSticky() = %q err=%v", boundID, err)
+	}
+	m1.BindSession("sess-restart", boundID)
+	m1.BindResponse("resp_restart", boundID)
+	// 直接注入一条过期绑定，验证加载时剪除。
+	m1.mu.Lock()
+	m1.sticky["resp:stale"] = stickyBinding{AccountID: boundID, ExpiresAt: time.Now().Add(-time.Minute)}
+	m1.stickyDirty = true
+	m1.mu.Unlock()
+	if err := m1.flushSticky(); err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := NewManager(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, id, lost, err := m2.NextTokenSticky(t.Context(), "sess-restart", "")
+	if err != nil || lost || token == "" {
+		t.Fatalf("after restart NextTokenSticky() = %q lost=%v err=%v", id, lost, err)
+	}
+	if id != boundID {
+		t.Fatalf("session affinity lost after restart: got %q want %q", id, boundID)
+	}
+	_, respID, lostResp, err := m2.NextTokenSticky(t.Context(), "", "resp_restart")
+	if err != nil || lostResp || respID != boundID {
+		t.Fatalf("response affinity lost after restart: id=%q lost=%v err=%v", respID, lostResp, err)
+	}
+	m2.mu.Lock()
+	_, staleExists := m2.sticky["resp:stale"]
+	m2.mu.Unlock()
+	if staleExists {
+		t.Fatal("expired binding survived reload")
+	}
+}
+
+func TestNoAvailableAccountErrorExplainsReasons(t *testing.T) {
+	manager, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := manager.Import([]ImportFile{
+		{Name: "a.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-a","expired":%q,"email":"a@example.com"}`, expiry)},
+		{Name: "b.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-b","expired":%q,"email":"b@example.com"}`, expiry)},
+		{Name: "c.json", Content: fmt.Sprintf(`{"type":"xai","access_token":"token-c","expired":%q,"email":"c@example.com"}`, expiry)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ids := manager.Status().Accounts
+	if _, err := manager.SetDisabled(ids[0].ID, true); err != nil {
+		t.Fatal(err)
+	}
+	manager.ObserveResponse(ids[1].ID, 429, `{"code":"free-usage-exhausted","message":"You have used all the included free usage"}`)
+	manager.ObserveResponse(ids[2].ID, 401, `{"code":"unauthorized","error":"token has been invalidated"}`)
+
+	_, _, _, err = manager.NextTokenSticky(t.Context(), "", "")
+	if err == nil {
+		t.Fatal("expected error when every account is unavailable")
+	}
+	message := err.Error()
+	for _, want := range []string{"共 3 个账号", "1 个已手动停用", "1 个免费额度耗尽", "1 个待重新登录"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error %q missing %q", message, want)
+		}
 	}
 }

--- a/internal/grokpool/types.go
+++ b/internal/grokpool/types.go
@@ -135,6 +135,8 @@ type Manager struct {
 	roundRobin     atomic.Uint64
 	stores         map[string]*grokauth.Store
 	sticky         map[string]stickyBinding
+	stickyPath     string
+	stickyDirty    bool
 
 	// Auth-dir hot-load state (in-memory fingerprints; re-scanned after restart).
 	watchHashes     map[string]string

--- a/internal/server/grok_proxy.go
+++ b/internal/server/grok_proxy.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"grok_switch/internal/grokauth"
@@ -128,6 +129,22 @@ func grokShouldFailover(statusCode int) bool {
 	return statusCode >= 500
 }
 
+// setGrokSwitchHeaders 暴露号池服务账号与换号次数，方便用户在客户端
+// 侧排查"请求被哪个账号服务、是否发生过故障转移"。仅池模式调用。
+func setGrokSwitchHeaders(w http.ResponseWriter, accountID string, failovers int) {
+	if accountID == "" {
+		return
+	}
+	short := accountID
+	if len(short) > 8 {
+		short = short[:8]
+	}
+	w.Header().Set("X-Grok-Switch-Account", short)
+	if failovers > 0 {
+		w.Header().Set("X-Grok-Switch-Failovers", strconv.Itoa(failovers))
+	}
+}
+
 func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, token, accountID string, body []byte, lostContinuation bool) {
 	hints := parseGrokRequestHints(body)
 	attemptBody := body
@@ -144,6 +161,7 @@ func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, tok
 	}
 	excluded := make(map[string]bool)
 	sessionKey := grokSessionKey(r, hints)
+	failovers := 0
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		resp, err := s.doGrokUpstream(r, token, attemptBody, hints.Model)
@@ -180,12 +198,14 @@ func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, tok
 				nextToken, nextID, _, pickErr := s.GrokPool.NextTokenStickyExcluding(r.Context(), sessionKey, hints.PreviousResponseID, excluded)
 				if pickErr != nil || nextID == "" {
 					// 没有备选账号：透传原始上游错误。
+					setGrokSwitchHeaders(w, accountID, failovers)
 					copyHeaderSkippingHop(w.Header(), resp.Header)
 					w.WriteHeader(resp.StatusCode)
 					_, _ = w.Write(raw)
 					return
 				}
 				fmt.Fprintf(os.Stderr, "grok_switch: grok 代理故障转移 (HTTP %d)，更换账号重试\n", resp.StatusCode)
+				failovers++
 				token = nextToken
 				accountID = nextID
 				// 新账号不认识旧续接引用，能安全丢弃就先丢，省一次往返。
@@ -196,12 +216,14 @@ func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, tok
 				}
 				continue
 			}
+			setGrokSwitchHeaders(w, accountID, failovers)
 			copyHeaderSkippingHop(w.Header(), resp.Header)
 			w.WriteHeader(resp.StatusCode)
 			_, _ = w.Write(raw)
 			return
 		}
 
+		setGrokSwitchHeaders(w, accountID, failovers)
 		copyHeaderSkippingHop(w.Header(), resp.Header)
 		w.WriteHeader(resp.StatusCode)
 		responseID, streamError := copyGrokUpstreamBody(w, resp)

--- a/internal/server/grok_proxy_test.go
+++ b/internal/server/grok_proxy_test.go
@@ -279,6 +279,12 @@ func TestGrokProxyFailsOverToNextPoolAccountOnRateLimit(t *testing.T) {
 	if len(upstreamAuths) != 2 || upstreamAuths[0] == upstreamAuths[1] {
 		t.Fatalf("upstream calls = %v, want two different bearer tokens", upstreamAuths)
 	}
+	if got := recorder.Header().Get("X-Grok-Switch-Account"); len(got) != 8 {
+		t.Fatalf("X-Grok-Switch-Account = %q, want 8-char short id", got)
+	}
+	if got := recorder.Header().Get("X-Grok-Switch-Failovers"); got != "1" {
+		t.Fatalf("X-Grok-Switch-Failovers = %q, want 1", got)
+	}
 
 	// 成功后粘性绑定应落到新账号：连续两次按 resp_ok 取号必须命中同一账号。
 	_, firstBound, _, err := pool.NextTokenSticky(t.Context(), "", "resp_ok")
@@ -324,6 +330,12 @@ func TestGrokProxyPassesThroughWhenNoAlternativeAccount(t *testing.T) {
 	}
 	if upstreamCalls != 1 {
 		t.Fatalf("upstream calls = %d, want 1 (no alternative account)", upstreamCalls)
+	}
+	if got := recorder.Header().Get("X-Grok-Switch-Account"); len(got) != 8 {
+		t.Fatalf("X-Grok-Switch-Account = %q, want 8-char short id", got)
+	}
+	if got := recorder.Header().Get("X-Grok-Switch-Failovers"); got != "" {
+		t.Fatalf("X-Grok-Switch-Failovers = %q, want empty (no failover happened)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #25

延续 #24 的会话连续性与号池可观测性，补齐三个体验缺口：

- **粘性绑定持久化**：绑定写入 `sticky.json`（脏标记 + 15 秒周期刷盘 + 关闭时兜底刷盘，原子写复用 `atomicWrite`）。应用重启或自动更新后加载并剪除过期条目——进行中的 Grok CLI 会话不再因重启掉亲和，省掉一次故障转移往返和推理上下文丢失
- **池耗尽错误可操作**：区分「号池为空，请先导入」与「共 N 个账号但全部不可用」，后者给出原因分布（已手动停用 / 免费额度耗尽 / 待重新登录 / 对话权限被拒 / 暂不可用各多少个）；故障转移耗尽候选时提示「本轮请求已尝试全部可用账号」。用户看到错误就知道下一步该补号、重登还是跑巡检
- **换号可观测**：池模式响应附带 `X-Grok-Switch-Account`（服务账号 8 位短 ID）与发生换号时的 `X-Grok-Switch-Failovers` 计数，从客户端就能确认故障转移是否生效

## Test plan

- [x] `TestStickyBindingsSurviveRestart`：绑定 → 刷盘 → 同目录新建 Manager → 会话与 resp_ 亲和仍命中原账号；过期绑定加载时被剪除
- [x] `TestNoAvailableAccountErrorExplainsReasons`：停用 + 额度耗尽 + 待重登三种账号并存时，错误信息包含「共 3 个账号」及各类原因计数
- [x] 故障转移 e2e 扩展断言：`X-Grok-Switch-Account` 为 8 位短 ID、`X-Grok-Switch-Failovers=1`；无备选透传场景 Failovers 头为空
- [x] `go vet` / `gofmt -l .` 干净；`go test -tags=wailsgui .` 通过
- [x] 全量测试仅剩 2 个预存环境相关失败（`TestImagineEngineFresh`/`TestImagineGenerateOne`，活体测试撞真实限流，CI 自动 skip，已在 #24 说明）