### PR TITLE
feat: Web UI 暗色模式 + 号池筛选计数修复 + 启用徽章去重 + 移动端头部优化

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -188,7 +188,12 @@ func normalize(s Settings) Settings {
 	if s.Theme == "" {
 		s.Theme = "light"
 	}
-	s.Theme = "light"
+	// theme 三态：light / dark / auto（跟随系统）；未知值回退 light。
+	switch s.Theme {
+	case "light", "dark", "auto":
+	default:
+		s.Theme = "light"
+	}
 	if s.Autostart {
 		s.SilentAutostart = true
 	}

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -62,3 +62,20 @@ func assertOneCorruptBackup(t *testing.T, path string) {
 		t.Fatalf("corrupt backups = %#v, want one", matches)
 	}
 }
+
+func TestNormalizeThemeAcceptsThreeStates(t *testing.T) {
+	cases := map[string]string{
+		"light": "light",
+		"dark":  "dark",
+		"auto":  "auto",
+		"":      "light",
+		"blue":  "light",
+		"DARK":  "light",
+	}
+	for input, want := range cases {
+		got := normalize(Settings{Theme: input}).Theme
+		if got != want {
+			t.Errorf("normalize(Settings{Theme:%q}).Theme = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/ui/app.js
+++ b/ui/app.js
@@ -531,6 +531,54 @@ async function run(fn, { button, busyLabel, success } = {}) {
   }
 }
 
+// ---- 界面主题（light / dark / auto）----
+// 设置持久化在 settings.theme；localStorage 仅用于首屏防闪烁的即时恢复。
+const THEME_STORAGE_KEY = "gs_theme_v1";
+const themeMedia = window.matchMedia("(prefers-color-scheme: dark)");
+const THEME_ICONS = {
+  light: '<svg viewBox="0 0 20 20" width="18" height="18" aria-hidden="true"><circle cx="10" cy="10" r="4.2" fill="currentColor"/><g stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><line x1="10" y1="1.6" x2="10" y2="3.6"/><line x1="10" y1="16.4" x2="10" y2="18.4"/><line x1="1.6" y1="10" x2="3.6" y2="10"/><line x1="16.4" y1="10" x2="18.4" y2="10"/><line x1="4" y1="4" x2="5.4" y2="5.4"/><line x1="14.6" y1="14.6" x2="16" y2="16"/><line x1="4" y1="16" x2="5.4" y2="14.6"/><line x1="14.6" y1="5.4" x2="16" y2="4"/></g></svg>',
+  dark: '<svg viewBox="0 0 20 20" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M17.2 12.4A7.6 7.6 0 0 1 7.6 2.8 7.6 7.6 0 1 0 17.2 12.4Z"/></svg>',
+  auto: '<svg viewBox="0 0 20 20" width="18" height="18" aria-hidden="true"><circle cx="10" cy="10" r="7.6" fill="none" stroke="currentColor" stroke-width="1.6"/><path fill="currentColor" d="M10 2.4a7.6 7.6 0 0 1 0 15.2Z"/></svg>',
+};
+const THEME_TITLES = {
+  light: "主题：亮色（点击切换为暗色）",
+  dark: "主题：暗色（点击切换为跟随系统）",
+  auto: "主题：跟随系统（点击切换为亮色）",
+};
+
+function themeSetting() {
+  const value = (state.settings && state.settings.theme) ||
+    localStorage.getItem(THEME_STORAGE_KEY) || "light";
+  return value === "dark" || value === "auto" ? value : "light";
+}
+
+function applyTheme() {
+  const setting = themeSetting();
+  const resolved = setting === "auto" && themeMedia.matches ? "dark" : setting === "dark" ? "dark" : "light";
+  document.documentElement.dataset.theme = resolved;
+  localStorage.setItem(THEME_STORAGE_KEY, setting);
+  const button = $("themeToggleBtn");
+  if (button) {
+    button.innerHTML = THEME_ICONS[setting];
+    button.title = THEME_TITLES[setting];
+    button.setAttribute("aria-label", THEME_TITLES[setting]);
+  }
+}
+
+async function cycleTheme() {
+  const order = ["light", "dark", "auto"];
+  const next = order[(order.indexOf(themeSetting()) + 1) % order.length];
+  state.settings = await api("/api/settings", {
+    method: "PUT",
+    body: JSON.stringify({ ...(state.settings || {}), theme: next }),
+  });
+  applyTheme();
+}
+
+themeMedia.addEventListener("change", () => {
+  if (themeSetting() === "auto") applyTheme();
+});
+
 async function refreshAll() {
   const [status, profiles, backups, settings, grokAuth, grokPool, registrar, lanAccess] = await Promise.all([
     api("/api/status"),
@@ -551,6 +599,7 @@ async function refreshAll() {
   state.registrar = registrar;
   state.lanAccess = lanAccess;
   composerConfigLoaded = false;
+  applyTheme();
   // Coerce to strict boolean for UI.
   if (state.status && typeof state.status.config_matches_active !== "boolean") {
     state.status.config_matches_active = true;
@@ -4212,7 +4261,6 @@ function renderProfiles() {
 				</div>
 				<div class="providerFlags">
 					${profile.pinned ? '<span class="pinBadge">已置顶</span>' : ""}
-					${profile.is_active ? '<span class="badge">当前启用</span>' : ""}
 				</div>
 			</div>
 			<div class="providerActions">
@@ -4829,8 +4877,8 @@ function renderAccountFilterChips(summary) {
   const counts = {
     "": summary.total || 0,
     healthy: summary.healthy || 0,
-    quota_exhausted: summary.quota || 0,
-    permission_denied: summary.permission || 0,
+    quota_exhausted: summary.quota_exhausted || 0,
+    permission_denied: summary.permission_denied || 0,
     reauth: summary.reauth || 0,
     abnormal: summary.abnormal || 0,
     uninspected: summary.uninspected || 0,
@@ -6185,6 +6233,10 @@ $("activateCurrentBtn").onclick = () => run(async () => {
   success: "已保存并启用。新开 grok 会话生效。",
 });
 
+$("themeToggleBtn").onclick = () => run(async () => {
+  await cycleTheme();
+});
+
 $("settingsForm").onsubmit = (event) => {
   event.preventDefault();
   run(async () => {
@@ -6194,7 +6246,7 @@ $("settingsForm").onsubmit = (event) => {
       silent_autostart: $("silentAutostart").checked,
       auto_open_browser: $("autoOpenBrowser").checked,
       lan_access_enabled: $("lanAccessEnabled").checked,
-      theme: "light",
+      theme: themeSetting(),
       port: Number($("port").value || 17878),
     };
     await api("/api/settings", { method: "PUT", body: JSON.stringify(settings) });

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,7 +7,18 @@
   <link rel="icon" href="/icon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/vendor/highlight-github.min.css?v=11.11.1">
   <link rel="stylesheet" href="/vendor/katex/katex.min.css?v=0.18.0">
-  <link rel="stylesheet" href="/style.css?v=53">
+  <link rel="stylesheet" href="/style.css?v=54">
+  <script>
+    // 首屏防闪烁：CSS 生效前按本地缓存的主题写入 data-theme。
+    (function () {
+      try {
+        var theme = localStorage.getItem("gs_theme_v1") || "light";
+        var dark = theme === "dark" ||
+          (theme === "auto" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+        document.documentElement.dataset.theme = dark ? "dark" : "light";
+      } catch (e) { /* 隐私模式下存储可能不可用 */ }
+    })();
+  </script>
 </head>
 <body>
   <div class="shell">
@@ -30,6 +41,7 @@
         <button type="button" id="navAccountsBtn" class="btn" title="账号管理">账号</button>
         <button type="button" id="navImagineBtn" class="btn" title="生图">生图</button>
         <button type="button" id="navSettingsBtn" class="btn" title="设置">设置</button>
+        <button type="button" id="themeToggleBtn" class="navGithubBtn" title="主题：亮色（点击切换为暗色）" aria-label="切换主题"></button>
         <a href="https://github.com/1parado/grok-build-switch" target="_blank" rel="noopener" class="navGithubBtn" title="GitHub 仓库" aria-label="GitHub">
           <svg viewBox="0 0 16 16" width="20" height="20" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
         </a>
@@ -1129,6 +1141,6 @@
   <script src="/vendor/katex/katex.min.js?v=0.18.0"></script>
   <script src="/vendor/katex/contrib/auto-render.min.js?v=0.18.0"></script>
   <!-- mermaid (~3.5MB) is lazy-loaded by app.js only when a diagram is present -->
-  <script src="/app.js?v=57"></script>
+  <script src="/app.js?v=58"></script>
 </body>
 </html>

--- a/ui/style.css
+++ b/ui/style.css
@@ -17,11 +17,59 @@
   --warn-soft: #fffbeb;
   --warn-border: #fcd34d;
   --success: #16a34a;
+  --success-soft: #f0faf3;
+  --success-border: #b9d8c3;
+  --success-strong: #174b2a;
+  --success-muted: #4e765a;
+  --tone-blue: #2563eb;
+  --tone-blue-soft: #eff6ff;
+  --tone-teal: #0f766e;
+  --tone-teal-soft: #f0fdfa;
+  --tone-teal-chip: #99f6e4;
+  --tone-violet: #7c3aed;
+  --tone-violet-soft: #f5f3ff;
+  --tone-violet-border: #ddd6fe;
   --radius: 12px;
   --radius-sm: 8px;
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.04);
   --font: "Segoe UI", "PingFang SC", "Microsoft YaHei UI", system-ui, sans-serif;
   --mono: ui-monospace, "Cascadia Mono", "SF Mono", Consolas, monospace;
+}
+
+/* 暗色主题：app.js 按设置（light/dark/auto）解析后写到 <html data-theme>。
+   只覆盖变量；对话工作台保留其独立主题系统，不受影响。 */
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0f0f12;
+  --surface: #17171b;
+  --surface-2: #1e1e24;
+  --text: #e6e6ea;
+  --muted: #94949e;
+  --line: #26262d;
+  --line-strong: #36363f;
+  --primary: #5b93f5;
+  --primary-fg: #ffffff;
+  --primary-soft: #17233a;
+  --primary-border: #2c4a7d;
+  --danger: #ef4444;
+  --danger-soft: #2a1518;
+  --warn: #d97706;
+  --warn-soft: #291d0d;
+  --warn-border: #574315;
+  --success: #34d377;
+  --success-soft: #12241a;
+  --success-border: #24513a;
+  --success-strong: #86dba9;
+  --success-muted: #74b18d;
+  --tone-blue: #6ba1f7;
+  --tone-blue-soft: #17233a;
+  --tone-teal: #34b3a7;
+  --tone-teal-soft: #0f2320;
+  --tone-teal-chip: #134e48;
+  --tone-violet: #a78bfa;
+  --tone-violet-soft: #221a38;
+  --tone-violet-border: #3f3266;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.5), 0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 * { box-sizing: border-box; }
@@ -978,7 +1026,7 @@ body {
 .chatNode.active {
   border-color: var(--primary);
   background: var(--primary);
-  color: #fff;
+  color: var(--primary-fg);
 }
 
 .chatNode.hasTool {
@@ -1093,6 +1141,8 @@ body {
   font-size: 22px;
   font-weight: 650;
   letter-spacing: -0.02em;
+  /* 窄屏下标题保持整词显示，不折行 */
+  white-space: nowrap;
 }
 
 .pageDesc {
@@ -1530,7 +1580,7 @@ textarea:focus,
   width: min(220px, 100%);
   aspect-ratio: 1;
   margin: 0 auto;
-  border: 8px solid #fff;
+  border: 8px solid var(--surface);
   border-radius: var(--radius-sm);
   box-shadow: 0 0 0 1px var(--line);
   image-rendering: pixelated;
@@ -1771,13 +1821,13 @@ textarea:focus,
 }
 
 .registrarChallengeStatus.is-ok {
-  border-color: color-mix(in srgb, #22c55e 45%, var(--line));
-  background: color-mix(in srgb, #22c55e 12%, var(--surface-2));
+  border-color: color-mix(in srgb, var(--success) 45%, var(--line));
+  background: color-mix(in srgb, var(--success) 12%, var(--surface-2));
 }
 
 .registrarChallengeStatus.is-fail {
-  border-color: color-mix(in srgb, #ef4444 45%, var(--line));
-  background: color-mix(in srgb, #ef4444 12%, var(--surface-2));
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
+  background: color-mix(in srgb, var(--danger) 12%, var(--surface-2));
 }
 
 .registrarResults {
@@ -2344,6 +2394,8 @@ textarea {
   font-weight: 500;
   font-size: 13px;
   cursor: pointer;
+  /* 窄屏下按钮文字保持整词，不折成竖排 */
+  white-space: nowrap;
 }
 
 .btn:hover, .ghostBtn:hover {
@@ -2433,9 +2485,9 @@ textarea {
   gap: 14px;
   margin: 0 0 14px;
   padding: 11px 13px;
-  border: 1px solid #b9d8c3;
+  border: 1px solid var(--success-border);
   border-radius: 8px;
-  background: #f0faf3;
+  background: var(--success-soft);
   color: #245d37;
 }
 
@@ -2462,8 +2514,8 @@ textarea {
   min-width: 0;
 }
 
-.updateCopy strong { color: #174b2a; }
-.updateCopy span { color: #4e765a; font-size: 12px; overflow-wrap: anywhere; }
+.updateCopy strong { color: var(--success-strong); }
+.updateCopy span { color: var(--success-muted); font-size: 12px; overflow-wrap: anywhere; }
 .updateActions { flex: 0 0 auto; }
 
 @media (max-width: 640px) {
@@ -4884,22 +4936,22 @@ body.resizingChatPanels * {
 }
 
 .skillsSourceChip[data-tone="agents"] {
-  border-color: color-mix(in srgb, #2563eb 28%, var(--line));
-  background: color-mix(in srgb, #eff6ff 70%, var(--surface));
+  border-color: color-mix(in srgb, var(--tone-blue) 28%, var(--line));
+  background: color-mix(in srgb, var(--tone-blue-soft) 70%, var(--surface));
 }
-.skillsSourceChip[data-tone="agents"] .skillsSourceChipLabel { color: #2563eb; }
+.skillsSourceChip[data-tone="agents"] .skillsSourceChipLabel { color: var(--tone-blue); }
 
 .skillsSourceChip[data-tone="user"] {
-  border-color: color-mix(in srgb, #7c3aed 28%, var(--line));
-  background: color-mix(in srgb, #f5f3ff 70%, var(--surface));
+  border-color: color-mix(in srgb, var(--tone-violet) 28%, var(--line));
+  background: color-mix(in srgb, var(--tone-violet-soft) 70%, var(--surface));
 }
-.skillsSourceChip[data-tone="user"] .skillsSourceChipLabel { color: #7c3aed; }
+.skillsSourceChip[data-tone="user"] .skillsSourceChipLabel { color: var(--tone-violet); }
 
 .skillsSourceChip[data-tone="bundled"] {
-  border-color: color-mix(in srgb, #0f766e 28%, var(--line));
-  background: color-mix(in srgb, #f0fdfa 70%, var(--surface));
+  border-color: color-mix(in srgb, var(--tone-teal) 28%, var(--line));
+  background: color-mix(in srgb, var(--tone-teal-soft) 70%, var(--surface));
 }
-.skillsSourceChip[data-tone="bundled"] .skillsSourceChipLabel { color: #0f766e; }
+.skillsSourceChip[data-tone="bundled"] .skillsSourceChipLabel { color: var(--tone-teal); }
 
 .skillsSourceHintNote {
   margin: 0;
@@ -5033,21 +5085,21 @@ body.resizingChatPanels * {
 }
 
 .skillsGroup[data-tone="agents"] .skillsGroupCount {
-  color: #2563eb;
+  color: var(--tone-blue);
   background: var(--primary-soft);
   border-color: var(--primary-border);
 }
 
 .skillsGroup[data-tone="user"] .skillsGroupCount {
-  color: #7c3aed;
-  background: #f5f3ff;
-  border-color: #ddd6fe;
+  color: var(--tone-violet);
+  background: var(--tone-violet-soft);
+  border-color: var(--tone-violet-border);
 }
 
 .skillsGroup[data-tone="bundled"] .skillsGroupCount {
-  color: #0f766e;
-  background: #f0fdfa;
-  border-color: #99f6e4;
+  color: var(--tone-teal);
+  background: var(--tone-teal-soft);
+  border-color: var(--tone-teal-chip);
 }
 
 .skillsItems {
@@ -5081,7 +5133,7 @@ body.resizingChatPanels * {
   display: grid;
   place-items: center;
   border-radius: 10px;
-  background: #f7f9fc;
+  background: var(--surface-2);
   border: 1px solid var(--line);
 }
 
@@ -5149,9 +5201,9 @@ body.resizingChatPanels * {
 .skillReadonlyBadge {
   font-size: 11px;
   font-weight: 600;
-  color: #0f766e;
-  background: #f0fdfa;
-  border: 1px solid #99f6e4;
+  color: var(--tone-teal);
+  background: var(--tone-teal-soft);
+  border: 1px solid var(--tone-teal-chip);
   border-radius: 999px;
   padding: 4px 8px;
 }
@@ -5228,7 +5280,7 @@ body.resizingChatPanels * {
   gap: 10px;
   padding: 10px 12px;
   border-bottom: 1px solid var(--line);
-  background: linear-gradient(180deg, #fafafa, #f4f4f5);
+  background: linear-gradient(180deg, var(--surface-2), var(--bg));
 }
 
 .skillsPopupHeadLeft {


### PR DESCRIPTION
## Summary

Fixes #27

在隔离实例（假 HOME + 合成数据）中逐页实测后发现并修复的问题：

### Bug 修复
- **号池筛选 chips 计数错误**：`renderAccountFilterChips` 读取 `summary.quota` / `summary.permission`，而 API 返回 `quota_exhausted` / `permission_denied`——「额度用尽」「权限被拒」永远显示 0。已改为正确字段，实测计数与账号一致
- **「当前启用」徽章重复**：卡片/列表模板同时渲染徽章与启用按钮文案；移除冗余徽章，保留带禁用态样式的按钮作为唯一标识
- **设置表单保存会重置主题**：`settingsForm.onsubmit` 硬编码 `theme: "light"`，保存任何设置都会丢掉用户主题选择

### 新功能：主界面暗色模式
- CSS 新增 `[data-theme="dark"]` 变量覆盖（背景/表面/文字/边框/状态色全套），并把更新横幅、Skills 色调 chips、注册机人机验证状态等硬编码颜色转为语义变量；对话工作台保留其独立主题系统不受影响
- 头部新增主题切换按钮：亮色 → 暗色 → 跟随系统 三态循环，SVG 图标随动
- 持久化到 `settings.theme`；后端 `normalize` 从强制 `"light"` 改为接受三态值（未知值回退 light）；首屏内联脚本按 localStorage 即时应用，避免闪烁；auto 模式监听系统配色变化即时切换
- 静态资源版本号 bump（style v54 / app.js v58）防缓存

### 移动端优化
- 按钮 `white-space: nowrap`：390px 视口下不再出现"聊/天"式竖排折行
- 页面标题不折行

## Test plan

- [x] 浏览器实测（Playwright + Chrome，1440px 与 390px 视口）：主题切换即时生效、刷新后保持、chips 计数正确、启用标识唯一、无 JS 错误
- [x] 截图核对亮色/暗色/移动端首页、号池列表、设置页
- [x] `go test .`（含 ui_layout_test.go 等 UI 断言）与 `go test -tags=wailsgui .` 全绿
- [x] 新增 `TestNormalizeThemeAcceptsThreeStates` 覆盖后端 theme 三态归一化
- [x] `go vet` / `gofmt -l .` 干净