### PR TITLE
fix: 聊天错误可读化 + 活体生图测试显式门控

### DIFF
--- a/internal/server/imagine_engine_test.go
+++ b/internal/server/imagine_engine_test.go
@@ -11,7 +11,11 @@ import (
 // TestImagineEngineFresh 直接走引擎的 wsGenerate（已含 SetReadLimit），
 // 用某个未被烧掉的新鲜账号验证能拿到图片 blob。
 // ACCT 环境变量指定账号下标（默认用最后一个，确保未使用过）。
+// 活体测试会真实调用 grok.com 并消耗账号额度，仅在显式开启时运行。
 func TestImagineEngineFresh(t *testing.T) {
+	if os.Getenv("GROK_SWITCH_LIVE_IMAGINE") == "" {
+		t.Skip("live test consumes real quota; set GROK_SWITCH_LIVE_IMAGINE=1 to enable")
+	}
 	dataDir := imagineTestDataDir(t)
 	eng := NewImagineEngine(dataDir)
 	if eng.AccountCount() == 0 {

--- a/internal/server/imagine_save_test.go
+++ b/internal/server/imagine_save_test.go
@@ -10,7 +10,11 @@ import (
 )
 
 // TestImagineGenerateOne 验证 generateOne 全链路：生图 + 过滤缩略图 + 落盘 + 返回 URL。
+// 活体测试会真实调用 grok.com 并消耗账号额度，仅在显式开启时运行。
 func TestImagineGenerateOne(t *testing.T) {
+	if os.Getenv("GROK_SWITCH_LIVE_IMAGINE") == "" {
+		t.Skip("live test consumes real quota; set GROK_SWITCH_LIVE_IMAGINE=1 to enable")
+	}
 	dataDir := imagineTestDataDir(t)
 	eng := NewImagineEngine(dataDir)
 	if eng.AccountCount() == 0 {

--- a/ui/app.js
+++ b/ui/app.js
@@ -2171,6 +2171,28 @@ function bindChatEmptyActions() {
   });
 }
 
+// friendlyAgentError 把后端错误里内嵌的 JSON（如 RPC -32000 响应）解析成
+// 可读文案，并为常见错误补充可操作指引；无法解析时原样返回。
+function friendlyAgentError(text) {
+  const raw = (text || "").trim();
+  if (!raw) return raw;
+  const start = raw.indexOf("{");
+  if (start >= 0) {
+    try {
+      const parsed = JSON.parse(raw.slice(start));
+      const message = parsed?.message || parsed?.error?.message || "";
+      if (message) {
+        let prefix = raw.slice(0, start).trim().replace(/[:：\s]+$/, "");
+        if (/authentication required/i.test(message) || /no auth method/i.test(parsed?.data || "")) {
+          return `${prefix ? prefix + "：" : ""}Grok CLI 未登录或凭据不可用。请在终端运行 grok 登录后重试。`;
+        }
+        return prefix ? `${prefix}：${message}` : message;
+      }
+    } catch (e) { /* 不是合法 JSON，按原文展示 */ }
+  }
+  return raw;
+}
+
 function renderChatEmptyState(status = state.agentStatus) {
   const empty = $("chatEmpty");
   if (!empty || !empty.isConnected) return;
@@ -2182,7 +2204,7 @@ function renderChatEmptyState(status = state.agentStatus) {
   if (status && status.available === false) {
     empty.dataset.state = "missing";
     title.textContent = "未找到 Grok Build";
-    desc.textContent = status.error || "本机未检测到 grok 可执行文件。请先安装并登录 Grok CLI，然后重试。";
+    desc.textContent = friendlyAgentError(status.error) || "本机未检测到 grok 可执行文件。请先安装并登录 Grok CLI，然后重试。";
     if (actions) {
       actions.innerHTML = `
         <button type="button" id="chatEmptyRetryBtn" class="btn sm primary">重新检测</button>
@@ -2195,7 +2217,7 @@ function renderChatEmptyState(status = state.agentStatus) {
   if (status && (status.state === "dead" || status.error) && !agentIsRunning(status)) {
     empty.dataset.state = "error";
     title.textContent = "Agent 未就绪";
-    desc.textContent = status.error || "连接异常，请检查工作目录后重新启动 Agent。";
+    desc.textContent = friendlyAgentError(status.error) || "连接异常，请检查工作目录后重新启动 Agent。";
     if (actions) {
       actions.innerHTML = `
         <button type="button" id="chatEmptyStartBtn" class="btn sm primary">启动 Agent</button>


### PR DESCRIPTION
## Summary

Fixes #29

- **聊天错误可读化**：新增 `friendlyAgentError`，解析后端错误串中内嵌的 JSON（RPC 响应等），展示其中的可读 message；对「Authentication required / no auth method」类错误补充可操作指引——「Grok CLI 未登录或凭据不可用。请在终端运行 grok 登录后重试。」实测空状态从 raw JSON 变为一句人话
- **活体测试门控**：`TestImagineEngineFresh` / `TestImagineGenerateOne` 会用真实账号真实调用 grok.com 生图并消耗额度，CI 无账号数据时本来就 skip，但任何有本地数据的开发机跑全量测试都会真实消耗且大概率限流失败。加 `GROK_SWITCH_LIVE_IMAGINE=1` 显式门控，默认跳过；需要跑时设环境变量即可

## Test plan

- [x] 隔离实例浏览器实测：聊天空状态显示「创建 Grok 会话失败：Grok CLI 未登录或凭据不可用。请在终端运行 grok 登录后重试。」，无 raw JSON、无 JS 错误
- [x] 默认 `go test ./internal/... .` 在有本地数据的机器上首次全绿（14 包全过，活体测试 skip）
- [x] `go vet` / `gofmt -l .` 干净