### PR TITLE
fix: 安全与稳定性加固 + 代理热路径性能优化

### DIFF
--- a/internal/grokauth/store.go
+++ b/internal/grokauth/store.go
@@ -557,6 +557,11 @@ func atomicWrite(path string, data []byte) error {
 		tmp.Close()
 		return err
 	}
+	// rename 前把数据块刷盘，避免掉电时丢失刚轮换的 refresh_token 等关键凭据。
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}

--- a/internal/grokpool/inspect.go
+++ b/internal/grokpool/inspect.go
@@ -123,14 +123,22 @@ func (m *Manager) recordInspection(result Account) {
 		if m.state.Accounts[i].ID != result.ID {
 			continue
 		}
-		result.Disabled = m.state.Accounts[i].Disabled
-		result.FileName = firstNonEmpty(result.FileName, m.state.Accounts[i].FileName)
-		result.ImportedAt = m.state.Accounts[i].ImportedAt
-		m.state.Accounts[i] = result
+		current := &m.state.Accounts[i]
+		result.Disabled = current.Disabled
+		result.FileName = firstNonEmpty(result.FileName, current.FileName)
+		result.ImportedAt = current.ImportedAt
+		// result.LastInspected 是探测开始的时间。一轮巡检可能持续数分钟，
+		// 期间的实时观测（recordObservation / recordTokenFailure）或凭据
+		// 热更新已写入更新的状态；旧快照不允许整体回滚这些新状态。
+		stale := current.LastInspected.After(result.LastInspected) ||
+			current.ImportedAt.After(result.LastInspected)
+		if !stale {
+			*current = result
+			_ = m.saveLocked()
+		}
 		break
 	}
 	m.doneCount++
-	_ = m.saveLocked()
 }
 
 // ObserveResponse lets the live proxy react before the next scheduled sweep.
@@ -287,7 +295,7 @@ func (m *Manager) doProbe(ctx context.Context, method, rawURL, token string, bod
 	if len(body) > 0 {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := m.client.Do(req)
+	resp, err := m.client.Load().Do(req)
 	if err != nil {
 		return probeResponse{}, err
 	}

--- a/internal/grokpool/manager.go
+++ b/internal/grokpool/manager.go
@@ -23,7 +23,6 @@ func NewManager(dir string) (*Manager, error) {
 		indexPath:   filepath.Join(dir, "pool.json"),
 		accountsDir: filepath.Join(dir, "accounts"),
 		stickyPath:  filepath.Join(dir, "sticky.json"),
-		client:      &http.Client{Timeout: 25 * time.Second},
 		upstreamURL: grokauth.UpstreamURL(),
 		wake:        make(chan struct{}, 1),
 		stop:        make(chan struct{}),
@@ -32,6 +31,7 @@ func NewManager(dir string) (*Manager, error) {
 		watchHashes: make(map[string]string),
 		sticky:      make(map[string]stickyBinding),
 	}
+	m.client.Store(&http.Client{Timeout: 25 * time.Second})
 	if err := m.load(); err != nil {
 		return nil, err
 	}
@@ -41,8 +41,8 @@ func NewManager(dir string) (*Manager, error) {
 		return nil, fmt.Errorf("读取号池代理设置: %w", err)
 	}
 	m.state.Settings.ProxyURL = normalizedProxy
-	m.transport = transport
-	m.client = clientForTransport(transport)
+	m.transport.Store(transport)
+	m.client.Store(clientForTransport(transport))
 	if err := m.saveLocked(); err != nil {
 		return nil, err
 	}
@@ -294,8 +294,8 @@ func (m *Manager) UpdateSettings(settings Settings) (Status, error) {
 	}
 	m.mu.Lock()
 	m.state.Settings = settings
-	m.transport = transport
-	m.client = clientForTransport(transport)
+	m.transport.Store(transport)
+	m.client.Store(clientForTransport(transport))
 	for _, store := range m.stores {
 		_ = store.SetProxyURL(settings.ProxyURL)
 	}
@@ -572,12 +572,18 @@ func (m *Manager) accountStore(id string) *grokauth.Store {
 }
 
 func (m *Manager) Transport() http.RoundTripper {
+	if t := m.transport.Load(); t != nil {
+		return t
+	}
+	return nil
+}
+
+// SetUpstreamURL 覆盖巡检探测的上游地址。测试用：把探测指向本地 httptest
+// 服务，避免单测期间访问生产环境。
+func (m *Manager) SetUpstreamURL(url string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.transport == nil {
-		return nil
-	}
-	return m.transport
+	m.upstreamURL = url
 }
 
 // clientForTransport builds an HTTP client for pool inspection.

--- a/internal/grokpool/manager_test.go
+++ b/internal/grokpool/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -80,7 +81,7 @@ func TestAutomaticInspectionClassifiesAndRoutesOnlyAvailableAccount(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	manager.client = upstream.Client()
+	manager.client.Store(upstream.Client())
 	manager.upstreamURL = upstream.URL
 	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 	_, err = manager.Import([]ImportFile{
@@ -341,9 +342,9 @@ func TestProbeErrorTextIsBounded(t *testing.T) {
 }
 
 func TestInspectionUsesConfiguredHTTPProxy(t *testing.T) {
-	var proxyCalls int
+	var proxyCalls atomic.Int64
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxyCalls++
+		proxyCalls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/models":
@@ -381,8 +382,8 @@ func TestInspectionUsesConfiguredHTTPProxy(t *testing.T) {
 	}
 	manager.runWG.Wait()
 	status := manager.Status()
-	if proxyCalls < 2 || status.Accounts[0].Classification != "healthy" {
-		t.Fatalf("proxy calls = %d, status = %#v", proxyCalls, status)
+	if proxyCalls.Load() < 2 || status.Accounts[0].Classification != "healthy" {
+		t.Fatalf("proxy calls = %d, status = %#v", proxyCalls.Load(), status)
 	}
 	if status.Settings.ProxyURL != proxy.URL {
 		t.Fatalf("stored proxy URL = %q", status.Settings.ProxyURL)

--- a/internal/grokpool/store.go
+++ b/internal/grokpool/store.go
@@ -127,6 +127,11 @@ func atomicWrite(path string, data []byte) error {
 		tmp.Close()
 		return err
 	}
+	// rename 前把数据块刷盘，避免掉电时丢失刚轮换的 refresh_token 等关键凭据。
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}

--- a/internal/grokpool/types.go
+++ b/internal/grokpool/types.go
@@ -115,8 +115,10 @@ type Manager struct {
 	dir         string
 	indexPath   string
 	accountsDir string
-	client      *http.Client
-	transport   *http.Transport
+	// client/transport 会在运行中被 UpdateSettings 替换，而探测与代理请求
+	// 不持有 m.mu，因此用原子指针读写，避免数据竞争。
+	client      atomic.Pointer[http.Client]
+	transport   atomic.Pointer[http.Transport]
 	upstreamURL string
 
 	mu             sync.Mutex

--- a/internal/profiles/store.go
+++ b/internal/profiles/store.go
@@ -161,7 +161,14 @@ func (s *Store) ClearActive() error {
 }
 
 func (s *Store) EnsureDir() error {
-	return os.MkdirAll(filepath.Dir(s.path), 0o755)
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	// 旧版本可能以 0755 创建了目录；profile 内含明文 API Key，尽力收紧权限。
+	if runtime.GOOS != "windows" {
+		_ = os.Chmod(filepath.Dir(s.path), 0o700)
+	}
+	return nil
 }
 
 func (s *Store) readLocked() ([]Profile, error) {
@@ -207,7 +214,7 @@ func (s *Store) writeLocked(profiles []Profile) error {
 }
 
 func atomicWrite(path string, data []byte) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
@@ -216,7 +223,16 @@ func atomicWrite(path string, data []byte) error {
 	}
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil && runtime.GOOS != "windows" {
+		tmp.Close()
+		return err
+	}
 	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	// rename 前把数据块刷盘，避免掉电时目标文件变成空文件或残缺内容。
+	if err := tmp.Sync(); err != nil {
 		tmp.Close()
 		return err
 	}

--- a/internal/server/grok_proxy.go
+++ b/internal/server/grok_proxy.go
@@ -74,8 +74,7 @@ func (s *Server) grokProxyAuthorized(r *http.Request) bool {
 	return s.GrokAuth != nil && s.GrokAuth.Authorized(r)
 }
 
-func (s *Server) grokProxyToken(ctx context.Context, r *http.Request, body []byte) (token, accountID string, lostContinuation bool, err error) {
-	hints := parseGrokRequestHints(body)
+func (s *Server) grokProxyToken(ctx context.Context, r *http.Request, hints grokRequestHints) (token, accountID string, lostContinuation bool, err error) {
 	sessionID := grokSessionKey(r, hints)
 	if s.GrokPool != nil && s.GrokPool.Authorized(r) {
 		token, accountID, lostContinuation, err = s.GrokPool.NextTokenSticky(ctx, sessionID, hints.PreviousResponseID)
@@ -105,11 +104,10 @@ func grokSessionKey(r *http.Request, hints grokRequestHints) string {
 	)
 }
 
-func (s *Server) rememberGrokProxySticky(r *http.Request, body []byte, accountID, responseID string) {
+func (s *Server) rememberGrokProxySticky(r *http.Request, hints grokRequestHints, accountID, responseID string) {
 	if s.GrokPool == nil || accountID == "" {
 		return
 	}
-	hints := parseGrokRequestHints(body)
 	if sessionID := grokSessionKey(r, hints); sessionID != "" {
 		s.GrokPool.BindSession(sessionID, accountID)
 	}
@@ -145,8 +143,9 @@ func setGrokSwitchHeaders(w http.ResponseWriter, accountID string, failovers int
 	}
 }
 
-func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, token, accountID string, body []byte, lostContinuation bool) {
-	hints := parseGrokRequestHints(body)
+// forwardGrokUpstream 的 hints 由调用方（handleGrokProxy）解析一次后传入，
+// 避免对最大 32MB 的请求体重复做全量 JSON 解析。
+func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, token, accountID string, body []byte, lostContinuation bool, hints grokRequestHints) {
 	attemptBody := body
 	if lostContinuation && !hints.HasToolOutput {
 		if next, ok := dropPreviousResponseID(attemptBody); ok {
@@ -232,7 +231,7 @@ func (s *Server) forwardGrokUpstream(w http.ResponseWriter, r *http.Request, tok
 			s.GrokPool.ObserveStreamError(accountID, streamError)
 		}
 		if resp.StatusCode < 300 {
-			s.rememberGrokProxySticky(r, body, accountID, responseID)
+			s.rememberGrokProxySticky(r, hints, accountID, responseID)
 		}
 		return
 	}

--- a/internal/server/grokauth.go
+++ b/internal/server/grokauth.go
@@ -183,7 +183,10 @@ func (s *Server) handleGrokProxy(w http.ResponseWriter, r *http.Request) {
 		restoreRequestBody(r, body)
 	}
 
-	token, poolAccountID, lostContinuation, err := s.grokProxyToken(r.Context(), r, body)
+	// 请求体最多 32MB：hints 只在这里全量解析一次，后续 token 选择、
+	// 粘性绑定与上游转发全部复用，避免重复 JSON 解析。
+	hints := parseGrokRequestHints(body)
+	token, poolAccountID, lostContinuation, err := s.grokProxyToken(r.Context(), r, hints)
 	if err != nil {
 		writeError(w, err, http.StatusBadGateway)
 		return
@@ -222,7 +225,7 @@ func (s *Server) handleGrokProxy(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	s.forwardGrokUpstream(w, r, token, poolAccountID, body, lostContinuation)
+	s.forwardGrokUpstream(w, r, token, poolAccountID, body, lostContinuation, hints)
 }
 
 // isImageGenProxyPath 判断是否为内置 image_gen 工具的图片生成请求
@@ -792,7 +795,11 @@ func cloneModelDefs(models []profiles.ModelDef, baseURL, apiKey string) []profil
 		out[i] = model
 		out[i].BaseURL = baseURL
 		out[i].APIKey = apiKey
-		out[i].APIBackend = "responses"
+		// 仅在缺失时补默认后端；保留上游 /models 上报的 api_backend，
+		// 避免把 messages/chat_completions 后端的模型错误标记为 responses。
+		if strings.TrimSpace(out[i].APIBackend) == "" {
+			out[i].APIBackend = "responses"
+		}
 		if model.ExtraHeaders != nil {
 			out[i].ExtraHeaders = make(map[string]string, len(model.ExtraHeaders))
 			for key, value := range model.ExtraHeaders {

--- a/internal/server/grokauth_imagegen.go
+++ b/internal/server/grokauth_imagegen.go
@@ -250,7 +250,7 @@ func (s *Server) buildChatCompletionsFinal(chatResp map[string]any, executedCall
 		if data, err := os.ReadFile(filepath.Join(s.Imagine.outputsDir, path.Base(res.Images[0]))); err == nil {
 			b64 = base64.StdEncoding.EncodeToString(data)
 		}
-		url := "http://127.0.0.1:17878" + res.Images[0]
+		url := fmt.Sprintf("http://127.0.0.1:%d%s", s.ActualPort, res.Images[0])
 		msg := fmt.Sprintf("图片已生成：%dx%d，模型 %s。", res.Width, res.Height, res.ModelName)
 		if b64 != "" {
 			msg += "\n\n![generated image](data:image/jpeg;base64," + b64 + ")"

--- a/internal/server/grokpool_test.go
+++ b/internal/server/grokpool_test.go
@@ -72,6 +72,22 @@ func TestGrokProxyFallsBackToSingleAuthWhenPoolHasNoAvailableAccount(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Import 会立刻触发后台巡检：先把上游指向本地 httptest，巡检结束后
+	// 才允许下面对 http.DefaultTransport 全局变量做替换，避免数据竞争。
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/models":
+			_, _ = io.WriteString(w, `{"data":[{"id":"grok-4.5"}]}`)
+		case "/responses":
+			_, _ = io.WriteString(w, `{"id":"ok"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+	pool.SetUpstreamURL(upstream.URL)
+
 	expiry := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
 	_, err = pool.Import([]grokpool.ImportFile{{
 		Name:    "disabled.json",
@@ -88,6 +104,7 @@ func TestGrokProxyFallsBackToSingleAuthWhenPoolHasNoAvailableAccount(t *testing.
 	if _, err := single.Import([]byte(fmt.Sprintf(`{"type":"xai","access_token":"single-access","expired":%q}`, expiry))); err != nil {
 		t.Fatal(err)
 	}
+	waitForInspection(t, pool)
 
 	previousTransport := http.DefaultTransport
 	var upstreamAuthorization string
@@ -120,4 +137,18 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return fn(request)
+}
+
+// waitForInspection 等待 Import 触发的后台巡检完成（分类离开 uninspected）。
+func waitForInspection(t *testing.T, pool *grokpool.Manager) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		status := pool.Status()
+		if len(status.Accounts) > 0 && status.Accounts[0].Classification != "uninspected" {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("background inspection did not finish in time")
 }

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -25,10 +25,9 @@ type chatProject struct {
 	PathOK       bool      `json:"path_ok"`
 }
 
-type projectsStore struct {
-	mu   sync.Mutex
-	path string
-}
+// projectsMu 保护 projects.json 的整个「读-改-写」流程：所有 handler 必须
+// 先持有 s.projectsMu 再调用 loadProjects / saveProjects，否则并发请求会
+// 相互覆盖更新。
 
 func (s *Server) projectsFile() string {
 	return filepath.Join(s.Paths.DataDir, "projects.json")
@@ -76,17 +75,43 @@ func (s *Server) loadProjects() ([]chatProject, error) {
 }
 
 func (s *Server) saveProjects(list []chatProject) error {
-	if err := os.MkdirAll(filepath.Dir(s.projectsFile()), 0o755); err != nil {
+	path := s.projectsFile()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(list, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.projectsFile(), data, 0o600)
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		if runtime.GOOS == "windows" {
+			// Windows 不允许 rename 覆盖已存在文件。
+			if removeErr := os.Remove(path); removeErr != nil && !os.IsNotExist(removeErr) {
+				return err
+			}
+			return os.Rename(tmpName, path)
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *Server) handleAgentProjects(w http.ResponseWriter, r *http.Request) {
+	s.projectsMu.Lock()
+	defer s.projectsMu.Unlock()
 	switch r.Method {
 	case http.MethodGet:
 		list, err := s.loadProjects()
@@ -160,6 +185,8 @@ func (s *Server) handleAgentProjectAction(w http.ResponseWriter, r *http.Request
 		methodNotAllowed(w)
 		return
 	}
+	s.projectsMu.Lock()
+	defer s.projectsMu.Unlock()
 	action := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/agent/projects/"), "/")
 	var req struct {
 		ID     string `json:"id"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,6 +63,7 @@ type Server struct {
 	httpServer   *http.Server
 	loginMu      sync.Mutex
 	loginFails   map[string]loginFailure
+	projectsMu   sync.Mutex
 
 	reloginMu   sync.Mutex
 	reloginSeq  int64

--- a/internal/server/skills.go
+++ b/internal/server/skills.go
@@ -22,22 +22,14 @@ func (s *Server) handleSkills(w http.ResponseWriter, r *http.Request) {
 		methodNotAllowed(w)
 		return
 	}
-	home, _ := os.UserHomeDir()
-	agentsDir := filepath.Join(home, ".agents")
-	grokDir := s.Paths.GrokHome
-	if grokDir == "" {
-		grokDir = filepath.Join(home, ".grok")
-	}
+	roots := s.skillRoots()
 
 	var skills []SkillEntry
 	seen := make(map[string]bool)
 
-	// Scan ~/.agents/skills/ — agent-specific skills
-	scanSkillsDir(filepath.Join(agentsDir, "skills"), "agents/skills", &skills, seen)
-	// Scan ~/.grok/skills/ — user-installed skills
-	scanSkillsDir(filepath.Join(grokDir, "skills"), "grok/skills", &skills, seen)
-	// Scan ~/.grok/bundled/skills/ — bundled/packaged skills
-	scanSkillsDir(filepath.Join(grokDir, "bundled", "skills"), "grok/bundled", &skills, seen)
+	scanSkillsDir(roots[0], "agents/skills", &skills, seen)
+	scanSkillsDir(roots[1], "grok/skills", &skills, seen)
+	scanSkillsDir(roots[2], "grok/bundled", &skills, seen)
 
 	sort.Slice(skills, func(i, j int) bool {
 		if skills[i].Source != skills[j].Source {
@@ -226,6 +218,23 @@ func formatSkillPrompt(name, content, remainder string) string {
 	return b.String()
 }
 
+// skillRoots returns the three directories whose contents the skills page may
+// list and delete. Deletion is restricted to these subtrees so a stray request
+// can never remove ~/.grok/config.toml, auth.json or session data.
+func (s *Server) skillRoots() []string {
+	home, _ := os.UserHomeDir()
+	agentsDir := filepath.Join(home, ".agents")
+	grokDir := s.Paths.GrokHome
+	if grokDir == "" {
+		grokDir = filepath.Join(home, ".grok")
+	}
+	return []string{
+		filepath.Join(agentsDir, "skills"),
+		filepath.Join(grokDir, "skills"),
+		filepath.Join(grokDir, "bundled", "skills"),
+	}
+}
+
 func (s *Server) handleSkillsDelete(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		methodNotAllowed(w)
@@ -234,7 +243,7 @@ func (s *Server) handleSkillsDelete(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Path string `json:"path"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
 		writeError(w, err, http.StatusBadRequest)
 		return
 	}
@@ -243,35 +252,38 @@ func (s *Server) handleSkillsDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Security: prevent path traversal by resolving and verifying the path
-	// is within allowed directories (~/.agents or ~/.grok).
+	// Security: resolve symlinks and verify the target really lives inside one
+	// of the skill roots before removing anything.
 	absPath, err := filepath.Abs(req.Path)
 	if err != nil {
 		writeError(w, err, http.StatusBadRequest)
 		return
 	}
-	home, _ := os.UserHomeDir()
-	agentsDir := filepath.Join(home, ".agents")
-	grokDir := s.Paths.GrokHome
-	if grokDir == "" {
-		grokDir = filepath.Join(home, ".grok")
+	resolved := filepath.Clean(absPath)
+	if resolvedPath, err := filepath.EvalSymlinks(absPath); err == nil {
+		resolved = resolvedPath
+	} else if !os.IsNotExist(err) {
+		writeError(w, err, http.StatusInternalServerError)
+		return
 	}
 	allowed := false
-	for _, dir := range []string{agentsDir, grokDir} {
-		if dir != "" {
-			rel, err := filepath.Rel(dir, absPath)
-			if err == nil && len(rel) > 0 && rel[0] != '.' {
-				allowed = true
-				break
-			}
+	for _, root := range s.skillRoots() {
+		rootResolved := filepath.Clean(root)
+		if rootResolvedAbs, err := filepath.Abs(rootResolved); err == nil {
+			rootResolved = rootResolvedAbs
+		}
+		rel, err := filepath.Rel(rootResolved, resolved)
+		if err == nil && rel != "" && rel != "." && rel[0] != '.' && !filepath.IsAbs(rel) {
+			allowed = true
+			break
 		}
 	}
 	if !allowed {
-		writeError(w, fmt.Errorf("path is outside allowed directories"), http.StatusForbidden)
+		writeError(w, fmt.Errorf("只能删除 Skills 目录下的条目"), http.StatusForbidden)
 		return
 	}
 
-	if err := os.RemoveAll(absPath); err != nil {
+	if err := os.RemoveAll(resolved); err != nil {
 		writeError(w, err, http.StatusInternalServerError)
 		return
 	}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 
 	"grok_switch/internal/recovery"
 )
@@ -38,6 +39,14 @@ type Settings struct {
 type Store struct {
 	path string
 	mu   sync.Mutex
+
+	// 热路径缓存：Get() 位于每个本地代理请求的路径上，逐次读盘 + JSON 解析
+	// 是纯开销。settings.json 只由本进程写入（单实例），用 mtime+size 判断
+	// 是否需要重新读取即可。
+	cacheValid bool
+	cacheValue Settings
+	cacheMod   time.Time
+	cacheSize  int64
 }
 
 type ValidationError struct {
@@ -104,6 +113,16 @@ func (s *Store) readLocked() (Settings, error) {
 	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
 		return Settings{}, err
 	}
+	var modTime time.Time
+	var size int64
+	cacheHit := false
+	if info, err := os.Stat(s.path); err == nil {
+		modTime, size = info.ModTime(), info.Size()
+		cacheHit = s.cacheValid && modTime.Equal(s.cacheMod) && size == s.cacheSize
+	}
+	if cacheHit {
+		return s.cacheValue, nil
+	}
 	data, err := os.ReadFile(s.path)
 	if errors.Is(err, os.ErrNotExist) {
 		def := Default()
@@ -129,6 +148,10 @@ func (s *Store) readLocked() (Settings, error) {
 		}
 		return s.recoverLocked(fmt.Errorf("invalid settings: %w", err), repaired)
 	}
+	s.cacheValid = true
+	s.cacheValue = current
+	s.cacheMod = modTime
+	s.cacheSize = size
 	return current, nil
 }
 
@@ -174,6 +197,15 @@ func (s *Store) writeLocked(current Settings) error {
 			return os.Rename(tmpName, s.path)
 		}
 		return err
+	}
+	// 写入成功后同步缓存；Stat 失败则失效缓存，下次读取时重建。
+	s.cacheValue = normalize(current)
+	if info, err := os.Stat(s.path); err == nil {
+		s.cacheValid = true
+		s.cacheMod = info.ModTime()
+		s.cacheSize = info.Size()
+	} else {
+		s.cacheValid = false
 	}
 	return nil
 }

--- a/ui/app.js
+++ b/ui/app.js
@@ -493,9 +493,10 @@ function isAbortError(err) {
 function toast(message, type = "info") {
   const el = $("toast");
   el.textContent = message;
-  el.classList.remove("error", "success", "show");
+  el.classList.remove("error", "success", "warn", "show");
   if (type === "error") el.classList.add("error");
   if (type === "success") el.classList.add("success");
+  if (type === "warn") el.classList.add("warn");
   requestAnimationFrame(() => el.classList.add("show"));
   clearTimeout(toastTimer);
   toastTimer = setTimeout(() => el.classList.remove("show"), type === "error" ? 4200 : 2800);
@@ -2049,7 +2050,22 @@ function connectAgentSocket() {
   };
 }
 
+// 切换会话后，旧会话的流式事件仍可能在 WS 上晚到（服务端补发/重连回放同理）；
+// 凡带 session_id 且与当前活动会话不符的内容事件一律丢弃，避免串话污染新记录。
+const STALE_SESSION_EVENT_TYPES = new Set([
+  "assistant_chunk", "thought_chunk", "assistant_media",
+  "tool_call", "tool_update", "turn_done", "error",
+]);
+
 function handleAgentEvent(event) {
+  const activeSessionId = state.activeAgentSession?.id || "";
+  if (
+    event.session_id && activeSessionId &&
+    event.session_id !== activeSessionId &&
+    STALE_SESSION_EVENT_TYPES.has(event.type)
+  ) {
+    return;
+  }
   switch (event.type) {
     case "agent_status": {
       const current = state.agentStatus || {};
@@ -2131,7 +2147,7 @@ function clearAgentTranscript(showEmpty = true) {
   state.lastUserMessage = "";
   state.chatStickToBottom = true;
   resetChatNodes();
-  clearChatAttachments();
+  clearChatAttachments(true);
   if ($("permissionBar")) $("permissionBar").hidden = true;
   if ($("planBar")) $("planBar").hidden = true;
   historyRenderedStart = 0;
@@ -3372,9 +3388,12 @@ function renderAgentTool(tool, isUpdate, sessionID = "") {
   }
   // Always force collapsed during history mount / streaming updates unless user opened it.
   if (!details.dataset.userOpened) details.open = false;
-  details.addEventListener("toggle", () => {
-    if (details.open) details.dataset.userOpened = "1";
-  }, { once: true });
+  if (!details.dataset.userOpenedBound) {
+    details.dataset.userOpenedBound = "1";
+    details.addEventListener("toggle", () => {
+      if (details.open) details.dataset.userOpened = "1";
+    });
+  }
 
   const title = tool.title || details.querySelector(".agentToolTitle").textContent || "工具调用";
   const status = tool.status || details.dataset.status || (isUpdate ? "更新" : "等待");
@@ -3823,13 +3842,29 @@ function renderChatAttachments() {
     remove.className = "chatAttachmentRemove";
     remove.textContent = "×";
     remove.setAttribute("aria-label", `移除 ${att.name || "附件"}`);
-    remove.onclick = () => { state.pendingAttachments.splice(index, 1); renderChatAttachments(); updateChatComposerState(); };
+    remove.onclick = () => {
+      releaseAttachmentPreview(state.pendingAttachments[index]);
+      state.pendingAttachments.splice(index, 1);
+      renderChatAttachments();
+      updateChatComposerState();
+    };
     chip.append(remove);
     wrap.append(chip);
   });
 }
 
-function clearChatAttachments() {
+// blob 预览 URL 只在移除附件或整段会话记录被丢弃时释放；发送后消息气泡
+// 仍引用同一 URL，那里不能提前 revoke。
+function releaseAttachmentPreview(att) {
+  if (att?.previewUrl && String(att.previewUrl).startsWith("blob:")) {
+    URL.revokeObjectURL(att.previewUrl);
+    att.previewUrl = "";
+    att.dataUrl = "";
+  }
+}
+
+function clearChatAttachments(revoke = false) {
+  if (revoke) state.pendingAttachments.forEach(releaseAttachmentPreview);
   state.pendingAttachments = [];
   renderChatAttachments();
 }
@@ -4937,6 +4972,9 @@ async function loadAccountsList({ silent = false, append = false } = {}) {
   const container = $("grokPoolAccounts");
   if (!container || accountListInFlight) return;
   accountListInFlight = true;
+  // 页码自增放在 in-flight 检查之后：连点时不会先跳页再把请求吞掉，
+  // 加载失败则回退页码。
+  if (append) accountListPage += 1;
   try {
     const params = new URLSearchParams({
       page: String(accountListPage),
@@ -4956,6 +4994,7 @@ async function loadAccountsList({ silent = false, append = false } = {}) {
       meta.textContent = `共 ${accountListTotal} 个账号 · 已加载 ${loadedUpTo}`;
     }
   } catch (err) {
+    if (append) accountListPage -= 1;
     if (!silent) toast(err.message, "error");
   } finally {
     accountListInFlight = false;
@@ -5866,7 +5905,6 @@ $("backFromSettingsBtn").onclick = () => showView("home");
 $("backFromAccountsBtn").onclick = () => showView("home");
 $("goAccountsFromSettingsBtn").onclick = () => showView("accounts");
 $("accountLoadMoreBtn").onclick = () => {
-  accountListPage += 1;
   loadAccountsList({ append: true }).catch((err) => toast(err.message, "error"));
 };
 $("accountSort").onchange = () => {
@@ -6385,7 +6423,7 @@ $("registrarClashAutoDetectBtn")?.addEventListener("click", async () => {
       if (data.controller && $("registrarClashController")) $("registrarClashController").value = data.controller;
       if (data.group && $("registrarClashSelectorGroup")) $("registrarClashSelectorGroup").value = data.group;
       const portInfo = data.mixed_port ? `（mixed-port=${data.mixed_port}）` : "";
-      hint.innerHTML = `✅ 已检测到 Clash 核心 v${data.core_version}，控制器=<code>${data.controller}</code>，选择器组=<code>${data.group || "未找到"}</code>（${data.group_node_count || 0} 个可用节点）${portInfo}。配置已自动填入。`;
+      hint.innerHTML = `✅ 已检测到 Clash 核心 v${escapeHtml(String(data.core_version ?? ""))}，控制器=<code>${escapeHtml(String(data.controller ?? ""))}</code>，选择器组=<code>${escapeHtml(String(data.group || "未找到"))}</code>（${Number(data.group_node_count) || 0} 个可用节点）${portInfo}。配置已自动填入。`;
       registrarFormDirty = true;
     } else {
       hint.innerHTML = "❌ 未检测到正在运行的 Clash/mihomo 控制器。请确认 FlClash / ClashVerge / ClashX 已启动并开启了外部控制器（默认端口 9090）。";

--- a/ui/style.css
+++ b/ui/style.css
@@ -2476,6 +2476,7 @@ textarea {
 }
 
 .toast.error { background: #b91c1c; }
+.toast.warn { background: var(--warn); }
 .toast.success { background: #15803d; }
 
 .updateBanner {


### PR DESCRIPTION
## 概述

本 PR 对项目做了一轮系统性的内容优化：修复 1 个 XSS 注入点、1 个越权删除面、2 处数据竞争、掉电丢凭据风险，消除代理热路径的重复 IO/解析，并顺手修掉一批前端体验毛刺。全部改动均通过 `go vet` + `go test ./... -race -count=1` 全绿验证。

## 正确性 / 安全

| 问题 | 影响 | 修复 |
|---|---|---|
| Clash 自动检测结果直接 innerHTML（app.js） | 分组名来自机场订阅，恶意订阅可注入脚本拿到 Web UI 全部能力（删文件、读 Key），LAN 配对下手机同受影响 | 统一 `escapeHtml` |
| `/api/skills/delete` 只校验在 `~/.agents`/`~/.grok` 下即 `RemoveAll` | 一个误调用可递归删掉 `config.toml`、`auth.json`、整个 sessions 目录 | 收紧到三个 skills 子树白名单 + 符号链接解析 + 64KB body 上限 |
| grokpool `client`/`transport` 运行中被替换但探测/代理请求无锁读取 | 真实可触发的数据竞争（UI 改代理设置 + 后台巡检是常态组合） | 改为 `atomic.Pointer` |
| projects.json 读-改-写全程无锁（且存在从未启用的死类型） | 并发请求丢失更新 | 加 `projectsMu` 覆盖 handler 完整事务；写盘改原子 temp+rename |
| 三处 `atomicWrite` 不 fsync | 掉电可能丢刚轮换的 refresh_token → 账号永久无法恢复；profiles 明文 API Key 全局可读 | 补 `tmp.Sync()`；profiles 收紧到 0700/0600 |
| 生图回退 URL 硬编码端口 17878 | 端口漂移后 chat/completions 生图结果 URL 全部失效 | 使用 `ActualPort` |
| `recordInspection` 整体覆盖账号状态 | 巡检耗时数分钟，期间的实时观测/凭据热更新被过期快照回滚 | 时间戳守卫，旧快照不落盘 |
| `cloneModelDefs` 无条件覆盖 `api_backend` | 上游上报的非 responses 后端被错误标记 | 仅缺失时补默认值 |

## 性能

- **代理热路径**：每个请求对最大 32MB 请求体重复做 3 次全量 JSON 解析（token 选择 / 粘性绑定 / 上游转发各一次），改为入口解析一次层层复用
- **settings 缓存**：`Get()` 位于每个本地代理请求路径上，此前每次都 MkdirAll+ReadFile+Unmarshal+Validate；增加 mtime+size 校验的内存缓存（settings.json 仅本进程单实例写入）

## 前端体验

- WS 内容事件按 `session_id` 过滤：快速切换会话时旧会话的流式回复不再串进新会话记录
- 补上 `toast.warn` 样式：注册"部分成功"结果此前显示成普通提示
- 工具卡片 toggle 监听器由每次流式更新追加一个改为只绑定一次
- 附件 blob 预览 URL 在移除/清空会话时释放（发送后的消息气泡仍安全引用）
- 号池"加载更多"在途连点不再跳页丢整页账号，加载失败自动回退页码

## 测试

- 顺带修复两处**测试自身**的数据竞争：`manager_test.go` 计数器非原子自增；`server/grokpool_test.go` 在后台巡检运行中替换全局 `http.DefaultTransport`（新增 `SetUpstreamURL` 测试注入点并等待巡检结束，同时避免单测访问生产环境）
- `gofmt` / `go vet` / `go test ./... -race -count=1` 全部通过