### PR TITLE
fix: 主题切换按钮样式统一 + hover 反转修复 + 暗色一键回亮色

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -543,7 +543,7 @@ const THEME_ICONS = {
 };
 const THEME_TITLES = {
   light: "主题：亮色（点击切换为暗色）",
-  dark: "主题：暗色（点击切换为跟随系统）",
+  dark: "主题：暗色（点击切换为亮色）",
   auto: "主题：跟随系统（点击切换为亮色）",
 };
 
@@ -567,11 +567,12 @@ function applyTheme() {
 }
 
 async function cycleTheme() {
-  const order = ["light", "dark", "auto"];
-  const next = order[(order.indexOf(themeSetting()) + 1) % order.length];
+  // 二态切换：按「当前实际渲染的主题」取反。旧的循环里夹着"跟随系统"，
+  // 系统本身是深色时从暗色点一下仍是深色，用户要点两下才能回到亮色。
+  const resolved = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
   state.settings = await api("/api/settings", {
     method: "PUT",
-    body: JSON.stringify({ ...(state.settings || {}), theme: next }),
+    body: JSON.stringify({ ...(state.settings || {}), theme: resolved }),
   });
   applyTheme();
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -41,7 +41,7 @@
         <button type="button" id="navAccountsBtn" class="btn" title="账号管理">账号</button>
         <button type="button" id="navImagineBtn" class="btn" title="生图">生图</button>
         <button type="button" id="navSettingsBtn" class="btn" title="设置">设置</button>
-        <button type="button" id="themeToggleBtn" class="navGithubBtn" title="主题：亮色（点击切换为暗色）" aria-label="切换主题"></button>
+        <button type="button" id="themeToggleBtn" class="themeToggleBtn" title="主题：亮色（点击切换为暗色）" aria-label="切换主题"></button>
         <a href="https://github.com/1parado/grok-build-switch" target="_blank" rel="noopener" class="navGithubBtn" title="GitHub 仓库" aria-label="GitHub">
           <svg viewBox="0 0 16 16" width="20" height="20" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
         </a>

--- a/ui/style.css
+++ b/ui/style.css
@@ -111,20 +111,50 @@ body {
   flex-wrap: wrap;
 }
 
+/* 头部右侧的透明图标位（GitHub 链接）。显式重置 UA 原生样式，
+   hover 用 --primary 与 .btn:hover 保持同一套语言（--accent 未在
+   :root 定义，此前引用会静默失效）。 */
 .navGithubBtn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 36px;
   height: 36px;
+  padding: 0;
+  border: none;
+  background: transparent;
   border-radius: var(--radius-sm, 8px);
   color: var(--text);
   text-decoration: none;
-  transition: background 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 .navGithubBtn:hover {
   background: var(--surface-2);
-  color: var(--accent);
+  color: var(--primary);
+}
+
+/* 主题切换按钮：与同排 .btn 完全一致的边框/底色/hover 语言，
+   仅以正方形图标形态出现。 */
+.themeToggleBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  min-height: 36px;
+  padding: 0;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  flex: 0 0 36px;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.themeToggleBtn:hover,
+.themeToggleBtn:focus-visible {
+  border-color: var(--primary);
+  color: var(--primary);
+  outline: none;
 }
 
 .brand {


### PR DESCRIPTION
## 问题（用户实测反馈）

1. **样式不符合整体 UI**：主题切换按钮复用了为 GitHub 链接设计的透明无边框样式 `navGithubBtn`，与同排一排带边框的 `.btn` 风格割裂
2. **hover 高亮方向反了**：鼠标移开时按钮"亮着"，悬停反而变成无高光——`<button>` 没有重置 UA 原生样式，静止时显示浏览器默认灰色凸起底；悬停时 CSS 才覆盖成扁平色。另外 hover 的 `color: var(--accent)` 引用的变量未在 `:root` 定义（只在聊天区作用域存在），一直静默失效
3. **暗色要点两下才回亮色**：切换循环是 亮→暗→跟随系统→亮，系统本身为深色时"跟随系统"仍渲染深色

## 修复

- 新增 `.themeToggleBtn`：与 `.btn` 完全同一套 边框 / 底色 / hover（主色蓝）语言的正方形图标按钮
- `.navGithubBtn`（GitHub 链接）显式重置原生样式，hover 从未定义的 `--accent` 改为 `--primary`
- 切换逻辑改为按**当前实际渲染主题**二态取反：亮 ↔ 暗一键直达；「跟随系统」仍作为初始值支持，点击一次即转为显式选择

## 验证（chromedp + 真实 Chrome 实测）

```
[rest-light] background=rgb(255,255,255) border=rgb(212,212,216)   ← 与 .btn 一致，非 UA 原生灰
[hover] border=rgb(37,99,235) color=rgb(37,99,235)                ← 主色高亮
[after-leave] border=rgb(212,212,216)                             ← 移开恢复
[dark-loaded] data-theme=dark
[after-one-click] data-theme=light (expect light)                 ← 暗色一键回亮色
RESULT: PASS
```

亮色静止 / 暗色静止 / hover 三张截图均已人工核对，按钮与同排 `.btn` 视觉一致。`node --check`、`go test .`（含 UI 布局测试）通过。