### PR TITLE
feat: 生图并行批量 + 画廊持久化 + 后台任务不随页面中断

### DIFF
--- a/internal/server/imagine_jobs.go
+++ b/internal/server/imagine_jobs.go
@@ -1,0 +1,365 @@
+package server
+
+// imagine_jobs.go —— 生图异步任务与画廊持久化。
+//
+// POST /api/imagine/generate 立即返回任务 ID，生成在后台并发执行：
+//   - 批量（count>1）时多张并行（引擎按账号排队，不会把同一账号并发打到上游）；
+//   - 前端切换视图 / 刷新页面均不影响后台任务，回来后经 /api/imagine/jobs 续接进度；
+//   - 每张成功图片带元数据 sidecar 落盘，画廊经 /api/imagine/gallery 刷新后仍在。
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	imagineMaxBatch      = 6               // 单批最多张数（抽卡上限）
+	imagineJobKeep       = 50              // 内存中保留的最近任务数
+	imagineJobTTL        = time.Hour       // 已结束任务的保留时长
+	imagineBatchTimeout  = 5 * time.Minute // 整批超时（含排队等待账号）
+	imagineGalleryLimit  = 200             // 画廊单次最多返回条数
+	imagineJobsPollAfter = 500 * time.Millisecond
+)
+
+// ImagineGalleryItem 是一张已落盘图片及其元数据。
+type ImagineGalleryItem struct {
+	URL       string    `json:"url"`
+	File      string    `json:"file"`
+	Prompt    string    `json:"prompt,omitempty"`
+	Model     string    `json:"model,omitempty"`
+	Aspect    string    `json:"aspect,omitempty"`
+	Account   string    `json:"account,omitempty"`
+	Width     int       `json:"width,omitempty"`
+	Height    int       `json:"height,omitempty"`
+	SavedTo   string    `json:"saved_to,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// imagineJob 是一次批量生图请求的完整生命周期。
+type imagineJob struct {
+	ID         string               `json:"id"`
+	Prompt     string               `json:"prompt"`
+	Model      string               `json:"model"`
+	Aspect     string               `json:"aspect"`
+	Count      int                  `json:"count"`
+	State      string               `json:"state"` // running | done | error
+	OKCount    int                  `json:"ok_count"`
+	FailCount  int                  `json:"fail_count"`
+	Images     []ImagineGalleryItem `json:"images"`
+	Error      string               `json:"error,omitempty"`
+	CreatedAt  time.Time            `json:"created_at"`
+	FinishedAt time.Time            `json:"finished_at,omitempty"`
+}
+
+// imagineJobList 是进程内的任务表（按创建时间倒序返回）。
+type imagineJobList struct {
+	mu   sync.Mutex
+	jobs []*imagineJob
+}
+
+func newImagineJobList() *imagineJobList {
+	return &imagineJobList{}
+}
+
+func (l *imagineJobList) add(job *imagineJob) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.jobs = append(l.jobs, job)
+	// 清理：超过保留数量或已结束超 TTL 的任务。
+	cutoff := time.Now().Add(-imagineJobTTL)
+	kept := l.jobs[:0]
+	for _, j := range l.jobs {
+		if j.State == "running" || j.FinishedAt.IsZero() || j.FinishedAt.After(cutoff) {
+			kept = append(kept, j)
+		}
+	}
+	if len(kept) > imagineJobKeep {
+		kept = kept[len(kept)-imagineJobKeep:]
+	}
+	l.jobs = kept
+}
+
+func (l *imagineJobList) snapshot() []imagineJob {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]imagineJob, 0, len(l.jobs))
+	for i := len(l.jobs) - 1; i >= 0; i-- {
+		out = append(out, *l.jobs[i])
+	}
+	return out
+}
+
+func (l *imagineJobList) get(id string) *imagineJob {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, j := range l.jobs {
+		if j.ID == id {
+			return j
+		}
+	}
+	return nil
+}
+
+// recordResult 记录一张图的成功/失败；返回任务当前快照。
+func (l *imagineJobList) recordResult(id string, item ImagineGalleryItem, ok bool, errMsg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, j := range l.jobs {
+		if j.ID != id {
+			continue
+		}
+		if ok {
+			j.OKCount++
+			j.Images = append(j.Images, item)
+		} else {
+			j.FailCount++
+			j.Error = errMsg
+		}
+		if j.OKCount+j.FailCount >= j.Count {
+			j.State = "done"
+			if j.OKCount == 0 {
+				j.State = "error"
+			}
+			j.FinishedAt = time.Now()
+		}
+		return
+	}
+}
+
+// ---- Server 侧接线 ----
+
+func (s *Server) jobList() *imagineJobList {
+	s.imagineMu.Lock()
+	defer s.imagineMu.Unlock()
+	if s.imagineJobs == nil {
+		s.imagineJobs = newImagineJobList()
+	}
+	return s.imagineJobs
+}
+
+// startImagineJob 校验并创建一个后台批量生图任务。
+// 返回 (job, httpStatus, err)：校验失败时 err 非空。
+func (s *Server) startImagineJob(prompt, model, aspect string, count int) (*imagineJob, int, error) {
+	if s.Imagine == nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("生图引擎未初始化")
+	}
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, http.StatusBadRequest, fmt.Errorf("prompt 不能为空")
+	}
+	if model == "" {
+		model = "grok-imagine-image"
+	}
+	if aspect == "" {
+		aspect = "1:1"
+	}
+	if count < 1 {
+		count = 1
+	}
+	if count > imagineMaxBatch {
+		count = imagineMaxBatch
+	}
+	// 热加载账号：新注册的账号无需重启即可用。
+	s.Imagine.ReloadAccounts()
+	if s.Imagine.AccountCount() == 0 {
+		return nil, http.StatusBadGateway, fmt.Errorf("未找到任何可用账号（registrar/cookies 为空或无效）")
+	}
+	job := &imagineJob{
+		ID:        "img-" + randomHex(6),
+		Prompt:    prompt,
+		Model:     model,
+		Aspect:    aspect,
+		Count:     count,
+		State:     "running",
+		CreatedAt: time.Now(),
+	}
+	s.jobList().add(job)
+	go s.runImagineJob(job)
+	return job, 0, nil
+}
+
+func (s *Server) runImagineJob(job *imagineJob) {
+	ctx, cancel := context.WithTimeout(context.Background(), imagineBatchTimeout)
+	defer cancel()
+	var wg sync.WaitGroup
+	for i := 0; i < job.Count; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res := s.Imagine.Generate(ctx, job.Prompt, job.Model, job.Aspect)
+			item := ImagineGalleryItem{
+				Prompt:    job.Prompt,
+				Model:     res.ModelName,
+				Aspect:    job.Aspect,
+				Account:   res.Account,
+				Width:     res.Width,
+				Height:    res.Height,
+				CreatedAt: time.Now().UTC(),
+			}
+			if res.OK && len(res.Images) > 0 {
+				file := filepath.Base(res.Images[0])
+				item.URL = res.Images[0]
+				item.File = file
+				// 与旧同步接口一致：额外复制一份到系统下载目录。
+				if dlPath, dlErr := saveImageToDownloads(filepath.Join(s.Imagine.outputsDir, file)); dlErr == nil {
+					item.SavedTo = dlPath
+				}
+				s.jobList().recordResult(job.ID, item, true, "")
+				return
+			}
+			errMsg := orEmpty(res.ErrMsg, "生图失败")
+			if res.ErrCode != "" {
+				errMsg = res.ErrCode + ": " + errMsg
+			}
+			s.jobList().recordResult(job.ID, item, false, errMsg)
+		}()
+	}
+	wg.Wait()
+}
+
+// handleImagineJobs GET /api/imagine/jobs —— 前端轮询任务进度。
+func (s *Server) handleImagineJobs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	writeJSON(w, map[string]any{"jobs": s.jobList().snapshot()})
+}
+
+// ---- 画廊持久化 ----
+
+func imagineImageExt(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".jpg", ".jpeg", ".png", ".webp":
+		return true
+	}
+	return false
+}
+
+// handleImagineGallery GET /api/imagine/gallery —— 扫描输出目录恢复画廊。
+func (s *Server) handleImagineGallery(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	if s.Imagine == nil {
+		writeJSON(w, map[string]any{"items": []ImagineGalleryItem{}})
+		return
+	}
+	writeJSON(w, map[string]any{"items": s.imagineGalleryItems()})
+}
+
+func (s *Server) imagineGalleryItems() []ImagineGalleryItem {
+	entries, err := os.ReadDir(s.Imagine.outputsDir)
+	if err != nil {
+		return []ImagineGalleryItem{}
+	}
+	type entryInfo struct {
+		name string
+		mod  time.Time
+		meta ImagineMeta
+	}
+	items := make([]entryInfo, 0, len(entries))
+	for _, ent := range entries {
+		if ent.IsDir() || !imagineImageExt(ent.Name()) {
+			continue
+		}
+		info, err := ent.Info()
+		if err != nil {
+			continue
+		}
+		entry := entryInfo{name: ent.Name(), mod: info.ModTime()}
+		if raw, err := os.ReadFile(filepath.Join(s.Imagine.outputsDir, ent.Name()+".json")); err == nil {
+			_ = json.Unmarshal(raw, &entry.meta)
+		}
+		items = append(items, entry)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].mod.After(items[j].mod) })
+	if len(items) > imagineGalleryLimit {
+		items = items[:imagineGalleryLimit]
+	}
+	out := make([]ImagineGalleryItem, 0, len(items))
+	for _, it := range items {
+		item := ImagineGalleryItem{
+			URL:       "/" + imagineOutputURLPath + "/" + it.name,
+			File:      it.name,
+			Prompt:    it.meta.Prompt,
+			Model:     it.meta.Model,
+			Aspect:    it.meta.Aspect,
+			Account:   it.meta.Account,
+			Width:     it.meta.Width,
+			Height:    it.meta.Height,
+			CreatedAt: it.meta.CreatedAt,
+		}
+		if item.CreatedAt.IsZero() {
+			item.CreatedAt = it.mod
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+// handleImagineGalleryClear POST /api/imagine/gallery/clear —— 删除全部输出。
+func (s *Server) handleImagineGalleryClear(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+		return
+	}
+	if s.Imagine == nil {
+		writeError(w, fmt.Errorf("生图引擎未初始化"), http.StatusInternalServerError)
+		return
+	}
+	entries, err := os.ReadDir(s.Imagine.outputsDir)
+	if err == nil {
+		for _, ent := range entries {
+			if ent.IsDir() {
+				continue
+			}
+			_ = os.Remove(filepath.Join(s.Imagine.outputsDir, ent.Name()))
+		}
+	}
+	writeJSON(w, map[string]bool{"ok": true})
+}
+
+// handleImagineGalleryDelete POST /api/imagine/gallery/delete —— 删除单张（含 sidecar）。
+func (s *Server) handleImagineGalleryDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+		return
+	}
+	if s.Imagine == nil {
+		writeError(w, fmt.Errorf("生图引擎未初始化"), http.StatusInternalServerError)
+		return
+	}
+	var req struct {
+		File string `json:"file"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<10)).Decode(&req); err != nil {
+		writeError(w, err, http.StatusBadRequest)
+		return
+	}
+	name := filepath.Base(strings.TrimSpace(req.File))
+	if name == "" || name == "." || !imagineImageExt(name) {
+		writeError(w, fmt.Errorf("无效的文件名"), http.StatusBadRequest)
+		return
+	}
+	target := filepath.Join(s.Imagine.outputsDir, name)
+	if _, err := os.Stat(target); err != nil {
+		writeError(w, fmt.Errorf("文件不存在"), http.StatusNotFound)
+		return
+	}
+	if err := os.Remove(target); err != nil {
+		writeError(w, err, http.StatusInternalServerError)
+		return
+	}
+	_ = os.Remove(target + ".json")
+	writeJSON(w, map[string]bool{"ok": true})
+}

--- a/internal/server/imagine_jobs_test.go
+++ b/internal/server/imagine_jobs_test.go
@@ -1,0 +1,261 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func imagineWriteCookie(t *testing.T, dir, name string) {
+	t.Helper()
+	cookieDir := filepath.Join(dir, "registrar", "cookies")
+	if err := os.MkdirAll(cookieDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	payload := fmt.Sprintf(`{"cookies":[{"name":"sso","value":"tok-%s","domain":".grok.com"}]}`, name)
+	if err := os.WriteFile(filepath.Join(cookieDir, name+".json"), []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// 画廊持久化：写入图片 + sidecar 后，刷新（重新扫描）仍能恢复元数据；
+// 单张删除与整库清空均只作用于输出目录。
+func TestImagineGalleryPersistence(t *testing.T) {
+	dir := t.TempDir()
+	s := &Server{Imagine: NewImagineEngine(dir)}
+
+	if err := os.WriteFile(filepath.Join(s.Imagine.outputsDir, "a.jpg"), []byte("jpg-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := ImagineMeta{Prompt: "一只橘猫", Model: "grok-imagine-image", Aspect: "1:1", Account: "acct", Width: 1024, Height: 1024, CreatedAt: time.Now().UTC()}
+	raw, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(s.Imagine.outputsDir, "a.jpg.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// 无关文件不应出现在画廊里。
+	if err := os.WriteFile(filepath.Join(s.Imagine.outputsDir, "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	s.handleImagineGallery(rec, httptest.NewRequest(http.MethodGet, "/api/imagine/gallery", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gallery status = %d", rec.Code)
+	}
+	var out struct {
+		Items []ImagineGalleryItem `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Items) != 1 {
+		t.Fatalf("want 1 item, got %d: %#v", len(out.Items), out.Items)
+	}
+	item := out.Items[0]
+	if item.File != "a.jpg" || item.URL != "/imagine-output/a.jpg" {
+		t.Fatalf("item = %#v", item)
+	}
+	if item.Prompt != "一只橘猫" || item.Model != "grok-imagine-image" || item.Account != "acct" || item.Width != 1024 {
+		t.Fatalf("metadata not restored: %#v", item)
+	}
+
+	// 单张删除。
+	rec = httptest.NewRecorder()
+	s.handleImagineGalleryDelete(rec, httptest.NewRequest(http.MethodPost, "/api/imagine/gallery/delete", bytes.NewBufferString(`{"file":"a.jpg"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(s.Imagine.outputsDir, "a.jpg")); !os.IsNotExist(err) {
+		t.Fatalf("image file should be removed, err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(s.Imagine.outputsDir, "a.jpg.json")); !os.IsNotExist(err) {
+		t.Fatalf("sidecar should be removed, err = %v", err)
+	}
+
+	// 路径穿越被中和：Base() 剥掉目录后目标不存在 → 404，绝不越出输出目录。
+	rec = httptest.NewRecorder()
+	s.handleImagineGalleryDelete(rec, httptest.NewRequest(http.MethodPost, "/api/imagine/gallery/delete", bytes.NewBufferString(`{"file":"../escape.jpg"}`)))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("traversal want 404, got %d", rec.Code)
+	}
+	// 非图片扩展名直接拒绝。
+	rec = httptest.NewRecorder()
+	s.handleImagineGalleryDelete(rec, httptest.NewRequest(http.MethodPost, "/api/imagine/gallery/delete", bytes.NewBufferString(`{"file":"../../etc/passwd"}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-image want 400, got %d", rec.Code)
+	}
+
+	// 清空。
+	if err := os.WriteFile(filepath.Join(s.Imagine.outputsDir, "b.png"), []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rec = httptest.NewRecorder()
+	s.handleImagineGalleryClear(rec, httptest.NewRequest(http.MethodPost, "/api/imagine/gallery/clear", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear status = %d", rec.Code)
+	}
+	entries, err := os.ReadDir(s.Imagine.outputsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("outputs dir should be empty, got %d entries", len(entries))
+	}
+}
+
+// 异步任务：提交后立即返回 running；引擎失败（假账号连不上上游）后任务
+// 进入 error 终态，fail_count 与 count 一致。
+func TestImagineJobLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	imagineWriteCookie(t, dir, "acct-a")
+	s := &Server{Imagine: NewImagineEngine(dir)}
+
+	body := `{"prompt":"a red cat","model":"grok-imagine-image","aspect_ratio":"1:1","count":2}`
+	rec := httptest.NewRecorder()
+	s.handleImagineGenerate(rec, httptest.NewRequest(http.MethodPost, "/api/imagine/generate", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("generate status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		OK  bool       `json:"ok"`
+		Job imagineJob `json:"job"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if !created.OK || created.Job.ID == "" || created.Job.State != "running" || created.Job.Count != 2 {
+		t.Fatalf("job = %#v", created.Job)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	var final *imagineJob
+	for time.Now().Before(deadline) {
+		rec := httptest.NewRecorder()
+		s.handleImagineJobs(rec, httptest.NewRequest(http.MethodGet, "/api/imagine/jobs", nil))
+		var out struct {
+			Jobs []imagineJob `json:"jobs"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Jobs) == 1 && out.Jobs[0].State != "running" {
+			final = &out.Jobs[0]
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if final == nil {
+		t.Fatal("job did not finish in time")
+	}
+	if final.State != "error" || final.FailCount != 2 || final.OKCount != 0 {
+		t.Fatalf("final job = %#v", final)
+	}
+	if final.Error == "" {
+		t.Fatal("expected error message")
+	}
+}
+
+// count 超上限被钳制到 imagineMaxBatch。
+func TestImagineJobCountClamped(t *testing.T) {
+	dir := t.TempDir()
+	imagineWriteCookie(t, dir, "acct-a")
+	s := &Server{Imagine: NewImagineEngine(dir)}
+	job, _, err := s.startImagineJob("p", "", "", 99)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.Count != imagineMaxBatch {
+		t.Fatalf("count = %d, want %d", job.Count, imagineMaxBatch)
+	}
+}
+
+// 引擎：busy 账号被跳过；exhausted 超过 TTL 自动恢复；热重载保留统计。
+func TestImagineEngineParallelAndRecovery(t *testing.T) {
+	dir := t.TempDir()
+	imagineWriteCookie(t, dir, "acct-a")
+	eng := NewImagineEngine(dir)
+	if eng.AccountCount() != 1 {
+		t.Fatalf("accounts = %d", eng.AccountCount())
+	}
+	acc := eng.accounts[0]
+
+	// busy：waitForAccount 在 ctx 超时前不应返回该账号。
+	acc.mu.Lock()
+	acc.busy = true
+	acc.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	if got := eng.waitForAccount(ctx); got != nil {
+		t.Fatal("busy account should not be returned")
+	}
+	cancel()
+	acc.mu.Lock()
+	acc.busy = false
+	acc.mu.Unlock()
+	if got := eng.waitForAccount(context.Background()); got != acc {
+		t.Fatalf("want account after busy cleared, got %v", got)
+	}
+
+	// exhausted + TTL 过期 → 自动恢复。
+	acc.mu.Lock()
+	acc.exhausted = true
+	acc.exhaustedAt = time.Now().Add(-2 * imagineExhaustedTTL)
+	acc.mu.Unlock()
+	eng.mu.Lock()
+	got := eng.nextLocked()
+	eng.mu.Unlock()
+	if got != acc {
+		t.Fatal("exhausted account should recover after TTL")
+	}
+	acc.mu.Lock()
+	recovered := !acc.exhausted
+	acc.mu.Unlock()
+	if !recovered {
+		t.Fatal("exhausted flag should be cleared")
+	}
+
+	// exhausted 未到 TTL → 不可用。
+	acc.mu.Lock()
+	acc.exhausted = true
+	acc.exhaustedAt = time.Now()
+	acc.mu.Unlock()
+	eng.mu.Lock()
+	got = eng.nextLocked()
+	eng.mu.Unlock()
+	if got != nil {
+		t.Fatal("freshly exhausted account should be skipped")
+	}
+
+	// 热重载：新增账号可见，原账号统计保留。
+	acc.mu.Lock()
+	acc.successCount = 5
+	acc.mu.Unlock()
+	imagineWriteCookie(t, dir, "acct-b")
+	eng.ReloadAccounts()
+	if eng.AccountCount() != 2 {
+		t.Fatalf("after reload accounts = %d", eng.AccountCount())
+	}
+	eng.mu.Lock()
+	var preserved *imagineAccount
+	for _, a := range eng.accounts {
+		if a.id == "acct-a" {
+			preserved = a
+		}
+	}
+	eng.mu.Unlock()
+	if preserved == nil {
+		t.Fatal("acct-a missing after reload")
+	}
+	preserved.mu.Lock()
+	success := preserved.successCount
+	preserved.mu.Unlock()
+	if success != 5 {
+		t.Fatalf("stats not preserved: successCount = %d", success)
+	}
+}

--- a/internal/server/imagine_local.go
+++ b/internal/server/imagine_local.go
@@ -47,12 +47,17 @@ type imagineAccount struct {
 	file         string
 	cookies      map[string]string // name -> value（仅 grok.com/x.ai 相关）
 	mu           sync.Mutex
-	exhausted    bool
+	busy         bool      // 正在执行一次生图（并行任务跳过，避免触发上游并发限制）
+	exhausted    bool      // 额度耗尽；exhaustedAt 超过 TTL 后自动恢复重试
+	exhaustedAt  time.Time // 零值表示非耗尽状态
 	successCount int
 	failCount    int
 	lastError    string
 	lastUsed     int64
 }
+
+// imagineExhaustedTTL 之后自动重新尝试已耗尽的账号（额度通常按日/按小时恢复）。
+const imagineExhaustedTTL = time.Hour
 
 // ImagineEngine 管理账号池并负责单次生图。
 type ImagineEngine struct {
@@ -98,6 +103,31 @@ func (e *ImagineEngine) AccountCount() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return len(e.accounts)
+}
+
+// ReloadAccounts 重新扫描 cookie 目录：新注册的账号无需重启即可参与生图。
+// 已知账号的成功/失败统计与耗尽状态会被保留。
+func (e *ImagineEngine) ReloadAccounts() {
+	fresh := &ImagineEngine{dataDir: e.dataDir, outputsDir: e.outputsDir}
+	fresh.loadAccounts()
+	if len(fresh.accounts) == 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	known := make(map[string]*imagineAccount, len(e.accounts))
+	for _, acc := range e.accounts {
+		known[acc.id] = acc
+	}
+	merged := make([]*imagineAccount, 0, len(fresh.accounts))
+	for _, acc := range fresh.accounts {
+		if old, ok := known[acc.id]; ok {
+			merged = append(merged, old)
+			continue
+		}
+		merged = append(merged, acc)
+	}
+	e.accounts = merged
 }
 
 // loadAccounts 扫描 <dataDir>/registrar/cookies/*.json。
@@ -146,25 +176,67 @@ func (e *ImagineEngine) loadAccounts() {
 	fmt.Fprintf(os.Stderr, "[imagine] loaded %d accounts from %s\n", len(e.accounts), cookieDir)
 }
 
-// next 返回一个未耗尽的账号并推进游标；全部耗尽返回 nil。
-func (e *ImagineEngine) next() *imagineAccount {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+// nextLocked 返回一个可立即使用的账号并推进游标；找不到返回 nil。
+// 跳过 busy（正在生图）的账号；exhausted 账号超过 TTL 后自动恢复。
+// 调用方必须持有 e.mu。
+func (e *ImagineEngine) nextLocked() *imagineAccount {
 	if len(e.accounts) == 0 {
 		return nil
 	}
+	now := time.Now()
 	start := e.index
 	for {
 		acc := e.accounts[e.index]
 		e.index = (e.index + 1) % len(e.accounts)
-		if !acc.exhausted {
+		eligible := false
+		acc.mu.Lock()
+		if acc.exhausted && !acc.exhaustedAt.IsZero() && now.Sub(acc.exhaustedAt) > imagineExhaustedTTL {
+			acc.exhausted = false
+			acc.exhaustedAt = time.Time{}
+		}
+		if !acc.exhausted && !acc.busy {
+			eligible = true
+		}
+		acc.mu.Unlock()
+		if eligible {
 			return acc
 		}
 		if e.index == start {
-			break
+			return nil
 		}
 	}
-	return nil
+}
+
+// waitForAccount 等待一个空闲账号：批量生图的并发数可能超过账号数，
+// 多出的任务在此排队，而不是误报「全部耗尽」。若所有账号都因额度耗尽
+// （且没有任务占用）则立即返回 nil。
+func (e *ImagineEngine) waitForAccount(ctx context.Context) *imagineAccount {
+	for {
+		e.mu.Lock()
+		acc := e.nextLocked()
+		e.mu.Unlock()
+		if acc != nil {
+			return acc
+		}
+		e.mu.Lock()
+		idleUnavailable := true
+		for _, a := range e.accounts {
+			a.mu.Lock()
+			if a.busy && !a.exhausted {
+				idleUnavailable = false // 还有任务在跑，等它释放
+			}
+			a.mu.Unlock()
+		}
+		e.mu.Unlock()
+		if idleUnavailable {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(400 * time.Millisecond):
+		}
+	}
 }
 
 func (e *ImagineEngine) markResult(acc *imagineAccount, ok bool, code, msg string) {
@@ -179,6 +251,7 @@ func (e *ImagineEngine) markResult(acc *imagineAccount, ok bool, code, msg strin
 		switch code {
 		case "usage_pool_exhausted", "usage_limit_reached", "concurrency_limit":
 			acc.exhausted = true
+			acc.exhaustedAt = time.Now()
 			fmt.Fprintf(os.Stderr, "[imagine] account %s marked exhausted: %s\n", acc.id, code)
 		}
 	}
@@ -243,20 +316,33 @@ type ImagineResult struct {
 	SavedTo   string   `json:"saved_to,omitempty"` // 额外复制到下载目录的路径
 }
 
-// Generate 使用账号轮询生成图片。prompt 为提示词，model 为 grok-imagine-image/quality，
-// aspectRatio 形如 "1:1"/"16:9"/"9:16"/"4:3"。
+// Generate 使用账号轮询生成一张图片。prompt 为提示词，model 为
+// grok-imagine-image/quality，aspectRatio 形如 "1:1"/"16:9"/"9:16"/"4:3"。
+// 可安全并发调用：并发数超过账号数时，多出的调用在 waitForAccount 排队，
+// 不会把同一账号同时打到上游（避免触发并发限制误标耗尽）。
 func (e *ImagineEngine) Generate(ctx context.Context, prompt, model, aspectRatio string) ImagineResult {
-	if len(e.accounts) == 0 {
+	e.mu.Lock()
+	total := len(e.accounts)
+	e.mu.Unlock()
+	if total == 0 {
 		return ImagineResult{OK: false, ErrCode: "no_accounts", ErrMsg: "未找到任何可用账号（registrar/cookies 为空或无效）"}
 	}
-	attempts := len(e.accounts)
-	for i := 0; i < attempts; i++ {
-		acc := e.next()
+	for attempt := 0; attempt < total; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return ImagineResult{OK: false, ErrCode: "canceled", ErrMsg: "生图已取消或超时"}
+		}
+		acc := e.waitForAccount(ctx)
 		if acc == nil {
 			return ImagineResult{OK: false, ErrCode: "all_exhausted", ErrMsg: "所有账号均已耗尽额度"}
 		}
+		acc.mu.Lock()
+		acc.busy = true
+		acc.mu.Unlock()
 		res := e.generateOne(ctx, acc, prompt, model, aspectRatio)
 		e.markResult(acc, res.OK, res.ErrCode, res.ErrMsg)
+		acc.mu.Lock()
+		acc.busy = false
+		acc.mu.Unlock()
 		if res.OK {
 			return res
 		}
@@ -323,6 +409,7 @@ func (e *ImagineEngine) generateOne(ctx context.Context, acc *imagineAccount, pr
 	if err := os.WriteFile(outPath, keep.buf, 0o644); err != nil {
 		return ImagineResult{OK: false, ErrCode: "write_error", ErrMsg: err.Error(), Account: acc.id}
 	}
+	writeImagineSidecar(outPath, prompt, model, aspectRatio, inner, acc.id)
 	saved = append(saved, "/"+imagineOutputURLPath+"/"+filename)
 	return ImagineResult{
 		OK:        true,
@@ -489,6 +576,36 @@ func imagineProps(model, aspectRatio string, isInitial bool) map[string]any {
 }
 
 // ---- 小工具 ----
+
+// ImagineMeta 是随图片一起落盘的元数据 sidecar（<图片文件名>.json），
+// 画廊刷新后据此恢复提示词、模型等信息。
+type ImagineMeta struct {
+	Prompt    string    `json:"prompt"`
+	Model     string    `json:"model,omitempty"`
+	Aspect    string    `json:"aspect,omitempty"`
+	Account   string    `json:"account,omitempty"`
+	Width     int       `json:"width,omitempty"`
+	Height    int       `json:"height,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func writeImagineSidecar(imagePath, prompt, model, aspect string, inner imagineGenInner, accountID string) {
+	modelName := orEmpty(inner.ModelName, model)
+	meta := ImagineMeta{
+		Prompt:    prompt,
+		Model:     modelName,
+		Aspect:    aspect,
+		Account:   accountID,
+		Width:     inner.Width,
+		Height:    inner.Height,
+		CreatedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(imagePath+".json", data, 0o644)
+}
 
 type imagineEnvelope struct {
 	Type      string      `json:"type"`

--- a/internal/server/imagine_local_test.go
+++ b/internal/server/imagine_local_test.go
@@ -45,7 +45,11 @@ func TestImagineProxyConnectivity(t *testing.T) {
 
 // TestImagineGenerate 调用带账号轮询的 Generate：自动跳过被限流的账号，
 // 验证 Go WS 协议端到端可用。
+// 活体测试会真实调用 grok.com 并消耗账号额度，仅在显式开启时运行。
 func TestImagineGenerate(t *testing.T) {
+	if os.Getenv("GROK_SWITCH_LIVE_IMAGINE") == "" {
+		t.Skip("live test consumes real quota; set GROK_SWITCH_LIVE_IMAGINE=1 to enable")
+	}
 	dataDir := imagineTestDataDir(t)
 	eng := NewImagineEngine(dataDir)
 	if eng.AccountCount() == 0 {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,6 +71,9 @@ type Server struct {
 
 	// Imagine 是基于 grok.com 网页端 /imagine 协议的本地生图引擎（走 registrar 账号 Cookie 轮询）。
 	Imagine *ImagineEngine
+
+	imagineMu   sync.Mutex
+	imagineJobs *imagineJobList
 }
 
 func (s *Server) SetOnChanged(fn func()) {
@@ -279,6 +282,10 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/imagine/v1", s.handleImagineProxy)
 	mux.HandleFunc("/imagine/v1/", s.handleImagineProxy)
 	mux.HandleFunc("/api/imagine/generate", s.handleImagineGenerate)
+	mux.HandleFunc("/api/imagine/jobs", s.handleImagineJobs)
+	mux.HandleFunc("/api/imagine/gallery", s.handleImagineGallery)
+	mux.HandleFunc("/api/imagine/gallery/clear", s.handleImagineGalleryClear)
+	mux.HandleFunc("/api/imagine/gallery/delete", s.handleImagineGalleryDelete)
 	mux.HandleFunc("/imagine-output/", s.handleImagineOutput)
 	mux.HandleFunc("/", s.handleStatic)
 }
@@ -1097,66 +1104,42 @@ func uniqueStrings(in []string) []string {
 }
 
 // handleImagineGenerate 接收 {prompt, model, aspect_ratio}，用本地账号池轮询生图。
+// handleImagineGenerate POST /api/imagine/generate —— 创建异步生图任务并立即返回。
+// 生成在后台并发执行（count 张并行，引擎按账号排队），前端经 /api/imagine/jobs
+// 轮询进度；切换视图或刷新页面不影响后台任务。
 func (s *Server) handleImagineGenerate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		methodNotAllowed(w)
-		return
-	}
-	if s.Imagine == nil {
-		writeError(w, fmt.Errorf("生图引擎未初始化"), http.StatusInternalServerError)
 		return
 	}
 	var req struct {
 		Prompt      string `json:"prompt"`
 		Model       string `json:"model"`
 		AspectRatio string `json:"aspect_ratio"`
+		Count       int    `json:"count"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
 		writeError(w, err, http.StatusBadRequest)
 		return
 	}
-	prompt := strings.TrimSpace(req.Prompt)
-	if prompt == "" {
-		writeError(w, fmt.Errorf("prompt 不能为空"), http.StatusBadRequest)
-		return
-	}
-	model := req.Model
-	if model == "" {
-		model = "grok-imagine-image"
-	}
-	aspect := req.AspectRatio
-	if aspect == "" {
-		aspect = "1:1"
-	}
-	ctx, cancel := context.WithTimeout(r.Context(), 120*time.Second)
-	defer cancel()
-	res := s.Imagine.Generate(ctx, prompt, model, aspect)
-	if !res.OK {
-		writeJSONStatus(w, res, http.StatusBadGateway)
-		return
-	}
-	// 额外复制一份到系统下载目录，方便用户直接使用。
-	savedPath := ""
-	if len(res.Images) > 0 {
-		if dlPath, dlErr := saveImageToDownloads(filepath.Join(s.Imagine.outputsDir, path.Base(res.Images[0]))); dlErr == nil {
-			savedPath = dlPath
-		} else {
-			fmt.Fprintf(os.Stderr, "grok_switch: save image to downloads: %v\n", dlErr)
+	job, status, err := s.startImagineJob(req.Prompt, req.Model, req.AspectRatio, req.Count)
+	if err != nil {
+		code := "no_accounts"
+		switch status {
+		case http.StatusBadRequest:
+			code = "invalid_prompt"
+		case http.StatusInternalServerError:
+			code = "engine_unavailable"
 		}
-	}
-	if savedPath != "" {
-		writeJSON(w, map[string]any{
-			"ok":         true,
-			"images":     res.Images,
-			"model_name": res.ModelName,
-			"width":      res.Width,
-			"height":     res.Height,
-			"account":    res.Account,
-			"saved_to":   savedPath,
-		})
+		writeJSONStatus(w, map[string]any{
+			"ok":       false,
+			"err_code": code,
+			"err_msg":  err.Error(),
+			"error":    err.Error(),
+		}, status)
 		return
 	}
-	writeJSON(w, res)
+	writeJSON(w, map[string]any{"ok": true, "job": job})
 }
 
 // handleImagineOutput 提供生成的图片文件（位于 <DataDir>/imagine_outputs/）。
@@ -1175,13 +1158,9 @@ func (s *Server) handleImagineOutput(w http.ResponseWriter, r *http.Request) {
 	if ct := mime.TypeByExtension(path.Ext(full)); ct != "" {
 		w.Header().Set("Content-Type", ct)
 	}
-	data, err := os.ReadFile(full)
-	if err != nil {
-		http.NotFound(w, r)
-		return
-	}
 	w.Header().Set("Cache-Control", "public, max-age=3600")
-	w.Write(data)
+	// ServeFile 支持条件请求与 Range，避免每次全量读入内存。
+	http.ServeFile(w, r, full)
 }
 
 func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -972,7 +972,7 @@ function showView(name) {
     loadSkills().catch((err) => toast(err.message, "error"));
   }
   if (name === "imagine") {
-    refreshImagineStatus().catch(() => {});
+    loadImagineView().catch(() => {});
   }
   if (name === "chat") {
     openAgentView().catch((err) => toast(err.message, "error"));
@@ -7459,6 +7459,24 @@ document.addEventListener("click", (event) => {
 });
 
 // ===== Imagine (生图) =====
+
+// imaginePoll：全局任务轮询状态。轮询独立于视图——切换页面、刷新后
+// 重新进入生图页都会续接后台任务进度，生成不会因此中断。
+const imaginePoll = {
+  timer: null,
+  seen: new Map(), // job.id -> { ok, state }
+};
+
+// 进入生图页：引擎状态 + 服务端画廊 + 续接后台任务。
+async function loadImagineView() {
+  refreshImagineStatus().catch(() => {});
+  await refreshImagineGallery().catch(() => {});
+  try {
+    await pollImagineJobsOnce();
+  } catch {}
+  startImaginePolling();
+}
+
 async function refreshImagineStatus() {
   const statusEl = $("imagineStatus");
   const emptyEl = $("imagineEmpty");
@@ -7467,11 +7485,11 @@ async function refreshImagineStatus() {
     const ready = !!(data && data.imagine_ready);
     const count = (data && Number(data.imagine_accounts)) || 0;
     if (statusEl) {
-      statusEl.hidden = false;
-      statusEl.className = "muted tiny imagineStatus" + (ready ? " ok" : "");
-      statusEl.textContent = ready
+      statusEl.dataset.engine = ready
         ? `生图引擎就绪 · 可用账号 ${count} 个`
         : "生图引擎未就绪：registrar/cookies 中未找到可用账号";
+      statusEl.dataset.ready = ready ? "1" : "0";
+      updateImagineStatusLine();
     }
   } catch {
     if (statusEl) {
@@ -7486,12 +7504,32 @@ async function refreshImagineStatus() {
   }
 }
 
+function updateImagineStatusLine(activeJobs) {
+  const statusEl = $("imagineStatus");
+  if (!statusEl) return;
+  const engine = statusEl.dataset.engine || "";
+  const ready = statusEl.dataset.ready === "1";
+  if (Array.isArray(activeJobs) && activeJobs.length) {
+    const pending = activeJobs.reduce(
+      (sum, j) => sum + Math.max(0, (j.count || 0) - (j.ok_count || 0) - (j.fail_count || 0)),
+      0,
+    );
+    statusEl.hidden = false;
+    statusEl.className = "muted tiny imagineStatus busy";
+    statusEl.textContent = `${engine ? engine + " · " : ""}后台生成中 ${activeJobs.length} 批 · 待出图 ${pending} 张（切换页面不受影响，可继续提交新任务）`;
+    return;
+  }
+  if (!engine) return;
+  statusEl.hidden = false;
+  statusEl.className = "muted tiny imagineStatus" + (ready ? " ok" : "");
+  statusEl.textContent = engine;
+}
+
 async function generateImagine() {
   const promptEl = $("imaginePrompt");
   const modelEl = $("imagineModel");
   const ratioEl = $("imagineRatio");
-  const statusEl = $("imagineStatus");
-  const btn = $("imagineGenerateBtn");
+  const countEl = $("imagineCount");
   const prompt = (promptEl && promptEl.value || "").trim();
   if (!prompt) {
     toast("请先输入提示词", "error");
@@ -7500,82 +7538,178 @@ async function generateImagine() {
   }
   const model = modelEl ? modelEl.value : "grok-imagine-image";
   const ratio = ratioEl ? ratioEl.value : "1:1";
-
-  if (statusEl) {
-    statusEl.hidden = false;
-    statusEl.className = "muted tiny imagineStatus busy";
-    statusEl.textContent = "正在生成，自动轮换账号中…";
-  }
-  setBusy(btn, true, "生成中…");
+  const count = Math.min(6, Math.max(1, Number(countEl && countEl.value) || 1));
   try {
-    const res = await fetch("/api/imagine/generate", {
+    const res = await api("/api/imagine/generate", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt, model, aspect_ratio: ratio }),
+      body: JSON.stringify({ prompt, model, aspect_ratio: ratio, count }),
     });
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok || !data.ok) {
-      const msg = data.err_msg || data.error || res.statusText || "生图失败";
-      throw new Error(msg);
-    }
-    const images = Array.isArray(data.images) ? data.images : [];
-    if (images.length === 0) {
-      throw new Error("未返回任何图片");
-    }
-    renderImagineImages(images, data);
-    if (statusEl) {
-      statusEl.hidden = false;
-      statusEl.className = "muted tiny imagineStatus ok";
-      const meta = [data.model_name, data.width && data.height ? `${data.width}x${data.height}` : null, data.account ? `账号 ${data.account}` : null]
-        .filter(Boolean).join(" · ");
-      statusEl.textContent = `生成成功（${images.length} 张）${meta ? " · " + meta : ""}`;
-    }
-    toast(`生成成功，${images.length} 张图片`, "success");
+    if (!res.ok || !res.job) throw new Error(res.error || res.err_msg || "任务创建失败");
+    imaginePoll.seen.set(res.job.id, { ok: 0, state: "running" });
+    toast(count > 1 ? `已提交 ${count} 张，后台并行生成中…` : "已提交，后台生成中…", "success");
+    updateImagineStatusLine([res.job]);
+    startImaginePolling();
   } catch (err) {
-    if (statusEl) {
-      statusEl.hidden = false;
-      statusEl.className = "muted tiny imagineStatus error";
-      statusEl.textContent = "生成失败：" + (err.message || err);
-    }
-    toast("生图失败：" + (err.message || err), "error");
-  } finally {
-    setBusy(btn, false);
+    toast("提交失败：" + (err.message || err), "error");
   }
 }
 
-function renderImagineImages(images, data) {
+// 画廊从服务端加载（imagine_outputs 目录扫描 + 元数据 sidecar），
+// 刷新页面后依然完整恢复。
+async function refreshImagineGallery() {
+  const data = await api("/api/imagine/gallery?limit=120").catch(() => ({ items: [] }));
+  renderImagineGallery(Array.isArray(data.items) ? data.items : []);
+}
+
+function renderImagineGallery(items) {
   const gallery = $("imagineGallery");
   const emptyEl = $("imagineEmpty");
   if (!gallery) return;
+  gallery.innerHTML = "";
   const frag = document.createDocumentFragment();
-  for (const url of images) {
-    const card = document.createElement("div");
-    card.className = "imagineCard";
-
-    const img = document.createElement("img");
-    img.src = url;
-    img.alt = (data && data.model_name ? data.model_name + " " : "") + "生成图片";
-    img.loading = "lazy";
-    card.appendChild(img);
-
-    const actions = document.createElement("div");
-    actions.className = "imagineCardActions";
-    const dl = document.createElement("button");
-    dl.type = "button";
-    dl.className = "btn sm";
-    dl.textContent = "下载";
-    dl.onclick = (e) => {
-      e.stopPropagation();
-      downloadImagine(url);
-    };
-    actions.appendChild(dl);
-    card.appendChild(actions);
-
-    card.onclick = () => openImagineLightbox(url);
-    frag.appendChild(card);
-  }
+  for (const item of items) frag.appendChild(buildImagineCard(item));
   gallery.appendChild(frag);
-  if (emptyEl) emptyEl.hidden = true;
+  if (emptyEl) emptyEl.hidden = items.length > 0;
+}
+
+function buildImagineCard(item) {
+  const card = document.createElement("div");
+  card.className = "imagineCard";
+  if (item.prompt) card.title = item.prompt;
+
+  const img = document.createElement("img");
+  img.src = item.url;
+  img.alt = (item.prompt || "生成图片").slice(0, 60);
+  img.loading = "lazy";
+  card.appendChild(img);
+
+  const actions = document.createElement("div");
+  actions.className = "imagineCardActions";
+  const dl = document.createElement("button");
+  dl.type = "button";
+  dl.className = "btn sm";
+  dl.textContent = "下载";
+  dl.onclick = (e) => {
+    e.stopPropagation();
+    downloadImagine(item.url);
+  };
+  actions.appendChild(dl);
+  const del = document.createElement("button");
+  del.type = "button";
+  del.className = "btn sm";
+  del.textContent = "删除";
+  del.onclick = async (e) => {
+    e.stopPropagation();
+    try {
+      await api("/api/imagine/gallery/delete", { method: "POST", body: JSON.stringify({ file: item.file }) });
+    } catch (err) {
+      toast("删除失败：" + (err.message || err), "error");
+      return;
+    }
+    card.remove();
+    const gallery = $("imagineGallery");
+    const emptyEl = $("imagineEmpty");
+    if (emptyEl && gallery && gallery.children.length === 0) emptyEl.hidden = false;
+  };
+  actions.appendChild(del);
+  card.appendChild(actions);
+
+  card.onclick = () => openImagineLightbox(item);
+  return card;
+}
+
+// 进行中任务条：每张待出图占一格（旋转指示），失败占位标红。
+function renderImagineActive(jobs) {
+  const strip = $("imagineActive");
+  if (!strip) return;
+  const running = jobs.filter((j) => j.state === "running");
+  strip.hidden = running.length === 0;
+  strip.innerHTML = "";
+  for (const job of running) {
+    const pending = Math.max(0, (job.count || 0) - (job.ok_count || 0) - (job.fail_count || 0));
+    for (let i = 0; i < pending; i++) {
+      const card = document.createElement("div");
+      card.className = "imagineCard imaginePending";
+      card.title = job.prompt || "";
+      const spinner = document.createElement("div");
+      spinner.className = "imagineSpinner";
+      card.appendChild(spinner);
+      const label = document.createElement("span");
+      label.textContent = "生成中…";
+      card.appendChild(label);
+      strip.appendChild(card);
+    }
+    for (let i = 0; i < (job.fail_count || 0); i++) {
+      const card = document.createElement("div");
+      card.className = "imagineCard imaginePending imagineFailed";
+      const label = document.createElement("span");
+      label.textContent = "本张失败，重试下一账号中…";
+      card.appendChild(label);
+      strip.appendChild(card);
+    }
+  }
+}
+
+// 全局轮询：有运行中的任务时每 1.5s 拉一次 /api/imagine/jobs；
+// 新图落盘即刷新画廊，全部结束后停表并汇总提示。与当前视图无关。
+function startImaginePolling() {
+  if (imaginePoll.timer) return;
+  const tick = async () => {
+    let finished = true;
+    try {
+      finished = await pollImagineJobsOnce();
+    } catch {
+      // 网络抖动：保持轮询，下一轮重试。
+      finished = false;
+    }
+    if (finished) stopImaginePolling();
+  };
+  imaginePoll.timer = setInterval(tick, 1500);
+  tick();
+}
+
+function stopImaginePolling() {
+  if (imaginePoll.timer) clearInterval(imaginePoll.timer);
+  imaginePoll.timer = null;
+}
+
+async function pollImagineJobsOnce() {
+  const data = await api("/api/imagine/jobs");
+  const jobs = Array.isArray(data.jobs) ? data.jobs : [];
+  const running = jobs.filter((j) => j.state === "running");
+  let galleryDirty = false;
+  const liveIds = new Set();
+  for (const job of jobs) {
+    liveIds.add(job.id);
+    const prev = imaginePoll.seen.get(job.id);
+    if (!prev) {
+      imaginePoll.seen.set(job.id, { ok: job.ok_count || 0, state: job.state });
+      if (job.state !== "running") galleryDirty = true;
+      continue;
+    }
+    if ((job.ok_count || 0) > prev.ok) {
+      galleryDirty = true;
+      const added = (job.ok_count || 0) - prev.ok;
+      toast(`新图片已生成（+${added}）`, "success");
+    }
+    if (prev.state === "running" && job.state !== "running") {
+      if (job.state === "error") {
+        toast("本批生图失败：" + (job.error || "所有账号均失败"), "error");
+      } else {
+        toast(`本批完成：成功 ${job.ok_count} 张${job.fail_count ? `，失败 ${job.fail_count} 张` : ""}`, job.fail_count ? "warn" : "success");
+      }
+    }
+    imaginePoll.seen.set(job.id, { ok: job.ok_count || 0, state: job.state });
+  }
+  if (imaginePoll.seen.size > 80) {
+    for (const id of imaginePoll.seen.keys()) {
+      if (!liveIds.has(id)) imaginePoll.seen.delete(id);
+    }
+  }
+  renderImagineActive(jobs);
+  updateImagineStatusLine(running);
+  if (galleryDirty) await refreshImagineGallery();
+  return running.length === 0;
 }
 
 function downloadImagine(url) {
@@ -7587,7 +7721,8 @@ function downloadImagine(url) {
   a.remove();
 }
 
-function openImagineLightbox(url) {
+function openImagineLightbox(item) {
+  const url = typeof item === "string" ? item : item.url;
   const existing = $("imagineLightbox");
   if (existing) existing.remove();
   const box = document.createElement("div");
@@ -7602,6 +7737,24 @@ function openImagineLightbox(url) {
   dl.textContent = "下载";
   dl.onclick = (e) => { e.stopPropagation(); downloadImagine(url); };
   bar.appendChild(dl);
+  if (item && typeof item === "object" && item.file) {
+    const del = document.createElement("button");
+    del.type = "button";
+    del.className = "btn sm";
+    del.textContent = "删除";
+    del.onclick = async (e) => {
+      e.stopPropagation();
+      try {
+        await api("/api/imagine/gallery/delete", { method: "POST", body: JSON.stringify({ file: item.file }) });
+      } catch (err) {
+        toast("删除失败：" + (err.message || err), "error");
+        return;
+      }
+      box.remove();
+      refreshImagineGallery().catch(() => {});
+    };
+    bar.appendChild(del);
+  }
   const close = document.createElement("button");
   close.type = "button";
   close.className = "btn sm";
@@ -7615,13 +7768,39 @@ function openImagineLightbox(url) {
   img.alt = "预览";
   box.appendChild(img);
 
+  if (item && typeof item === "object") {
+    const bits = [
+      item.prompt,
+      item.model,
+      item.width && item.height ? `${item.width}x${item.height}` : "",
+      item.aspect,
+      formatImagineTime(item.created_at),
+    ].filter(Boolean);
+    if (bits.length) {
+      const meta = document.createElement("div");
+      meta.className = "imagineLightboxMeta";
+      meta.textContent = bits.join("  ·  ");
+      box.appendChild(meta);
+    }
+  }
+
   box.onclick = () => box.remove();
   document.body.appendChild(box);
 }
 
-function clearImagineGallery() {
-  const gallery = $("imagineGallery");
-  if (gallery) gallery.innerHTML = "";
-  const emptyEl = $("imagineEmpty");
-  if (emptyEl) emptyEl.hidden = false;
+function formatImagineTime(value) {
+  const t = new Date(value);
+  if (!value || Number.isNaN(t.getTime())) return "";
+  return t.toLocaleString();
+}
+
+async function clearImagineGallery() {
+  if (!confirm("确定清空画廊？所有已生成的图片文件将被删除。")) return;
+  try {
+    await api("/api/imagine/gallery/clear", { method: "POST" });
+    await refreshImagineGallery();
+    toast("画廊已清空", "success");
+  } catch (err) {
+    toast("清空失败：" + (err.message || err), "error");
+  }
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -1029,7 +1029,7 @@
     <main id="viewImagine" class="view imagineView" hidden>
       <div class="pageHead">
         <h1 class="pageTitle">生图</h1>
-        <p class="pageDesc">基于 grok.com /imagine 协议，自动轮换可用账号生成图片</p>
+        <p class="pageDesc">基于 grok.com /imagine 协议，多账号并行生成；后台任务不受切换页面/刷新影响</p>
       </div>
 
       <section class="formCard imagineComposer">
@@ -1053,6 +1053,14 @@
               <option value="3:4">3:4</option>
             </select>
           </label>
+          <label class="field">张数
+            <select id="imagineCount">
+              <option value="1" selected>1 张</option>
+              <option value="2">2 张</option>
+              <option value="4">4 张 · 抽卡</option>
+              <option value="6">6 张 · 抽卡</option>
+            </select>
+          </label>
         </div>
 
         <div class="inlineActions">
@@ -1062,6 +1070,7 @@
         <p id="imagineStatus" class="muted tiny imagineStatus" hidden></p>
       </section>
 
+      <div id="imagineActive" class="imagineGallery imagineActive" hidden></div>
       <div id="imagineGallery" class="imagineGallery"></div>
       <div id="imagineEmpty" class="empty" hidden>
         <p>还没有图片。输入提示词，点击「生成图片」试试。</p>

--- a/ui/style.css
+++ b/ui/style.css
@@ -5528,6 +5528,45 @@ body.resizingChatPanels * {
   margin-top: 18px;
 }
 
+/* 进行中任务条：位于画廊上方，每张待出图占一格。 */
+.imagineActive {
+  margin-top: 16px;
+}
+
+.imagineCard.imaginePending {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 165px;
+  color: var(--muted);
+  font-size: 12px;
+  cursor: default;
+}
+
+.imagineCard.imaginePending:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.imagineCard.imagineFailed {
+  color: var(--danger);
+}
+
+.imagineSpinner {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 3px solid var(--line);
+  border-top-color: var(--primary);
+  animation: imagineSpin 0.9s linear infinite;
+}
+
+@keyframes imagineSpin {
+  to { transform: rotate(360deg); }
+}
+
 .imagineCard {
   position: relative;
   border: 1px solid var(--line);
@@ -5592,4 +5631,21 @@ body.resizingChatPanels * {
   right: 16px;
   display: flex;
   gap: 8px;
+}
+
+.imagineLightboxMeta {
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  max-width: 86vw;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
 }


### PR DESCRIPTION
## 用户实测反馈的问题与修复

### 1. 刷新后画廊图片消失
此前画廊只存在于前端内存，刷新即空（磁盘上 `imagine_outputs/` 明明有 92 张历史图片）。
- 每张成功图片现在随写元数据 sidecar（`<图片>.json`：提示词/模型/比例/账号/尺寸/时间）
- 新增 `GET /api/imagine/gallery` 扫描输出目录恢复画廊；进入生图页即加载
- 实测：**92 张历史图片刷新后完整恢复**，lightbox 可查看提示词等元数据

### 2. 不能并行 / 不能批量抽卡
- `POST /api/imagine/generate` 改为**异步任务制**并支持 `count`（1/2/4/6 张）
- 每张一个 goroutine 并行生图；引擎加账号级 `busy` 标记 + `waitForAccount` 排队：
  并发数超过账号数时排队等待，而不是把同一账号并发打到上游触发限流
- 引擎 `Generate` 可安全并发调用（旧实现并发会误报"全部耗尽"）

### 3. 切换界面生成中断
- 生成在服务端后台执行；前端**全局轮询** `/api/imagine/jobs`（1.5s），与当前视图无关
- 刷新页面后重新进入生图页自动续接进度（进行中任务条逐张旋转占位，新图落盘即入库）
- 状态行常显"后台生成中 N 批 · 待出图 M 张（切换页面不受影响，可继续提交新任务）"

### 4. 顺带修复（自查发现）
- **exhausted 账号永久作废**：额度类错误标记的耗尽账号加 1 小时 TTL 自动恢复重试
- **新注册账号需重启**：提交任务时热重载 `registrar/cookies` 目录（保留原账号统计）
- **"清空画廊"只清 DOM 不删文件**：改为真实删除（带 confirm），并支持单张删除
- `/imagine-output` 改用 `http.ServeFile`（支持 Range/条件请求，不再整文件读入内存）
- 补上 `TestImagineGenerate` 漏掉的 `GROK_SWITCH_LIVE_IMAGINE` 门控（活体测试会真实消耗额度，与同文件其它测试保持一致）

## 验证

- 新增单元测试：画廊持久化/删除/清空与路径穿越防护、异步任务生命周期（running→error 终态）、count 钳制、busy 跳过/exhausted TTL/热重载保留统计
- `go test ./... -count=1` 全绿；`node --check ui/app.js` 通过
- chromedp + 真实 Chrome E2E：进入生图页 92 张卡片渲染 → **刷新后 92 张** → 切走再切回 92 张，张数选择器在位，进行中条正确隐藏 — RESULT: PASS