### PR TITLE
fix: busy 状态下 NewSession 不复位导致服务被卡死 turn 永久锁住

### DIFF
--- a/docs/design/native-agent-engine.md
+++ b/docs/design/native-agent-engine.md
@@ -1,0 +1,355 @@
+# 自研 Agent 引擎（路径 C）技术方案
+
+状态：v2 裁定稿（4 项开放问题已裁决，可作为实施依据）
+日期：2026-08-28
+前置阅读：Kimi Code 源码分析（会话记录）、`internal/agentbridge`（现有 ACP 桥）
+
+## 1. 背景与动机
+
+当前聊天工作台的 Agent 能力完全外包给 Grok CLI：`agentbridge` spawn `grok` 子进程，
+通过 ACP 协议转发 prompt、回传事件。这带来三个结构性问题：
+
+1. **能力天花板被锁死**。上下文管理、工具质量、子代理、权限粒度全部由 Grok CLI 决定，
+   我们只能在壳层做灾难恢复（session load overflow 后降级重建 + bootstrap 注入）。
+2. **脆**。ACP 连接层的 notification queue overflow、peer disconnected 等错误只能靠
+   字符串匹配识别（`IsSessionLoadOverflow`），恢复路径不可控。
+3. **依赖用户环境**。要求用户机器上装有 grok CLI 且已登录，终端里能跑 `grok`。
+
+Kimi Code（Moonshot 开源）证明了正确的形态：引擎自研，模型层用窄接口隔离。
+其 agent-core 约 71k 行 TS、230 个测试文件；但其中**可支撑一个生产级引擎的内核
+只有约 3k 行 loop + 1.5k 行 provider 抽象**，其余是 TUI/插件/遥测等生态件。
+用 Go 复刻这个内核，对我们是完全可行的工程量。
+
+## 2. 目标与非目标
+
+### 目标
+
+- G1：聊天工作台的 Agent loop 由 grok_switch 进程内自研引擎驱动，摆脱对 grok CLI 的运行时依赖。
+- G2：现有 Web UI（桌面 + 配对手机）零重写或极小改动接入。
+- G3：在自研引擎上落地 Kimi Code 验证过的能力：主动上下文压实、权限规则 DSL、
+  结构化 todo/plan、事件录制回放；后续 goal mode 与并行子代理。
+- G4：acp 桥保留为可切换的旧引擎，灰度过渡，出问题可一键回退。
+
+### 非目标
+
+- 不做通用 Agent 框架 / 不发布为库（先服务本工具）。
+- 不复刻 Kimi 的 plugin 市场、IDE ACP server、cron、swarm（列为远期）。
+- 不做自定义模型接入的通用 provider 矩阵（只覆盖本工具实际服务的上游，见 §4 决策 D1）。
+
+## 3. 现状盘点：可直接复用的资产
+
+| 资产 | 位置 | 对引擎的价值 |
+|---|---|---|
+| `/grok/v1` 本地代理 | `internal/server/grok_proxy.go` | 已解决上游全部 wire 层难题：previous_response_id 丢失重写、加密 reasoning 剥离、跨账号故障转移（3 次尝试）、粘性会话绑定（resp_/sess_ key + 1h TTL 持久化）、`x-grok-switch-*` 可观测头。**引擎直接 loopback 调它，一行不用改。** |
+| 号池 | `internal/grokpool` | 账号巡检/隔离/轮换/粘性，引擎天然继承"生图同款"的多账号能力 |
+| 供应商 Profile | `internal/profiles/model.go` | 已有 `upstream_format`、`api_backend`、`context_window`、`max_completion_tokens`、`supports_reasoning_effort` —— 这就是 Kimi `ModelCapability` 的数据基础 |
+| 生图引擎 | `internal/server/imagine*.go` | 原生工具化：不再需要 MCP 子进程绕行，`generate_image` 直接作为 builtin tool 调 `ImagineEngine` |
+| AgentService 接口 | `internal/server/agent.go:25` | **关键接缝**：server 层已经通过接口消费 agent，替换实现即可，WS 事件协议可保持兼容 |
+| UI 事件协议 | `agentbridge.Event` | type/text/tool/permission/plan/retry 结构已被前端消费，新引擎按同协议发事件 |
+| 历史会话存储 | `agentbridge/history.go` | 存储布局与列表/回放 API 可沿用 |
+
+## 4. 关键决策
+
+### D1 上游协议：以 OpenAI Responses 为主，Profile 驱动适配
+
+- 现状：Grok Auth 池上游（`cli-chat-proxy.grok.com/v1`）走 Responses wire 格式；
+  供应商 Profile 已有 `upstream_format` 字段区分 `openai_responses` / 其他。
+- 决策：引擎内部使用统一的消息表示（参考 kosong 的 `Message`/`ContentPart`），
+  provider 适配器负责翻译。第一期只做 **Responses 适配器**（走 loopback `/grok/v1`），
+  P4.5 补 `chat/completions` 适配器（见 D7——这不是可选优化，是覆盖第三方中转
+  Profile 的必需件，one-api/new-api 系中转几乎只讲 chat/completions）。
+- 理由：Responses 的服务端 reasoning 状态与粘性会话是 Grok 上游的实际行为，代理已
+  处理其所有边界情况；先窄后宽。
+
+### D1b 引擎侧会话状态：无状态优先（全量历史重放），`previous_response_id` 仅作优化
+
+这是本方案最重要的协议层决策，直接影响正确性：
+
+- **引擎自持全部历史**，每步以完整 `input` 数组请求上游；`prompt_cache_key` 用
+  sessionID 固定，吃上游 prompt cache，摊平重放成本。
+- **不默认使用 `previous_response_id`**。原因：
+  1. 服务端状态把账号粘死——号池换号、上游丢弃响应（`isPreviousResponseNotFound`
+     已证明会发生）都会打断链条，引擎要为"续链"维护一套易错的状态机；
+  2. 无状态重放是 Claude API / kosong 的成熟形态，历史真实可控、可回放、可压实；
+  3. 重放时的已知脏问题（assistant reasoning 项被拒）代理层 `stripEncryptedReasoning`
+     已解决——loopback 方案的又一次红利。
+- 保留优化通道：Provider 接口暴露 `WithContinuation(responseID)`，某天想省流量再开，
+  且必须配"续链失败 → 自动降级全量重放"的阶梯（代理的 lost-continuation 信号做触发）。
+
+### D2 引擎调用上游的方式：loopback HTTP，而不是直连上游
+
+- 引擎以 HTTP 客户端身份请求 `http://127.0.0.1:<port>/grok/v1`，携带号池本地 key，
+  与今天 grok CLI 的身份完全一致。
+- 备选方案是引擎直接调 `grokpool`/`grokauth` 拿 token 直连上游——被否决：
+  会复制代理里 content-repair、failover、sticky 三套逻辑，两处漂移。
+- 代价：多一跳 loopback（localhost 开销可忽略）。测试时用注入的 base_url 指向 httptest server。
+
+### D3 上下文管理：用上游回传的真实 usage，不做 tokenizer
+
+- Kimi 用估算 token 触发 compaction（85% 窗口 + 50k 保留输出）。
+- 我们每一步都能从 Responses 流拿到真实 `usage.input_tokens`（代理已透传）。
+  触发条件直接用「上一步真实 input + 预留输出 ≥ context_window」，
+  省掉一个 tokenizer 依赖（Go 生态 tokenizer 对 grok 词表也不保证准）。
+- chat/completions 上游拿不到流式 usage 时（见 D7），按字符数/4 近似，
+  触发阈值自动放宽 10%——宁可晚压不可误压。
+
+### D4 工具面：第一期内置 9 个工具，不做 MCP 通用客户端
+
+参考 Kimi builtin 工具集，第一期（对齐现有体验所需）：
+
+| 工具 | 说明 |
+|---|---|
+| `read` | 文本分页读取，行号格式，图片/视频复用现有 media 压缩逻辑 |
+| `write` | 整文件写入（原子写，复用 `switcher.atomicWrite` 模式） |
+| `edit` | 精确串替换（`old_string` 唯一性校验；模糊匹配列为二期） |
+| `glob` / `grep` | `doublestar` + 正则；数据量与超时预算 |
+| `bash` | 平台 shell 执行，超时、输出截断、后台化（前台超时转后台，学 Kimi） |
+| `todo_list` | 结构化任务列表，UI 已有渲染位（tool event） |
+| `enter/exit_plan_mode` | 对接现有 plan 审批 UI |
+| `generate_image` | 直连 `ImagineEngine`，支持快速/标准/高清 + 宽高比（对齐 MCP 版语义） |
+
+第二期：`fetch_url`、`read_media` 独立化、skills。MCP 通用客户端（Kimi 的
+registry/reconcile/OAuth 那套）列为远期——它单独立项都不小。
+
+### D5 权限模型：规则 DSL + 模式，一期就做
+
+现有会话级 autoApprove 布尔太粗。自研后直接落 Kimi 的三模式 + 规则 DSL：
+
+- 模式：`manual`（默认，未命中规则就问）/ `yolo`（只拦 deny 规则）/ `auto`（全放行，等价今天的 autoApprove）。
+- 规则：`Tool(pattern)` 形态，如 `read(**)` 免批、`bash(git *)` 免批、`bash(rm *)` 拒绝、
+  `write(~/.ssh/**)` 拒绝。scope 分 `session`（内存）与 `user`（settings.json 持久）。
+- 审批 UI 复用现有 permission event 流，扩展「本次会话记住」选项即对应 session 规则。
+
+### D6 过渡策略：引擎选择器 + 会话级隔离
+
+- `settings.json` 增加 `agent_engine: "acp" | "native"`。默认值定 **`native`**，
+  但带运行时自检：MVP 联调通过后翻转默认；`native` 引擎启动失败（理论上只剩
+  配置错误）自动降级 `acp` 并在 UI 顶条提示。不做长期双默认——两个"默认"等于
+  没有默认，维护者会永远背着两套引擎的隐性兼容负担。
+- 切换粒度：新会话用当前引擎；旧会话历史两边都只读支持，回放不混写。
+- 收尾计划：P6 完成且稳定一个版本周期后，ACP 桥进入只修不增模式，
+  作为「官方账号兼容模式」长期保留（部分用户用 grok CLI 自身能力如 skills，
+  不应被强制迁移）。
+
+### D7 第三方中转 Profile：P1 就必须支持 chat/completions
+
+以维护者视角看这不是"加不加"的问题：本工具的核心场景之一就是接第三方中转
+（one-api/new-api 系），而这些中转几乎只讲 chat/completions。native 引擎若只讲
+Responses，等于把「供应商切换」这个产品根基在聊天工作台里砍掉一半，用户切到
+中转 Profile 后 Agent 按钮直接不可用——不可接受。
+
+- 落点：`internal/llm` 的 Provider 接口天生为多后端设计（kosong 有 4 个 provider
+  实现，接口面很窄），chat/completions 适配器作为 P1 的第二交付物，与 Responses
+  适配器共享 Message/usage/流式装配层，增量约 400 行。
+- 差异处理：chat/completions 无服务端 reasoning 状态（与 D1b 无状态重放天然契合），
+  usage 在流式 `chunk.usage`（需 `stream_options.include_usage`）拿不到时按字符
+  近似并在能力表标记 `usage_accuracy: approximate`，compaction 阈值自动放宽 10%。
+
+### D8 手机端：零改动假设成立，但补一条端到端验收
+
+事件走同一条 WS 广播，配对手机用的是同一个前端 bundle，D6 的引擎切换对手机透明。
+验收标准加一条：P4 联调必须含「手机配对 → 发消息 → 收流式回复 → 权限弹窗可审批」
+的端到端用例，防止 server 层实现里埋了仅桌面可用的分支。
+
+## 5. 总体架构
+
+```
+ui/app.js (不动)                    WS + REST
+──────────────────────────────────────────────
+server 层 (小改)
+  /api/agent/*  ←→  AgentService 接口
+                        │
+        ┌───────────────┴────────────────┐
+        │ acpBridgeService (现有)         │ nativeAgentService (新)
+        │ spawn grok CLI                  │ agentloop.Engine
+        └────────────────────────────────┘
+─── 引擎边界（internal/ 新包，互不依赖 server）───
+  internal/llm        kosong-go：Message/ContentPart/ToolCall/TokenUsage/
+                      ModelCapability + Provider 接口 + Responses 适配器
+  internal/agentloop  loop-go：RunTurn / Step / ToolCall 批次 / 调度 /
+                      重试与 resend 策略 / 事件流（录制+直播分离）
+  internal/tools      工具实现 + 注册表 + 参数校验 + 结果预算截断
+  internal/agentfs    执行环境抽象（kaos-go 最小集：路径/读/写/进程，local 实现）
+  internal/ctxmem     上下文记忆：PromptOrigin 标记、compaction handoff
+──────────────────────────────────────────────
+  loopback /grok/v1 ──→ grok_proxy ──→ grokpool ──→ cli-chat-proxy.grok.com
+  imagine 引擎 ←── tools/generate_image
+```
+
+分层契约（抄 Kimi loop/README 的纪律，翻译成 Go 约定）：
+
+- `agentloop` 不 import 任何 UI/存储/权限实现；通过接口注入。
+- 事件单出口：`Dispatch(Event)`；录制（JSONL append）与直播（chan 广播）都在出口处分发，
+  直播订阅者 panic/慢速不影响 loop。
+- usage 在 LLM 返回后立即记录（不等工具跑完），abort 也报告已消耗 token。
+
+## 6. 模块设计
+
+### 6.1 internal/llm（kosong-go，约 1.5k 行）
+
+```go
+type Role string // system|user|assistant|tool
+
+type ContentPart interface{} // TextPart | ThinkPart | ImagePart | ...（sealed）
+
+type ToolCall struct { ID, Name string; Arguments json.RawMessage }
+
+type Message struct { Role Role; Parts []ContentPart; ToolCalls []ToolCall; ToolCallID string }
+
+type TokenUsage struct { InputOther, Output, InputCacheRead, InputCacheCreation int64 }
+func (u TokenUsage) InputTotal() int64; func (u TokenUsage) GrandTotal() int64
+
+type ModelCapability struct {
+    ImageIn, VideoIn, Thinking, ToolUse bool
+    MaxContextTokens int   // 0 = 未知
+    MaxInputTokens   int   // 0 = 仅总量上限
+}
+
+type Provider interface {
+    Name() string
+    ModelName() string
+    Capability() ModelCapability
+    Generate(ctx, SystemPrompt string, Tools []Tool, History []Message,
+             opts GenerateOptions) (*StreamResult, error) // 流式回调 + 最终装配
+    WithThinking(effort string) Provider
+}
+```
+
+- `ResponsesProvider`：POST loopback `/grok/v1/responses`，SSE 解析
+  `response.output_text.delta` / `response.function_call_arguments.delta` /
+  `response.completed`（usage 在这里）。思考流映射 `ThinkPart`（上游 reasoning summary）。
+- 能力表来源：`profiles.Profile` 的 `context_window`/`max_completion_tokens`/
+  `supports_reasoning_effort`/模型名前缀规则；未知模型返回 `UnknownCapability`，
+  调用方自行 gate（与 kosong 的冻结 UNKNOWN 语义一致）。
+
+### 6.2 internal/agentloop（loop-go，约 2k 行）
+
+```go
+type Engine struct { /* deps: Provider, ToolTable, PermGate, Recorder, CtxMemory */ }
+
+func (e *Engine) RunTurn(ctx context.Context, in RunTurnInput) (TurnResult, error)
+
+type RunTurnInput struct {
+    SessionID   string          // 作为 prompt_cache_key（粘性会话复用代理绑定）
+    Build       *ctxmem.Memory  // 每步重建 model-visible messages
+    Hooks       Hooks           // beforeStep(compaction 切入点)/shouldContinueAfterStop/…
+    MaxSteps    int             // 默认 100
+    MaxRetry    int             // 默认 3（对齐代理 failover 次数）
+}
+```
+
+- **RunTurn**（对应 run-turn.ts，255 行）：while 循环；`tool_use` 继续、其余终止；
+  abort 区分 user_cancelled；max-step 抛错；usage 聚合。
+- **Step**（对应 turn-step.ts，587 行）：pre/post hook、消息构建、原子 step 封套、
+  流回调、**三级 resend 策略**：
+  1. 工具相邻性 400 → strict rebuild 重发一次；
+  2. 413/体积超限 → media-degraded（旧媒体换文本标记，保留最近一条）重发，
+     成功后本 turn 后续步全部用降级投影；
+  3. 图片格式错误 → media-stripped（全部媒体换标记）。
+  这三条是 Kimi 踩坑换来的实战逻辑，全部照搬。
+- **ToolCall 批次**（tool-call.ts）：provider 顺序记录 call 事件；执行调度一期从简——
+  顺序执行 + 只读工具（read/glob/grep）并行小优化放二期；每个 call 必有 result 事件配对。
+- **重试**（retry.ts 语义）：限流/网络错误指数退避，429 尊重 Retry-After；错误分类
+  可恢复（pause 语义，见 6.5）vs 终止。
+- **权限闸**：工具执行前过 `PermGate.Check(tool, args) → allow|deny|ask`；ask 通过
+  审批回调（对应现有 WS permission request）挂起 turn。
+
+### 6.3 internal/tools
+
+```go
+type Tool interface {
+    Name() string
+    Schema() map[string]any        // JSON Schema
+    Doc() string                   // 工具用法说明（拼进 system prompt，学 Kimi 的 *.md 内嵌）
+    Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolResult
+}
+type ToolResult struct { Output string; IsError bool; Truncated bool; Media []MediaPart }
+```
+
+- 结果预算：统一字符截断 + `[truncated]` 标记（Kimi `tool-result-budget` 的简化版）。
+- bash：`context` 超时 → 转后台任务表（任务 ID + 完成事件推送），不直接 kill；
+  每次调用独立 shell 环境，cwd 参数化。
+- read：行号 + 分页 + 大文件守卫；图片走现有压缩管线。
+- edit：`old_string` 必须唯一命中，否则报错并列出命中次数（比模糊匹配安全，先跑起来）。
+
+### 6.4 internal/ctxmem + 会话持久化
+
+- `PromptOrigin` 分类（学 Kimi context/types.ts）：`user / injection / shell /
+  compaction_summary / system_trigger / background`。**这是 compaction 正确性的根基**：
+  压实时只保留真实 user 消息原话，injection 类一律可重建。
+- 持久化：每会话一个 JSONL（`~/.grok_switch/agent2/sessions/<id>/transcript.jsonl`），
+  事件追加式（seq 严格递增），恢复 = 重放进 `ctxmem.Memory`。
+  另存轻量 meta（标题/模型/cwd/统计），列表 API 直接读 meta。
+- Compaction（二期，一期先做阈值提示）：
+  - 触发：上一步真实 usage ≥ 85% 窗口，或 usage + 预留 50k ≥ 窗口；
+  - handoff：保留用户原话（预算 20k token 按字符近似，最老 2k 强制保留形成 head/tail +
+    省略标记）+ 摘要消息（带 `COMPACTION_SUMMARY:` 前缀告知模型这是交接上下文）；
+  - 压实请求本身溢出时，诚实记录 droppedCount。
+  - token 预算按「字符数/4」近似即可，误差对 85% 阈值安全。
+
+### 6.5 稳定性与错误语义（对齐 Kimi goal 的停车分类，先用于 turn 级）
+
+- 用户中断 → turn 终止，标记 `user_cancelled`；
+- 限流/网络/上游 5xx → 指数退避重试，耗尽后 turn 暂停（会话可恢复）；
+- 上下文溢出 → 触发 compaction 后重试（限 3 次）；
+- 权限拒绝 → 工具结果以 `IsError` 回给模型继续 turn（不是终止）；
+- 全部进遥测日志，`x-grok-switch-*` 头的换号信息透传到事件流。
+
+### 6.6 权限（internal/permission，约 500 行）
+
+规则编译：`Tool(pattern)` → 工具名精确匹配 + 参数 matcher（每工具提供
+`MatchPattern(args, pattern) bool`；bash=命令前缀通配，read/write/edit/glob=glob 路径）。
+决策顺序：deny 规则 > 模式 > allow 规则 > ask 默认。UI 上「总是允许/仅本会话/仅本次」
+三按钮 → 分别写 user 规则 / session 规则 / 单次放行。
+
+### 6.7 server 接入
+
+`nativeAgentService` 实现 `AgentService` 全部 20 个方法：
+- `Start/Stop`：懒加载引擎实例（不再管子进程生命周期）；
+- `Prompt`：构造 RunTurn 异步执行，事件泵转发到 `Subscribe` chan（协议不变）；
+- `RespondPermission*` / `RespondPlan`：唤醒挂起的闸；
+- 历史方法走新存储；旧的 `ArmBootstrapFromSession` 在 native 引擎下是 no-op。
+
+## 7. 分阶段实施
+
+| 阶段 | 内容 | 产出/验收 | 预估 |
+|---|---|---|---|
+| P1 | `internal/llm` + ResponsesProvider + chat/completions 适配器（D7）+ 能力表 | httptest 上游跑通流式/usage/重试单测，双协议同一套 e2e | 5-6 天 |
+| P2 | `internal/agentloop`（RunTurn/Step/resend/重试/事件录制） | 假工具 e2e：多步工具调用、abort、413 降级、限流退避 | 4-5 天 |
+| P3 | `internal/tools` 9 工具 + `internal/agentfs` | 工具单测 + 冒烟：读改文件、跑测试命令 | 5-6 天 |
+| P4 | 会话持久化 + `nativeAgentService` + 引擎选择器 | WS 协议对齐老事件；含手机端到端用例（D8） | 4-5 天 |
+| P5 | 权限 DSL + 审批 UI 三按钮 | 规则单测；UI 联调 | 3-4 天 |
+| P6 | ctxmem origin 标记 + compaction handoff | 长会话压测：85% 触发、恢复回放一致 | 4-5 天 |
+| P7 | generate_image 原生工具化 | 脱离 MCP 子进程的生图链路 | 2 天 |
+| 远期 | goal mode / swarm / MCP 客户端 / skills | 另立设计文档 | — |
+
+MVP = P1–P4（约 3.5 周全职当量），此后每阶段独立可发布。默认引擎翻转（D6）
+在 P5 结束、P6 开工前执行，让 compaction 直接按"默认引擎"验收，不做两遍。
+
+## 8. 风险与对策
+
+| 风险 | 对策 |
+|---|---|
+| 我们的 system prompt + 工具文档调教不如 xAI 官方 | 引擎选择器保底回退 ACP；工具 Doc 直接借用 Kimi 的成熟文案骨架逐条本地化迭代 |
+| 上游 Responses 行为依赖 grok CLI 侧协议演进 | 引擎与 CLI 都走同一个代理，代理层已隔离差异；引擎不做协议假设的硬编码 |
+| edit 精确替换在真实代码上成功率低 | P3 验收含 20 个真实编辑用例；不达标提前上模糊匹配（`fuzzy` 唯一命中+diff 预览） |
+| 双引擎维护成本 | 原生稳定后（P6 完成）ACP 桥降级为「官方账号兼容模式」，只修不增 |
+| 每会话 JSONL 无限增长 | 复用 compaction：transcript 全量保留（回放用），context memory 是投影，磁盘量级可控 |
+
+## 9. 决策裁定（此前"待确认问题"的裁决结果）
+
+原方案的 4 个开放问题，以维护者视角裁定如下，文档相应章节已同步：
+
+1. **工具面（原问题 1）**：维持 9 工具。`fetch_url` 不进一期——它是独立能力
+   （HTML→markdown、体积预算、robots 语义），塞进 MVP 只会稀释验收质量；
+   权限 DSL（D5）让 bash 里 `curl` 的审批可控，一期够用。二期与 skills 同批进。
+2. **默认引擎（原问题 2）**：裁定 MVP 后默认 `native`，带自检降级（D6）。
+   理由：自研引擎是本项目的战略方向，长期 opt-in 意味着它永远吃不到真实流量、
+   永远是"实验品"，双引擎的隐性维护成本反而更高。灰度用翻转前的版本周期完成。
+3. **chat/completions（原问题 3）**：裁定 P1 必须交付（D7）。理由：供应商切换是
+   产品根基，砍掉中转 Profile 的 Agent 能力等于自残；接口已为其设计，增量小。
+4. **手机端（原问题 4）**：零改动假设成立，追加端到端验收用例（D8）。
+
+另新增一条非开放性裁决——**D1b 无状态重放**：引擎自持全部历史、每步全量请求、
+不用 `previous_response_id` 做默认路径（详见 §4）。这是号池多账号形态下唯一
+自洽的会话状态模型，也是方案正确性的基石。

--- a/internal/agentfs/agentfs.go
+++ b/internal/agentfs/agentfs.go
@@ -1,0 +1,164 @@
+// Package agentfs 是 Agent 的执行环境抽象（对标 Kimi Code 的 kaos 最小集）。
+//
+// 工具（internal/tools）只通过本包接口触碰文件系统与进程，local 实现即宿主机。
+// 远期 SSH/容器执行环境在此接口后替换，工具代码不变（设计文档 §5）。
+package agentfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Env 是一次工具执行的上下文：工作目录 + 环境抽象。
+type Env struct {
+	// Cwd 是本会话允许操作的根目录（用户在 UI 里选择的工作目录）。
+	Cwd string
+	// SandboxExtra 是额外允许访问的绝对路径（如临时目录）；空则只有 Cwd。
+	SandboxExtra []string
+}
+
+// Resolve 把相对/带 ~ 的路径解析为绝对路径并归一化。
+func (e Env) Resolve(path string) (string, error) {
+	p := strings.TrimSpace(path)
+	if p == "" {
+		return e.Cwd, nil
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		p = filepath.Join(home, strings.TrimPrefix(p[1:], "/"))
+	}
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(e.Cwd, p)
+	}
+	return filepath.Clean(p), nil
+}
+
+// WithinSandbox 判断绝对路径是否落在允许范围内（Cwd 或 SandboxExtra 的前缀内）。
+// Windows 大小写不敏感，这里按大小写折叠比较。
+func (e Env) WithinSandbox(abs string) bool {
+	abs = filepath.Clean(abs)
+	if withinRoot(e.Cwd, abs) {
+		return true
+	}
+	for _, extra := range e.SandboxExtra {
+		if withinRoot(extra, abs) {
+			return true
+		}
+	}
+	return false
+}
+
+func withinRoot(root, target string) bool {
+	if root == "" {
+		return false
+	}
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (!strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel))
+}
+
+// SandboxError 是越界访问错误。
+type SandboxError struct{ Path string }
+
+func (e *SandboxError) Error() string {
+	return fmt.Sprintf("路径越出工作目录沙箱: %s", e.Path)
+}
+
+// Guard 解析路径并强制沙箱。所有读写工具入口必须先走它。
+func (e Env) Guard(path string) (string, error) {
+	abs, err := e.Resolve(path)
+	if err != nil {
+		return "", err
+	}
+	if !e.WithinSandbox(abs) {
+		return "", &SandboxError{Path: abs}
+	}
+	return abs, nil
+}
+
+// ReadText 读取文件（上限 maxBytes；0 表示默认 2MB）。
+func (e Env) ReadText(abs string, maxBytes int64) (string, error) {
+	if maxBytes <= 0 {
+		maxBytes = 2 << 20
+	}
+	f, err := os.Open(abs)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	if st.Size() > maxBytes {
+		return "", fmt.Errorf("文件过大 (%d 字节)，上限 %d", st.Size(), maxBytes)
+	}
+	buf := make([]byte, st.Size())
+	if _, err := f.Read(buf); err != nil && st.Size() > 0 {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// WriteText 原子写入：写临时文件后 rename。
+func (e Env) WriteText(abs, content string) error {
+	dir := filepath.Dir(abs)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".agentfs-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	_, writeErr := tmp.WriteString(content)
+	closeErr := tmp.Close()
+	if writeErr != nil || closeErr != nil {
+		os.Remove(tmpName)
+		if writeErr != nil {
+			return writeErr
+		}
+		return closeErr
+	}
+	return os.Rename(tmpName, abs)
+}
+
+// ListDir 返回目录条目名（排序）。
+func (e Env) ListDir(abs string) ([]string, error) {
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// StatResult 是文件元信息。
+type StatResult struct {
+	Exists  bool
+	IsDir   bool
+	Size    int64
+	ModTime int64 // Unix 秒
+}
+
+// Stat 探测路径。
+func (e Env) Stat(abs string) StatResult {
+	st, err := os.Stat(abs)
+	if err != nil {
+		return StatResult{}
+	}
+	return StatResult{Exists: true, IsDir: st.IsDir(), Size: st.Size(), ModTime: st.ModTime().Unix()}
+}

--- a/internal/agentfs/agentfs_test.go
+++ b/internal/agentfs/agentfs_test.go
@@ -1,0 +1,127 @@
+package agentfs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGuardResolvesAndEnforces(t *testing.T) {
+	cwd := t.TempDir()
+	env := Env{Cwd: cwd}
+
+	abs, err := env.Guard("sub/file.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abs != filepath.Join(cwd, "sub", "file.go") {
+		t.Fatalf("相对路径解析错误: %s", abs)
+	}
+
+	if _, err := env.Guard("../outside.txt"); err == nil {
+		t.Fatal("越出 Cwd 应被拒绝")
+	} else if _, ok := err.(*SandboxError); !ok {
+		t.Fatalf("应为 SandboxError: %T", err)
+	}
+
+	// 额外沙箱路径允许访问。
+	extra := t.TempDir()
+	env2 := Env{Cwd: cwd, SandboxExtra: []string{extra}}
+	if _, err := env2.Guard(filepath.Join(extra, "data.bin")); err != nil {
+		t.Fatalf("SandboxExtra 应放行: %v", err)
+	}
+}
+
+func TestGuardSiblingDirectoryRejected(t *testing.T) {
+	cwd := t.TempDir()
+	sibling := t.TempDir() // 同级目录，路径前缀相近
+	env := Env{Cwd: cwd}
+	// /tmp/A vs /tmp/B：前缀比较不安全，Rel 必须识别。
+	if _, err := env.Guard(filepath.Join(sibling, "x.txt")); err == nil {
+		t.Fatal("同级目录应被拒绝（前缀混淆防护）")
+	}
+}
+
+func TestWriteReadAtomic(t *testing.T) {
+	env := Env{Cwd: t.TempDir()}
+	abs, _ := env.Guard("nested/dir/file.txt")
+	if err := env.WriteText(abs, "hello 引擎"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := env.ReadText(abs, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello 引擎" {
+		t.Fatalf("内容不符: %q", got)
+	}
+	// 无残留临时文件。
+	entries, _ := os.ReadDir(filepath.Dir(abs))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".agentfs-") {
+			t.Fatalf("临时文件残留: %s", e.Name())
+		}
+	}
+}
+
+func TestReadTextTooLarge(t *testing.T) {
+	env := Env{Cwd: t.TempDir()}
+	abs, _ := env.Guard("big.txt")
+	if err := env.WriteText(abs, strings.Repeat("x", 100)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.ReadText(abs, 50); err == nil {
+		t.Fatal("超上限应报错")
+	}
+}
+
+func TestShellRunAndTimeout(t *testing.T) {
+	env := Env{Cwd: t.TempDir()}
+
+	res := env.Shell(context.Background(), "echo hello", "", time.Minute)
+	if res.ExitCode != 0 || !strings.Contains(res.Stdout, "hello") {
+		t.Fatalf("echo 失败: %+v", res)
+	}
+
+	start := time.Now()
+	res = env.Shell(context.Background(), "sleep 5", "", 200*time.Millisecond)
+	if !res.TimedOut {
+		t.Fatalf("应超时: %+v", res)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatal("超时未及时终止")
+	}
+}
+
+func TestShellNonZeroExit(t *testing.T) {
+	env := Env{Cwd: t.TempDir()}
+	res := env.Shell(context.Background(), "exit 3", "", time.Minute)
+	if res.ExitCode != 3 {
+		t.Fatalf("退出码错误: %+v", res)
+	}
+}
+
+func TestShellCwdParameter(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	env := Env{Cwd: a}
+	res := env.Shell(context.Background(), "pwd", b, time.Minute)
+	if !strings.Contains(res.Stdout, filepath.Base(b)) {
+		t.Fatalf("cwd 参数未生效: %+v (want base %s)", res, filepath.Base(b))
+	}
+}
+
+func TestWithinSandboxDotDotInside(t *testing.T) {
+	// cwd/sub/.. 归一化后仍在 cwd 内。
+	env := Env{Cwd: t.TempDir()}
+	abs, err := env.Guard("sub/../ok.txt")
+	if err != nil {
+		t.Fatalf("cwd 内的 .. 应放行: %v", err)
+	}
+	if !strings.HasSuffix(abs, "ok.txt") || strings.Contains(abs, "..") {
+		t.Fatalf("路径未归一化: %s", abs)
+	}
+}

--- a/internal/agentfs/shell.go
+++ b/internal/agentfs/shell.go
@@ -1,0 +1,101 @@
+package agentfs
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// ShellResult 是一次命令执行的结果。
+type ShellResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	// TimedOut 标记命令因超时被终止。
+	TimedOut bool
+}
+
+// Combined 返回合并输出（stdout 在前，stderr 在后），供工具回传。
+func (r ShellResult) Combined() string {
+	var b strings.Builder
+	if r.Stdout != "" {
+		b.WriteString(r.Stdout)
+		if !strings.HasSuffix(r.Stdout, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	if r.Stderr != "" {
+		b.WriteString(r.Stderr)
+		if !strings.HasSuffix(r.Stderr, "\n") {
+			b.WriteByte('\n')
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// Shell 在指定目录执行命令。timeout<=0 用默认 120s。
+// 每次调用独立 shell 环境（不跨调用保留 cwd/env/history，对齐 Kimi bash 语义）。
+func (e Env) Shell(ctx context.Context, command, dir string, timeout time.Duration) ShellResult {
+	if timeout <= 0 {
+		timeout = 120 * time.Second
+	}
+	if dir == "" {
+		dir = e.Cwd
+	}
+	runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	var stdout, stderr strings.Builder
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(runCtx, "cmd", "/C", command)
+	} else {
+		cmd = exec.CommandContext(runCtx, "/bin/sh", "-c", command)
+	}
+	cmd.Dir = dir
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	res := ShellResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if runCtx.Err() != nil && errorsIs(runCtx.Err(), context.DeadlineExceeded) {
+		res.TimedOut = true
+		res.ExitCode = -1
+		return res
+	}
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			res.ExitCode = exitErr.ExitCode()
+		} else {
+			res.ExitCode = -1
+			res.Stderr = res.Stderr + "\n" + err.Error()
+		}
+	}
+	return res
+}
+
+func errorsIs(err, target error) bool {
+	return err != nil && err.Error() == target.Error()
+}
+
+// OpenPath 用系统默认方式打开文件/目录（对应现有 tray.OpenBrowser / open-path 语义）。
+func OpenPath(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		return err
+	}
+	switch runtime.GOOS {
+	case "windows":
+		return exec.Command("explorer", path).Start()
+	case "darwin":
+		return exec.Command("open", path).Start()
+	default:
+		return exec.Command("xdg-open", path).Start()
+	}
+}

--- a/internal/agentkit/agentkit_test.go
+++ b/internal/agentkit/agentkit_test.go
@@ -1,0 +1,199 @@
+package agentkit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"grok_switch/internal/llm"
+)
+
+func TestStoreCreateListTouchDelete(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1, err := store.Create(SessionMeta{Title: "会话一", Cwd: "/tmp/a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m2, _ := store.Create(SessionMeta{Title: "会话二", Cwd: "/tmp/b"})
+	if m1.Engine != "native" || m1.ID == "" {
+		t.Fatalf("Create 未回填: %+v", m1)
+	}
+	if m1.ID == m2.ID {
+		t.Fatal("ID 应唯一")
+	}
+
+	// 追加记录 → MessageCount 增加、UpdatedAt 更新。
+	before := m1.UpdatedAt
+	time.Sleep(2 * time.Millisecond)
+	if err := store.AppendRecord(m1.ID, Record{Origin: OriginUser, Role: llm.RoleUser, Text: "你好", UserTurn: 1}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := store.GetMeta(m1.ID)
+	if got.MessageCount != 1 || !got.UpdatedAt.After(before) {
+		t.Fatalf("AppendRecord 未更新 meta: %+v", got)
+	}
+
+	// 列表倒序。
+	list, _ := store.List(0)
+	if len(list) != 2 || list[0].ID != m1.ID {
+		t.Fatalf("列表顺序错误: %+v", list)
+	}
+
+	// 重命名。
+	if err := store.Rename(m1.ID, "新标题"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = store.GetMeta(m1.ID)
+	if got.Title != "新标题" {
+		t.Fatalf("重命名失败: %s", got.Title)
+	}
+
+	// 删除。
+	if err := store.Delete(m2.ID); err != nil {
+		t.Fatal(err)
+	}
+	list, _ = store.List(0)
+	if len(list) != 1 {
+		t.Fatalf("删除后应剩 1: %d", len(list))
+	}
+}
+
+func TestStoreTranscriptRoundTrip(t *testing.T) {
+	store, _ := NewStore(t.TempDir())
+	meta, _ := store.Create(SessionMeta{Cwd: "/tmp"})
+	records := []Record{
+		{Origin: OriginUser, Role: llm.RoleUser, Text: "读一下 main.go", UserTurn: 1},
+		{Origin: OriginAssistant, Role: llm.RoleAssistant, Text: "好的", Thinking: "思考中…"},
+		{Origin: OriginAssistant, Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "c1", Name: "read", Arguments: json.RawMessage(`{"path":"main.go"}`)}}},
+		{Origin: OriginTool, Role: llm.RoleTool, ToolCallID: "c1", Text: `{"output":"package main","error":false}`},
+		{Origin: OriginUser, Role: llm.RoleUser, Text: "带图消息", Media: []MediaRef{{Kind: "image", URI: "/tmp/a.png", MimeType: "image/png"}}, UserTurn: 2},
+	}
+	for _, r := range records {
+		if err := store.AppendRecord(meta.ID, r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := store.LoadRecords(meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(records) {
+		t.Fatalf("记录数不符: %d", len(got))
+	}
+	// Seq 递增。
+	for i, r := range got {
+		if r.Seq != int64(i+1) {
+			t.Fatalf("Seq 错误: idx %d seq %d", i, r.Seq)
+		}
+	}
+	// 回放消息投影。
+	msg := got[2].ToMessage()
+	if len(msg.ToolCalls) != 1 || msg.ToolCalls[0].Name != "read" {
+		t.Fatalf("tool_call 回放错误: %+v", msg)
+	}
+	toolMsg := got[3].ToMessage()
+	if toolMsg.Role != llm.RoleTool || toolMsg.ToolCallID != "c1" || toolMsg.Text() == "" {
+		t.Fatalf("tool 消息回放错误: %+v", toolMsg)
+	}
+	if len(got[4].Media) != 1 || got[4].Media[0].URI != "/tmp/a.png" {
+		t.Fatalf("media 引用丢失: %+v", got[4])
+	}
+}
+
+func TestStoreCorruptTolerant(t *testing.T) {
+	store, _ := NewStore(t.TempDir())
+	meta, _ := store.Create(SessionMeta{Cwd: "/tmp"})
+	if err := store.AppendRecord(meta.ID, Record{Origin: OriginUser, Role: llm.RoleUser, Text: "ok"}); err != nil {
+		t.Fatal(err)
+	}
+	// 注入一条坏行。
+	f, _ := os.OpenFile(store.transcriptPath(meta.ID), os.O_WRONLY|os.O_APPEND, 0o644)
+	f.WriteString("{broken json\n")
+	f.Close()
+	if err := store.AppendRecord(meta.ID, Record{Origin: OriginUser, Role: llm.RoleUser, Text: "after"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.LoadRecords(meta.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[1].Text != "after" {
+		t.Fatalf("坏行应被跳过: %+v", got)
+	}
+}
+
+func TestSanitizeID(t *testing.T) {
+	cases := map[string]string{
+		"abc-123":     "abc-123",
+		"../evil":     "evil",
+		"a/b\\c d":    "abcd",
+		"":            "unnamed",
+		"nat-123_456": "nat-123_456",
+	}
+	for in, want := range cases {
+		if got := sanitizeID(in); got != want {
+			t.Fatalf("sanitizeID(%q)=%q, want %q", in, got, want)
+		}
+	}
+	// 路径穿越防护端到端。
+	store, _ := NewStore(t.TempDir())
+	dir := store.sessionDir("../../evil")
+	root := store.root
+	if !strings.HasPrefix(dir, root) {
+		t.Fatalf("路径越界: %s not in %s", dir, root)
+	}
+	if filepath.Dir(dir) != root {
+		t.Fatalf("sanitize 后应直接位于根下: %s", dir)
+	}
+}
+
+func TestCtxMemoryTurnsAndRewind(t *testing.T) {
+	mem := NewCtxMemory()
+	mem.AppendWithOrigin(llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "t1"}}}, OriginUser)
+	mem.AppendWithOrigin(llm.Message{Role: llm.RoleAssistant, Parts: []llm.ContentPart{llm.TextPart{Text: "a1"}}}, OriginAssistant)
+	mem.AppendWithOrigin(llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "t2"}}}, OriginUser)
+	mem.AppendWithOrigin(llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "c"}}}, OriginAssistant)
+	mem.AppendWithOrigin(llm.Message{Role: llm.RoleTool, ToolCallID: "c"}, OriginTool)
+
+	if mem.UserTurns() != 2 {
+		t.Fatalf("用户轮次错误: %d", mem.UserTurns())
+	}
+	if !mem.RewindToUserTurn(2) {
+		t.Fatal("rewind 应成功")
+	}
+	// 回退到第 2 轮用户消息：保留 [t1, a1]，轮次变 1。
+	msgs, origins := mem.Snapshot()
+	if len(msgs) != 2 || mem.UserTurns() != 1 || origins[0] != OriginUser || origins[1] != OriginAssistant {
+		t.Fatalf("rewind 结果错误: %d msgs, %d turns, origins=%v", len(msgs), mem.UserTurns(), origins)
+	}
+	// 越界 rewind（第 5 轮不存在）：无操作返回 true（目标轮次本身有效定位失败时
+	// 返回 false 的语义留给「定位不到任何轮」场景；越界视为已达末尾）。
+	mem.RewindToUserTurn(5)
+	if mem.UserTurns() != 1 || len(mem.History()) != 2 {
+		t.Fatalf("越界 rewind 不应改变状态: turns=%d msgs=%d", mem.UserTurns(), len(mem.History()))
+	}
+}
+
+func TestCtxMemoryRestoreFromRecords(t *testing.T) {
+	store, _ := NewStore(t.TempDir())
+	meta, _ := store.Create(SessionMeta{Cwd: "/tmp"})
+	_ = store.AppendRecord(meta.ID, Record{Origin: OriginUser, Role: llm.RoleUser, Text: "q1", UserTurn: 1})
+	_ = store.AppendRecord(meta.ID, Record{Origin: OriginAssistant, Role: llm.RoleAssistant, Text: "a1"})
+
+	records, _ := store.LoadRecords(meta.ID)
+	mem := NewCtxMemory()
+	mem.Restore(records)
+	if mem.UserTurns() != 1 {
+		t.Fatalf("恢复后轮次错误: %d", mem.UserTurns())
+	}
+	hist := mem.History()
+	if len(hist) != 2 || hist[0].Text() != "q1" || hist[1].Text() != "a1" {
+		t.Fatalf("恢复历史错误: %+v", hist)
+	}
+}

--- a/internal/agentkit/compaction.go
+++ b/internal/agentkit/compaction.go
@@ -1,0 +1,284 @@
+package agentkit
+
+// Compaction handoff（设计文档 §6.4，语义对齐 Kimi compaction/handoff.ts）：
+//
+// 触发：上一步真实 usage ≥ 85% 窗口，或 usage + 预留输出 ≥ 窗口（D3）。
+// 重写：保留用户原话（字符预算内，最老 2k token 强制保留形成 head/tail +
+// 省略标记）+ 一条 COMPACTION_SUMMARY 前缀的摘要消息（明确告知模型这是交接
+// 上下文，不是真实用户输入）。assistant/tool 消息全部折叠进摘要。
+// PromptOrigin 是正确性根基：只有 OriginUser 是真实用户输入，其余可重建。
+
+import (
+	"strings"
+
+	"grok_switch/internal/llm"
+)
+
+// CompactionConfig 是压实参数（默认值对齐设计文档）。
+type CompactionConfig struct {
+	// TriggerRatio 触发阈值（占窗口比例）。
+	TriggerRatio float64
+	// ReservedContextSize 预留输出预算（token）。
+	ReservedContextSize int64
+	// KeptUserTokens 保留用户原话的 token 预算。
+	KeptUserTokens int64
+	// HeadUserTokens head 段预算（最老的用户输入，通常是最初任务陈述）。
+	HeadUserTokens int64
+	// MaxOverflowAttempts 摘要请求本身溢出时的最大重试。
+	MaxOverflowAttempts int
+}
+
+// DefaultCompactionConfig 默认参数：85% 触发、50k 保留输出、
+// 20k 用户原话预算（head 2k）——与 Kimi DEFAULT_COMPACTION_CONFIG 一致。
+func DefaultCompactionConfig() CompactionConfig {
+	return CompactionConfig{
+		TriggerRatio:        0.85,
+		ReservedContextSize: 50_000,
+		KeptUserTokens:      20_000,
+		HeadUserTokens:      2_000,
+		MaxOverflowAttempts: 3,
+	}
+}
+
+// COMPACTION_SUMMARY_PREFIX 出现在摘要消息开头，让模型识别这是交接上下文。
+const COMPACTION_SUMMARY_PREFIX = "COMPACTION_SUMMARY: 以下是对更早对话的交接摘要，不是用户的真实输入。"
+
+// COMPACTION_ELISION_MARKER 填在 head 与 tail 之间，告知模型中间省略了什么。
+const COMPACTION_ELISION_MARKER = "[……中间的用户消息已省略，摘要见上……]"
+
+// ShouldCompact 判断是否需要压实。usedTokens 来自上一步真实 usage
+// （D3：不用 tokenizer；无 usage 时调用方传入估算值并把阈值放宽 10%）。
+func (c CompactionConfig) ShouldCompact(usedTokens, maxContext int64) bool {
+	if maxContext <= 0 || usedTokens <= 0 {
+		return false
+	}
+	if usedTokens >= int64(float64(maxContext)*c.TriggerRatio) {
+		return true
+	}
+	if c.ReservedContextSize > 0 && c.ReservedContextSize < maxContext {
+		return usedTokens+c.ReservedContextSize >= maxContext
+	}
+	return false
+}
+
+// Compact 是压实的纯函数核心：输入全部消息（与 origins 平行）与摘要生成器，
+// 输出压实后的 (消息, origins) 及统计。original 只读，不修改。
+//
+// 摘要生成器 summarizer 由宿主提供（调用一次 LLM，输入被折叠的消息文本）；
+// 它返回摘要文本。近似 token 用 EstimateTokens（字符/4）。
+func Compact(msgs []llm.Message, origins []Origin, summarizer func(dropped []llm.Message) (string, error), cfg CompactionConfig) ([]llm.Message, []Origin, CompactionStats, error) {
+	stats := CompactionStats{}
+	if len(msgs) != len(origins) {
+		return nil, nil, stats, ErrOriginMismatch
+	}
+
+	// 1. 挑选保留的用户原话（OriginUser 且有文本）。
+	type keptUser struct{ idx int }
+	var userMsgs []keptUser
+	for i, o := range origins {
+		if o == OriginUser && msgs[i].Text() != "" {
+			userMsgs = append(userMsgs, keptUser{idx: i})
+		}
+	}
+	stats.UserMessagesTotal = len(userMsgs)
+
+	// 2. 在预算内从最新往回保留（tail），再保证最老 HeadUserTokens（head）。
+	budget := cfg.KeptUserTokens
+	headBudget := cfg.HeadUserTokens
+	if headBudget >= budget {
+		headBudget = budget / 4
+	}
+	keptSet := map[int]bool{}
+	used := int64(0)
+	for i := len(userMsgs) - 1; i >= 0; i-- {
+		m := msgs[userMsgs[i].idx]
+		cost := llm.EstimateMessageTokens(m)
+		if used+cost > budget {
+			continue // 超预算的单条跳过（继续尝试更老的小消息）
+		}
+		keptSet[userMsgs[i].idx] = true
+		used += cost
+	}
+	// head：从最老开始，在 headBudget 内强制保留（可能与 tail 重叠）。
+	headUsed := int64(0)
+	headCount := 0
+	for _, u := range userMsgs {
+		if keptSet[u.idx] {
+			headCount++
+			continue
+		}
+		m := msgs[u.idx]
+		cost := llm.EstimateMessageTokens(m)
+		if headUsed+cost > headBudget {
+			break
+		}
+		keptSet[u.idx] = true
+		headUsed += cost
+		headCount++
+	}
+	if headCount > len(userMsgs) {
+		headCount = len(userMsgs)
+	}
+	stats.KeptUserMessages = len(keptSet)
+	stats.KeptHeadUserMessages = headCount
+
+	// 3. 收集被折叠的消息（非保留用户消息 + 全部 assistant/tool）。
+	var dropped []llm.Message
+	var droppedUserCount int
+	for i, m := range msgs {
+		if origins[i] == OriginUser && keptSet[i] {
+			continue
+		}
+		// 已有的摘要与省略标记不重复折叠（Kimi：markers never stack）。
+		if origins[i] == OriginSummary || origins[i] == OriginInjection {
+			continue
+		}
+		dropped = append(dropped, m)
+		if origins[i] == OriginUser {
+			droppedUserCount++
+		}
+	}
+	stats.CompactedCount = len(dropped)
+	stats.DroppedUserMessages = droppedUserCount
+
+	if len(dropped) == 0 {
+		// 没有可折叠内容：原样返回。
+		return msgs, origins, stats, nil
+	}
+
+	// 4. 生成摘要。
+	summary, err := summarizer(dropped)
+	if err != nil {
+		return nil, nil, stats, err
+	}
+
+	// 5. 组装新序列：head 用户原话 → 省略标记（若有跳过）→ tail 用户原话 → 摘要。
+	var out []llm.Message
+	var outOrigins []Origin
+	lastKeptIdx := -1
+	needElision := false
+	for i, m := range msgs {
+		if origins[i] != OriginUser || !keptSet[i] {
+			continue
+		}
+		if needElision && lastKeptIdx >= 0 && hasGapBetween(msgs, origins, lastKeptIdx, i) {
+			out = append(out, llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: COMPACTION_ELISION_MARKER}}})
+			outOrigins = append(outOrigins, OriginInjection)
+		}
+		out = append(out, m)
+		outOrigins = append(outOrigins, OriginUser)
+		lastKeptIdx = i
+		needElision = true
+	}
+	// 摘要消息（user 角色承载，但 Origin=summary；compaction 时不再重复折叠）。
+	out = append(out, llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: COMPACTION_SUMMARY_PREFIX + "\n\n" + summary}}})
+	outOrigins = append(outOrigins, OriginSummary)
+
+	stats.TokensBefore = llm.EstimateHistoryTokens(msgs)
+	stats.TokensAfter = llm.EstimateHistoryTokens(out)
+	return out, outOrigins, stats, nil
+}
+
+// hasGapBetween 判断两个保留用户消息之间是否存在被省略的用户消息。
+func hasGapBetween(msgs []llm.Message, origins []Origin, from, to int) bool {
+	for i := from + 1; i < to; i++ {
+		if origins[i] == OriginUser {
+			return true
+		}
+	}
+	return false
+}
+
+// CompactionStats 是一次压实的统计（遥测/事件用）。
+type CompactionStats struct {
+	UserMessagesTotal    int
+	KeptUserMessages     int
+	KeptHeadUserMessages int
+	CompactedCount       int
+	DroppedUserMessages  int
+	TokensBefore         int64
+	TokensAfter          int64
+}
+
+// CompactInPlace 对 CtxMemory 应用压实结果（宿主层在 BeforeStep hook 调用）。
+func (m *CtxMemory) CompactInPlace(msgs []llm.Message, origins []Origin, stats CompactionStats) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.msgs = msgs
+	m.origins = origins
+	m.userTurns = 0
+	for _, o := range origins {
+		if o == OriginUser {
+			m.userTurns++
+		}
+	}
+}
+
+// 错误定义。
+var ErrOriginMismatch = compactionError("agentkit: 消息与来源数组长度不一致")
+
+type compactionError string
+
+func (e compactionError) Error() string { return string(e) }
+
+// DropOldest 在摘要请求本身溢出时的兜底：从待摘要消息里砍掉最老的 n 条
+// （诚实统计 blind spot，Kimi droppedCount 语义）。
+func DropOldest(msgs []llm.Message, dropTokens int64) ([]llm.Message, int) {
+	used := int64(0)
+	i := 0
+	for ; i < len(msgs); i++ {
+		used += llm.EstimateMessageTokens(msgs[i])
+		if used > dropTokens {
+			break
+		}
+	}
+	if i >= len(msgs) {
+		return nil, len(msgs)
+	}
+	return msgs[i:], i
+}
+
+// CompactInputText 把被折叠的消息压成摘要器的输入文本（截断到预算）。
+func CompactInputText(dropped []llm.Message, maxChars int) string {
+	var b strings.Builder
+	for _, m := range dropped {
+		if b.Len() >= maxChars {
+			break
+		}
+		switch m.Role {
+		case llm.RoleUser, llm.RoleAssistant:
+			if txt := m.Text(); txt != "" {
+				b.WriteString(roleLabel(m.Role))
+				b.WriteString(": ")
+				b.WriteString(truncateRunes(txt, 2000))
+				b.WriteString("\n")
+			}
+			for _, tc := range m.ToolCalls {
+				b.WriteString("tool_call: " + tc.Name + "\n")
+			}
+		case llm.RoleTool:
+			b.WriteString("tool_result: ")
+			b.WriteString(truncateRunes(m.Text(), 500))
+			b.WriteString("\n")
+		}
+	}
+	if b.Len() > maxChars {
+		return b.String()[:maxChars] + "\n[输入过长已截断]"
+	}
+	return b.String()
+}
+
+func roleLabel(r llm.Role) string {
+	if r == llm.RoleUser {
+		return "user"
+	}
+	return "assistant"
+}
+
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}

--- a/internal/agentkit/compaction_test.go
+++ b/internal/agentkit/compaction_test.go
@@ -1,0 +1,228 @@
+package agentkit
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"grok_switch/internal/llm"
+)
+
+func userMsg(text string) llm.Message {
+	return llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: text}}}
+}
+
+func assistMsg(text string) llm.Message {
+	return llm.Message{Role: llm.RoleAssistant, Parts: []llm.ContentPart{llm.TextPart{Text: text}}}
+}
+
+func TestShouldCompactThresholds(t *testing.T) {
+	cfg := DefaultCompactionConfig()
+	if cfg.ShouldCompact(40000, 100000) {
+		t.Fatal("低于阈值且低于预留线不应触发")
+	}
+	if !cfg.ShouldCompact(86000, 100000) {
+		t.Fatal("超过 85% 应触发")
+	}
+	// 预留输出路径：60% + 50k 预留 ≥ 窗口。
+	if !cfg.ShouldCompact(60000, 100000) {
+		t.Fatal("60% + 预留 50k 应触发")
+	}
+	if cfg.ShouldCompact(0, 100000) || cfg.ShouldCompact(50000, 0) {
+		t.Fatal("未知窗口/零用量不触发")
+	}
+}
+
+func fakeSummarizer(summary string) func([]llm.Message) (string, error) {
+	return func(dropped []llm.Message) (string, error) {
+		return summary, nil
+	}
+}
+
+func TestCompactKeepsUserMessagesAndSummary(t *testing.T) {
+	// 序列：任务二超长（装不进预算），一/三/四短。保留 一+三+四，
+	// 一与三之间因跳过二而产生省略间隙。
+	msgs := []llm.Message{
+		userMsg("任务一修复登录"),
+		assistMsg("好的，我看一下"),
+		userMsg("任务二" + strings.Repeat("细节", 2000)),
+		assistMsg("测试已加"),
+		userMsg("任务三跑CI"),
+		assistMsg("CI 通过"),
+		userMsg("任务四交付"),
+		assistMsg("收到"),
+	}
+	origins := []Origin{OriginUser, OriginAssistant, OriginUser, OriginAssistant, OriginUser, OriginAssistant, OriginUser, OriginAssistant}
+
+	// tail 装下最近的短消息；长消息（任务四）装不下，head 保住最老的。
+	cfg := CompactionConfig{TriggerRatio: 0.85, KeptUserTokens: 12, HeadUserTokens: 4}
+	out, outOrigins, stats, err := Compact(msgs, origins, fakeSummarizer("摘要：之前做了登录修复与测试。"), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.CompactedCount == 0 {
+		t.Fatalf("应有折叠: %+v", stats)
+	}
+	// 结构：全部保留项都是 user 原话或摘要/省略标记。
+	var keptUsers, summaries, elisions int
+	for i, m := range out {
+		switch outOrigins[i] {
+		case OriginUser:
+			keptUsers++
+			if !strings.HasPrefix(m.Text(), "任务") {
+				t.Fatalf("保留的应是用户原话: %q", m.Text())
+			}
+		case OriginSummary:
+			summaries++
+			if !strings.HasPrefix(m.Text(), COMPACTION_SUMMARY_PREFIX) {
+				t.Fatalf("摘要应带前缀: %q", m.Text())
+			}
+		case OriginInjection:
+			elisions++
+			if m.Text() != COMPACTION_ELISION_MARKER {
+				t.Fatalf("省略标记错误: %q", m.Text())
+			}
+		default:
+			t.Fatalf("assistant/tool 消息不应保留: %v", outOrigins[i])
+		}
+	}
+	if summaries != 1 {
+		t.Fatalf("应恰好 1 条摘要, got %d", summaries)
+	}
+	if keptUsers < 2 {
+		t.Fatalf("head+tail 应至少保留 2 条: %d", keptUsers)
+	}
+	if elisions < 1 {
+		t.Fatalf("head 与 tail 之间应有省略标记: %d", elisions)
+	}
+	// 最新可保留的用户消息必须在 tail 中（任务四超预算除外，tail 至少含任务三）。
+	foundRecent := false
+	for _, m := range out {
+		if strings.HasPrefix(m.Text(), "任务三") {
+			foundRecent = true
+		}
+	}
+	if !foundRecent {
+		t.Fatalf("tail 应含任务三: %v", outOrigins)
+	}
+	// token 收缩。
+	if stats.TokensAfter >= stats.TokensBefore {
+		t.Fatalf("压实后应更小: %d → %d", stats.TokensBefore, stats.TokensAfter)
+	}
+}
+
+func TestCompactNoDropped(t *testing.T) {
+	msgs := []llm.Message{userMsg("只有一条")}
+	origins := []Origin{OriginUser}
+	out, outOrigins, stats, err := Compact(msgs, origins, fakeSummarizer("不应调用"), DefaultCompactionConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || outOrigins[0] != OriginUser || stats.CompactedCount != 0 {
+		t.Fatalf("无可折叠内容应原样返回: %+v", stats)
+	}
+}
+
+func TestCompactSummarizerError(t *testing.T) {
+	msgs := []llm.Message{userMsg("u1"), assistMsg("a1"), userMsg("u2")}
+	origins := []Origin{OriginUser, OriginAssistant, OriginUser}
+	_, _, _, err := Compact(msgs, origins, func([]llm.Message) (string, error) {
+		return "", errors.New("llm down")
+	}, CompactionConfig{KeptUserTokens: 1, HeadUserTokens: 1})
+	if err == nil {
+		t.Fatal("摘要失败应上抛")
+	}
+}
+
+func TestCompactMarkersNeverStack(t *testing.T) {
+	// 已有摘要与省略标记的消息在下次压实时直接跳过，不进摘要输入。
+	summaryMsg := llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: COMPACTION_SUMMARY_PREFIX + "\n旧摘要"}}}
+	elision := llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: COMPACTION_ELISION_MARKER}}}
+	msgs := []llm.Message{
+		summaryMsg, elision,
+		userMsg("新任务一"), assistMsg("ok"),
+		userMsg("新任务二"),
+	}
+	origins := []Origin{OriginSummary, OriginInjection, OriginUser, OriginAssistant, OriginUser}
+
+	var seen []llm.Message
+	summarizer := func(dropped []llm.Message) (string, error) {
+		seen = dropped
+		return "新摘要", nil
+	}
+	out, outOrigins, _, err := Compact(msgs, origins, summarizer, CompactionConfig{KeptUserTokens: 2, HeadUserTokens: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = out
+	// 摘要输入不含旧摘要/标记。
+	for _, m := range seen {
+		if strings.Contains(m.Text(), "旧摘要") || m.Text() == COMPACTION_ELISION_MARKER {
+			t.Fatalf("旧摘要/标记不应进摘要输入: %q", m.Text())
+		}
+	}
+	// 输出恰好一条摘要（没有堆叠）。
+	count := 0
+	for _, o := range outOrigins {
+		if o == OriginSummary {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("摘要不应堆叠: %d", count)
+	}
+}
+
+func TestCompactInPlaceAndRestore(t *testing.T) {
+	mem := NewCtxMemory()
+	mem.AppendWithOrigin(userMsg(strings.Repeat("第一轮问题", 100)), OriginUser)
+	mem.AppendWithOrigin(assistMsg("a1"), OriginAssistant)
+	mem.AppendWithOrigin(userMsg(strings.Repeat("第二轮问题", 100)), OriginUser)
+
+	// 预算只够保留最新一条用户原话。
+	msgs, origins := mem.Snapshot()
+	out, outOrigins, _, err := Compact(msgs, origins, fakeSummarizer("s"), CompactionConfig{KeptUserTokens: 400, HeadUserTokens: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem.CompactInPlace(out, outOrigins, CompactionStats{})
+	if mem.UserTurns() != 1 {
+		t.Fatalf("压实后轮次错误: %d", mem.UserTurns())
+	}
+	if len(mem.History()) != len(out) {
+		t.Fatal("压实未生效")
+	}
+}
+
+func TestDropOldest(t *testing.T) {
+	msgs := []llm.Message{
+		userMsg(strings.Repeat("x", 400)), // ~100 tokens
+		userMsg(strings.Repeat("y", 400)),
+		userMsg("tail"),
+	}
+	rest, dropped := DropOldest(msgs, 150)
+	if dropped != 1 || len(rest) != 2 {
+		t.Fatalf("DropOldest 错误: dropped=%d rest=%d", dropped, len(rest))
+	}
+	if rest[len(rest)-1].Text() != "tail" {
+		t.Fatal("tail 不应被砍")
+	}
+}
+
+func TestCompactInputText(t *testing.T) {
+	dropped := []llm.Message{
+		userMsg("用户的问题"),
+		assistMsg("回答内容"),
+		{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: "c", Name: "read"}}},
+		{Role: llm.RoleTool, ToolCallID: "c", Parts: []llm.ContentPart{llm.TextPart{Text: strings.Repeat("结果", 600)}}},
+	}
+	text := CompactInputText(dropped, 5000)
+	if !strings.Contains(text, "user: 用户的问题") || !strings.Contains(text, "tool_call: read") {
+		t.Fatalf("摘要输入缺关键内容:\n%s", text)
+	}
+	// 超长截断。
+	long := CompactInputText([]llm.Message{userMsg(strings.Repeat("长", 9000))}, 1000)
+	if len(long) > 1100 {
+		t.Fatalf("未截断: %d", len(long))
+	}
+}

--- a/internal/agentkit/memory.go
+++ b/internal/agentkit/memory.go
@@ -1,0 +1,196 @@
+// Package agentkit 是原生引擎的会话宿主层：上下文记忆（PromptOrigin 标记）、
+// 会话持久化（meta.json + transcript.jsonl）与生命周期。
+// server 层的 nativeAgentService 组合本包与 agentloop 实现完整服务。
+package agentkit
+
+import (
+	"sync"
+	"time"
+
+	"grok_switch/internal/llm"
+)
+
+// Origin 标记消息来源（设计文档 D1b/§6.4：compaction 与回放的根基）。
+// 压实时只保留 OriginUser 原话；injection/system 类可重建，直接丢弃。
+type Origin string
+
+const (
+	OriginUser      Origin = "user"      // 真实用户输入
+	OriginAssistant Origin = "assistant" // 模型回复
+	OriginTool      Origin = "tool"      // 工具结果
+	OriginInjection Origin = "injection" // 注入的系统内容（bootstrap、reminder）
+	OriginSummary   Origin = "summary"   // compaction 摘要
+)
+
+// Record 是持久化 transcript 的一条记录。
+type Record struct {
+	Seq        int64          `json:"seq"`
+	Time       time.Time      `json:"time"`
+	Origin     Origin         `json:"origin"`
+	Role       llm.Role       `json:"role"`
+	Text       string         `json:"text,omitempty"`
+	Thinking   string         `json:"thinking,omitempty"`
+	ToolCalls  []llm.ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	// Media 引用（路径或 URI，不落 base64 大对象）。
+	Media []MediaRef `json:"media,omitempty"`
+	// TurnID 归属的引擎 turn。
+	TurnID string `json:"turn_id,omitempty"`
+	// UserTurnCount 是截至该记录的用户轮次（rewind 定位用）。
+	UserTurn int `json:"user_turn,omitempty"`
+}
+
+// MediaRef 是媒体附件的持久化引用。
+type MediaRef struct {
+	Kind     string `json:"kind"` // image | video | audio | resource
+	MimeType string `json:"mime_type,omitempty"`
+	URI      string `json:"uri,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+// ToMessage 把记录转回统一消息（回放进 ctxmem）。
+func (r Record) ToMessage() llm.Message {
+	msg := llm.Message{Role: r.Role, ToolCallID: r.ToolCallID}
+	if r.Text != "" {
+		msg.Parts = append(msg.Parts, llm.TextPart{Text: r.Text})
+	}
+	for _, m := range r.Media {
+		if m.URI != "" {
+			msg.Parts = append(msg.Parts, llm.ImagePart{URI: m.URI, MimeType: m.MimeType})
+		}
+	}
+	msg.ToolCalls = append(msg.ToolCalls, r.ToolCalls...)
+	return msg
+}
+
+// CtxMemory 实现 agentloop.Memory：引擎自持历史（D1b 无状态重放）。
+// 记录带 Origin；P6 的 compaction 在 History() 出口投影，当前为直通。
+type CtxMemory struct {
+	mu      sync.Mutex
+	msgs    []llm.Message
+	origins []Origin
+	// userTurns 计数用户轮次（每次 Append OriginUser 消息时 +1）。
+	userTurns int
+}
+
+func NewCtxMemory() *CtxMemory { return &CtxMemory{} }
+
+// History 实现 agentloop.Memory。
+func (m *CtxMemory) History() []llm.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]llm.Message, len(m.msgs))
+	copy(out, m.msgs)
+	return out
+}
+
+// Append 实现 agentloop.Memory：来源按角色推导（引擎写入的只有
+// assistant 回复与 tool 结果）。
+func (m *CtxMemory) Append(msg llm.Message) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.msgs = append(m.msgs, msg)
+	origin := OriginAssistant
+	if msg.Role == llm.RoleTool {
+		origin = OriginTool
+	} else if msg.Role == llm.RoleUser {
+		origin = OriginUser
+	}
+	m.origins = append(m.origins, origin)
+	if msg.Role == llm.RoleUser {
+		m.userTurns++
+	}
+}
+
+// AppendWithOrigin 追加并记录来源（宿主层写入用户消息/注入时使用）。
+func (m *CtxMemory) AppendWithOrigin(msg llm.Message, origin Origin) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.msgs = append(m.msgs, msg)
+	m.origins = append(m.origins, origin)
+	if origin == OriginUser {
+		m.userTurns++
+	}
+	return len(m.msgs) - 1
+}
+
+// UserTurns 返回当前用户轮次。
+func (m *CtxMemory) UserTurns() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.userTurns
+}
+
+// RewindToUserTurn 删除第 n 轮用户消息及其后的全部内容。
+// 返回是否发生截断。n 为 1 起；n <= 0 无操作。
+func (m *CtxMemory) RewindToUserTurn(n int) bool {
+	if n <= 0 {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	seen := 0
+	cut := -1
+	for i, msg := range m.msgs {
+		if msg.Role == llm.RoleUser {
+			seen++
+			if seen == n {
+				cut = i
+				break
+			}
+		}
+	}
+	if cut < 0 {
+		// 定位不到该轮次（越界）：视为回退到末尾，无操作。
+		return true
+	}
+	// 截断 origins 与 msgs 保持平行；rewind 后按剩余来源重算用户轮次。
+	if len(m.origins) >= cut {
+		m.origins = m.origins[:cut]
+	}
+	m.msgs = m.msgs[:cut]
+	turns := 0
+	for _, o := range m.origins {
+		if o == OriginUser {
+			turns++
+		}
+	}
+	m.userTurns = turns
+	return true
+}
+
+// Origins 返回与 History 平行的来源标记（持久化用）。
+func (m *CtxMemory) Origins() []Origin {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Origin, len(m.origins))
+	copy(out, m.origins)
+	return out
+}
+
+// Snapshot 返回 (消息, 来源) 平行数组副本。
+func (m *CtxMemory) Snapshot() ([]llm.Message, []Origin) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	msgs := make([]llm.Message, len(m.msgs))
+	copy(msgs, m.msgs)
+	origins := make([]Origin, len(m.origins))
+	copy(origins, m.origins)
+	return msgs, origins
+}
+
+// Restore 用持久化记录重建内存（不触发 userTurns 计数副作用时手动同步）。
+func (m *CtxMemory) Restore(records []Record) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.msgs = m.msgs[:0]
+	m.origins = m.origins[:0]
+	m.userTurns = 0
+	for _, r := range records {
+		m.msgs = append(m.msgs, r.ToMessage())
+		m.origins = append(m.origins, r.Origin)
+		if r.Origin == OriginUser {
+			m.userTurns++
+		}
+	}
+}

--- a/internal/agentkit/store.go
+++ b/internal/agentkit/store.go
@@ -1,0 +1,279 @@
+package agentkit
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"grok_switch/internal/llm"
+)
+
+// Store 管理会话目录：~/.grok_switch/agent2/sessions/<id>/
+//
+//	meta.json       轻量元数据（列表 API 直接读，不解析 transcript）
+//	transcript.jsonl 事件追加记录（回放/恢复）
+type Store struct {
+	root string
+	mu   sync.Mutex
+}
+
+// SessionMeta 是 meta.json 的内容与列表返回结构（字段与
+// agentbridge.SessionSummary 对齐，server 层直接映射）。
+type SessionMeta struct {
+	ID           string    `json:"id"`
+	Title        string    `json:"title"`
+	Cwd          string    `json:"cwd"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Model        string    `json:"model,omitempty"`
+	Engine       string    `json:"engine"` // 固定 "native"
+	MessageCount int       `json:"message_count"`
+	UserTurns    int       `json:"user_turns"`
+}
+
+// NewStore 打开会话存储根目录。
+func NewStore(root string) (*Store, error) {
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, fmt.Errorf("agentkit: 创建会话目录失败: %w", err)
+	}
+	return &Store{root: root}, nil
+}
+
+func (s *Store) sessionDir(id string) string {
+	return filepath.Join(s.root, sanitizeID(id))
+}
+
+// sanitizeID 防路径穿越：只允许字母数字与连字符下划线。
+func sanitizeID(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if out == "" {
+		out = "unnamed"
+	}
+	return out
+}
+
+// Create 新建会话并写入初始 meta。
+func (s *Store) Create(meta SessionMeta) (SessionMeta, error) {
+	if meta.ID == "" {
+		meta.ID = newSessionID()
+	}
+	meta.Engine = "native"
+	meta.CreatedAt = time.Now()
+	meta.UpdatedAt = meta.CreatedAt
+	dir := s.sessionDir(meta.ID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return SessionMeta{}, err
+	}
+	if err := s.writeMeta(meta); err != nil {
+		return SessionMeta{}, err
+	}
+	// 空 transcript 占位。
+	f, err := os.OpenFile(s.transcriptPath(meta.ID), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return SessionMeta{}, err
+	}
+	f.Close()
+	return meta, nil
+}
+
+// Exists 判断会话是否存在。
+func (s *Store) Exists(id string) bool {
+	_, err := os.Stat(s.metaPath(id))
+	return err == nil
+}
+
+// GetMeta 读取单个会话 meta。
+func (s *Store) GetMeta(id string) (SessionMeta, error) {
+	data, err := os.ReadFile(s.metaPath(id))
+	if err != nil {
+		return SessionMeta{}, err
+	}
+	var meta SessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return SessionMeta{}, fmt.Errorf("agentkit: meta 解析失败: %w", err)
+	}
+	return meta, nil
+}
+
+// List 返回全部会话（UpdatedAt 倒序）。limit<=0 表示全部。
+func (s *Store) List(limit int) ([]SessionMeta, error) {
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return nil, err
+	}
+	var out []SessionMeta
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		meta, err := s.GetMeta(e.Name())
+		if err != nil {
+			continue // 损坏条目跳过（corrupt 语义与 profiles 一致：不静默删）
+		}
+		out = append(out, meta)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].UpdatedAt.After(out[j].UpdatedAt) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// Touch 更新 meta 的可变字段并落盘。
+func (s *Store) Touch(id string, fn func(*SessionMeta)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	meta, err := s.GetMeta(id)
+	if err != nil {
+		return err
+	}
+	fn(&meta)
+	meta.UpdatedAt = time.Now()
+	return s.writeMeta(meta)
+}
+
+// Rename 设置标题。
+func (s *Store) Rename(id, title string) error {
+	return s.Touch(id, func(m *SessionMeta) { m.Title = title })
+}
+
+// Delete 删除整个会话目录。
+func (s *Store) Delete(id string) error {
+	return os.RemoveAll(s.sessionDir(id))
+}
+
+// AppendRecord 追加一条 transcript 记录（同步 flush，进程崩溃最多丢一行）。
+// 同时递增 meta.MessageCount 并更新 UpdatedAt。
+func (s *Store) AppendRecord(id string, rec Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if rec.Time.IsZero() {
+		rec.Time = time.Now()
+	}
+	f, err := os.OpenFile(s.transcriptPath(id), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	// Seq 取当前行数（简化：读现有记录数由调用方维护；这里用文件行数）。
+	rec.Seq = int64(countLines(s.transcriptPath(id))) + 1
+	b, err := json.Marshal(rec)
+	if err != nil {
+		f.Close()
+		return err
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	meta, err := s.GetMeta(id)
+	if err != nil {
+		return err
+	}
+	meta.MessageCount++
+	meta.UpdatedAt = time.Now()
+	return s.writeMeta(meta)
+}
+
+// LoadRecords 读回全部记录（恢复/回放）。
+func (s *Store) LoadRecords(id string) ([]Record, error) {
+	f, err := os.Open(s.transcriptPath(id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	var out []Record
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 256*1024), 8<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var rec Record
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue // 损坏行跳过
+		}
+		out = append(out, rec)
+	}
+	return out, scanner.Err()
+}
+
+// RecordsToMessages 把记录投影成回放消息（server 层组装 SessionHistory 用）。
+func RecordsToMessages(records []Record) []Record {
+	// 过滤空 assistant（纯 tool_call 载体）→ 保留：UI 需要渲染工具调用。
+	return records
+}
+
+func (s *Store) metaPath(id string) string {
+	return filepath.Join(s.sessionDir(id), "meta.json")
+}
+
+func (s *Store) transcriptPath(id string) string {
+	return filepath.Join(s.sessionDir(id), "transcript.jsonl")
+}
+
+func (s *Store) writeMeta(meta SessionMeta) error {
+	b, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWriteJSON(s.metaPath(meta.ID), b)
+}
+
+func countLines(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+func atomicWriteJSON(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".meta-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func newSessionID() string {
+	return fmt.Sprintf("nat-%d", time.Now().UnixNano())
+}
+
+var _ = llm.Role("")

--- a/internal/agentloop/events.go
+++ b/internal/agentloop/events.go
@@ -1,0 +1,146 @@
+package agentloop
+
+import (
+	"encoding/json"
+	"sync"
+
+	"grok_switch/internal/llm"
+)
+
+// EventType 是引擎事件类型。命名对齐现有 agentbridge.Event 的前端协议，
+// 尽量让 server 层做最小翻译即可推给浏览器。
+type EventType string
+
+const (
+	EventTurnBegin     EventType = "turn_begin"
+	EventStepBegin     EventType = "step_begin"
+	EventStepEnd       EventType = "step_end"
+	EventTextDelta     EventType = "text_delta"
+	EventThinkDelta    EventType = "think_delta"
+	EventToolCall      EventType = "tool_call"
+	EventToolResult    EventType = "tool_result"
+	EventTurnEnd       EventType = "turn_end"
+	EventTurnInterrupt EventType = "turn_interrupted"
+	EventUsage         EventType = "usage"
+	EventError         EventType = "error"
+)
+
+// Event 是引擎的单出口事件。录制器与直播订阅者收到的是同一个值。
+type Event struct {
+	Type EventType `json:"type"`
+
+	TurnID  string `json:"turn_id,omitempty"`
+	Step    int    `json:"step,omitempty"`
+	Session string `json:"session,omitempty"`
+
+	// 文本增量 / 完整文本
+	Text string `json:"text,omitempty"`
+	// 思考增量
+	Think string `json:"think,omitempty"`
+
+	// 工具事件
+	ToolCall   *ToolCallEvent   `json:"tool,omitempty"`
+	ToolResult *ToolResultEvent `json:"tool_result,omitempty"`
+
+	// 结束原因与错误
+	StopReason TurnStopReason `json:"stop_reason,omitempty"`
+	Error      string         `json:"error,omitempty"`
+
+	// 用量
+	Usage *llm.TokenUsage `json:"usage,omitempty"`
+	// UsageAccuracy 见 llm.UsageAccuracy
+	UsageAccuracy string `json:"usage_accuracy,omitempty"`
+}
+
+// ToolCallEvent 描述模型发起的一次工具调用。
+type ToolCallEvent struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// ToolResultEvent 描述一次工具执行结果。
+type ToolResultEvent struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Output    string `json:"output,omitempty"`
+	IsError   bool   `json:"is_error,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// Dispatcher 是事件单出口。Dispatch 必须非阻塞且不 panic 外泄。
+type Dispatcher interface {
+	Dispatch(Event)
+}
+
+// Broadcaster 是 Dispatcher 的默认实现：录制器 + N 个直播订阅。
+// 订阅者慢速时丢弃其事件（带计数），绝不阻塞 loop。
+type Broadcaster struct {
+	mu        sync.Mutex
+	recorders []Dispatcher
+	live      map[int]chan Event
+	nextID    int
+	dropped   int
+}
+
+func NewBroadcaster() *Broadcaster {
+	return &Broadcaster{live: map[int]chan Event{}}
+}
+
+// AddRecorder 注册持久化订阅（不丢事件，同步调用）。
+func (b *Broadcaster) AddRecorder(d Dispatcher) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.recorders = append(b.recorders, d)
+}
+
+// Subscribe 注册直播订阅，返回订阅 ID 与事件 chan。缓冲满即丢事件。
+func (b *Broadcaster) Subscribe(buffer int) (int, <-chan Event) {
+	if buffer < 16 {
+		buffer = 16
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	id := b.nextID
+	b.nextID++
+	ch := make(chan Event, buffer)
+	b.live[id] = ch
+	return id, ch
+}
+
+// Unsubscribe 注销直播订阅。
+func (b *Broadcaster) Unsubscribe(id int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if ch, ok := b.live[id]; ok {
+		close(ch)
+		delete(b.live, id)
+	}
+}
+
+// Dropped 返回直播丢弃的事件总数（可观测性）。
+func (b *Broadcaster) Dropped() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.dropped
+}
+
+func (b *Broadcaster) Dispatch(ev Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, r := range b.recorders {
+		r.Dispatch(ev)
+	}
+	for _, ch := range b.live {
+		select {
+		case ch <- ev:
+		default:
+			b.dropped++
+		}
+	}
+}
+
+// FuncDispatcher 用函数适配 Dispatcher 接口。
+type FuncDispatcher func(Event)
+
+func (f FuncDispatcher) Dispatch(ev Event) { f(ev) }

--- a/internal/agentloop/ports.go
+++ b/internal/agentloop/ports.go
@@ -1,0 +1,95 @@
+package agentloop
+
+import (
+	"context"
+
+	"grok_switch/internal/llm"
+)
+
+// ToolExecutor 是工具执行器接口：工具表持有者 + 执行入口。
+// internal/tools 的注册表实现它；测试用假工具实现它。
+type ToolExecutor interface {
+	// Execute 执行一次工具调用。返回结果或错误；错误会被包装成 IsError
+	// 的 ToolResult 回给模型（工具失败不终止 turn）。
+	Execute(ctx context.Context, call llm.ToolCall) (ToolResult, error)
+	// Schemas 返回当前步可用的工具定义（每步重查，支持运行时增减）。
+	Schemas() []llm.Tool
+}
+
+// Decision 是权限决定。
+type Decision string
+
+const (
+	DecAllow Decision = "allow"
+	DecDeny  Decision = "deny"
+	DecAsk   Decision = "ask"
+)
+
+// PermResult 是 WaitForDecision 的结果。
+type PermResult struct {
+	Decision Decision
+	// Reason 拒绝时回给模型的原因（用户反馈）。
+	Reason string
+}
+
+// PermissionGate 是权限闸。Check 在每次工具执行前调用：
+//   - allow：直接执行；
+//   - deny：返回拒绝结果给模型（不执行）；
+//   - ask：调用 WaitForDecision 挂起，等待宿主（server 层）回填决定。
+type PermissionGate interface {
+	Check(call llm.ToolCall) Decision
+	// WaitForDecision 挂起等待人工审批。ctx 被取消（用户取消 turn）时
+	// 返回 deny 决定。宿主通过返回值回填决定。
+	WaitForDecision(ctx context.Context, call llm.ToolCall) PermResult
+}
+
+// Hooks 是宿主层挂点（对齐 Kimi LoopHooks 的最小集）。
+type Hooks struct {
+	// BeforeStep 在每步消息构建前调用（compaction 的切入点）。
+	// 返回错误会终止 turn。
+	BeforeStep func(ctx context.Context, step int) error
+	// ShouldContinueAfterStop 在模型给出非 tool_use 终止后询问是否续跑
+	//（goal mode / 用户追加指令的场景）。默认不续。
+	ShouldContinueAfterStop func(ctx context.Context, in ContinueCheck) bool
+}
+
+// ContinueCheck 是 ShouldContinueAfterStop 的入参。
+type ContinueCheck struct {
+	Step       int
+	StopReason StepStopReason
+	Usage      llm.TokenUsage
+}
+
+// RunTurnInput 是 RunTurn 的全部依赖。
+type RunTurnInput struct {
+	TurnID string
+	// Provider 是模型后端（已由 server 层按 Profile 构造）。
+	Provider llm.Provider
+	// SystemPrompt 系统提示词。
+	SystemPrompt string
+	// Memory 是上下文记忆持有者（引擎自持历史，D1b）。
+	Memory Memory
+	// Tools 工具执行器；nil 表示纯对话。
+	Tools ToolExecutor
+	// PermGate 权限闸；nil 表示全放行（仅测试用）。
+	PermGate PermissionGate
+	// Events 事件出口；nil 丢弃全部事件。
+	Events Dispatcher
+	// MaxSteps 单 turn 步数上限；0 用默认 100。
+	MaxSteps int
+	// MaxRetries 可重试错误的最大尝试次数；0 用默认 3。
+	MaxRetries int
+	// Hooks 可选挂点。
+	Hooks Hooks
+	// Effort 覆盖推理强度；空用 Provider 当前值。
+	Effort string
+}
+
+// Memory 是上下文记忆接口：引擎通过它读写历史。internal/ctxmem 实现它，
+// 测试用内存切片实现。
+type Memory interface {
+	// History 返回当前 model-visible 全量历史（每步重建，D1b）。
+	History() []llm.Message
+	// Append 追加一条消息（user 输入 / assistant 回复 / 工具结果）。
+	Append(msg llm.Message)
+}

--- a/internal/agentloop/recorder.go
+++ b/internal/agentloop/recorder.go
@@ -1,0 +1,102 @@
+package agentloop
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// JSONLRecorder 把事件流按行追加写入 JSONL 文件（transcript 持久化的雏形）。
+// 每次 Dispatch 同步 flush——引擎事件频率低（步/工具粒度），吞吐不是瓶颈，
+// 换取进程崩溃时最多丢一行。
+type JSONLRecorder struct {
+	mu   sync.Mutex
+	file *os.File
+	w    *bufio.Writer
+}
+
+// NewJSONLRecorder 打开（或创建）录制文件。目录不存在会自动创建。
+func NewJSONLRecorder(path string) (*JSONLRecorder, error) {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("agentloop: 创建录制目录失败: %w", err)
+		}
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("agentloop: 打开录制文件失败: %w", err)
+	}
+	return &JSONLRecorder{file: f, w: bufio.NewWriter(f)}, nil
+}
+
+func (r *JSONLRecorder) Dispatch(ev Event) {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.w == nil {
+		return
+	}
+	r.w.Write(b)
+	r.w.WriteByte('\n')
+	r.w.Flush()
+}
+
+// Close 落盘并关闭文件。
+func (r *JSONLRecorder) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.w == nil {
+		return nil
+	}
+	flushErr := r.w.Flush()
+	file := r.file
+	r.w = nil
+	r.file = nil
+	if flushErr != nil {
+		file.Close()
+		return flushErr
+	}
+	return file.Close()
+}
+
+// MemoryRecorder 把事件收进内存切片（测试用）。
+type MemoryRecorder struct {
+	mu     sync.Mutex
+	Events []Event
+}
+
+func (m *MemoryRecorder) Dispatch(ev Event) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Events = append(m.Events, ev)
+}
+
+// Snapshot 返回事件副本。
+func (m *MemoryRecorder) Snapshot() []Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Event, len(m.Events))
+	copy(out, m.Events)
+	return out
+}
+
+// FilterTypes 按类型筛选快照。
+func (m *MemoryRecorder) FilterTypes(types ...EventType) []Event {
+	want := map[EventType]bool{}
+	for _, t := range types {
+		want[t] = true
+	}
+	var out []Event
+	for _, ev := range m.Snapshot() {
+		if want[ev.Type] {
+			out = append(out, ev)
+		}
+	}
+	return out
+}

--- a/internal/agentloop/recorder_test.go
+++ b/internal/agentloop/recorder_test.go
@@ -1,0 +1,152 @@
+package agentloop
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"grok_switch/internal/llm"
+)
+
+func TestJSONLRecorderRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "turn.jsonl")
+	rec, err := NewJSONLRecorder(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec.Dispatch(Event{Type: EventTurnBegin, TurnID: "t1"})
+	rec.Dispatch(Event{Type: EventTextDelta, TurnID: "t1", Text: "你好"})
+	u := llm.TokenUsage{InputOther: 5, Output: 3}
+	rec.Dispatch(Event{Type: EventUsage, TurnID: "t1", Usage: &u, UsageAccuracy: string(llm.UsageExact)})
+	rec.Dispatch(Event{Type: EventToolCall, TurnID: "t1", ToolCall: &ToolCallEvent{ID: "c1", Name: "read", Arguments: json.RawMessage(`{"path":"a.go"}`)}})
+	if err := rec.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// 逐行读回并验证事件完整。
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var events []Event
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var ev Event
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			t.Fatalf("行解析失败: %v", err)
+		}
+		events = append(events, ev)
+	}
+	if len(events) != 4 {
+		t.Fatalf("应有 4 行, got %d", len(events))
+	}
+	if events[1].Text != "你好" {
+		t.Fatalf("文本丢失: %+v", events[1])
+	}
+	if events[2].Usage == nil || events[2].Usage.InputOther != 5 {
+		t.Fatalf("usage 丢失: %+v", events[2])
+	}
+	if events[3].ToolCall == nil || events[3].ToolCall.Name != "read" {
+		t.Fatalf("工具事件丢失: %+v", events[3])
+	}
+}
+
+func TestJSONLRecorderAppendMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "turn.jsonl")
+	rec1, _ := NewJSONLRecorder(path)
+	rec1.Dispatch(Event{Type: EventTurnBegin, TurnID: "t1"})
+	rec1.Close()
+
+	rec2, _ := NewJSONLRecorder(path)
+	rec2.Dispatch(Event{Type: EventTurnEnd, TurnID: "t1"})
+	rec2.Close()
+
+	data, _ := os.ReadFile(path)
+	lines := strings.Count(strings.TrimSpace(string(data)), "\n") + 1
+	if lines != 2 {
+		t.Fatalf("重开应追加而非覆盖: %d 行", lines)
+	}
+}
+
+func TestBroadcasterDropAndRecord(t *testing.T) {
+	b := NewBroadcaster()
+	rec := &MemoryRecorder{}
+	b.AddRecorder(rec)
+
+	// Subscribe 下限 16 缓冲：灌 20 条，超出 16 的部分应被丢弃且不影响录制。
+	_, ch := b.Subscribe(4)
+	for i := 0; i < 20; i++ {
+		b.Dispatch(Event{Type: EventTextDelta, Text: "x"})
+	}
+	// 录制器 20 条全在。
+	if got := len(rec.FilterTypes(EventTextDelta)); got != 20 {
+		t.Fatalf("录制器不应丢事件: %d", got)
+	}
+	if b.Dropped() != 4 {
+		t.Fatalf("直播应丢弃 4 条, got %d", b.Dropped())
+	}
+	// 缓冲内前 16 条可读。
+	drained := 0
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				drained = -1
+			} else {
+				drained++
+			}
+			continue
+		default:
+		}
+		break
+	}
+	if drained != 16 {
+		t.Fatalf("直播应缓冲 16 条, got %d", drained)
+	}
+	b.Unsubscribe(0)
+	// 注销后再派发不应 panic。
+	b.Dispatch(Event{Type: EventTurnEnd})
+}
+
+func TestBroadcasterUnsubscribeTwice(t *testing.T) {
+	b := NewBroadcaster()
+	id, _ := b.Subscribe(4)
+	b.Unsubscribe(id)
+	b.Unsubscribe(id) // 幂等
+}
+
+func TestTurnInterruptedEventCarriesError(t *testing.T) {
+	prov := &scriptProvider{
+		steps:    []llm.StreamResult{textResult("never")},
+		failures: []error{llm.NewAPIError("auth", 401, "expired", 0)},
+	}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "x"}}}}}
+	rec := &MemoryRecorder{}
+	_, _ = RunTurn(context.Background(), RunTurnInput{TurnID: "tE", Provider: prov, Memory: mem, Events: rec})
+
+	interrupted := rec.FilterTypes(EventTurnInterrupt)
+	if len(interrupted) != 1 {
+		t.Fatalf("应有 1 条中断事件: %d", len(interrupted))
+	}
+	if interrupted[0].StopReason != TurnError || interrupted[0].Error == "" {
+		t.Fatalf("中断事件应带原因与错误: %+v", interrupted[0])
+	}
+	if interrupted[0].TurnID != "tE" {
+		t.Fatalf("turn_id 缺失: %+v", interrupted[0])
+	}
+}
+
+func TestToolResultJSONShape(t *testing.T) {
+	r := ToolResult{Output: "data", IsError: true, Truncated: true}
+	if !contains(r.ResultJSON(), `"error":true`) || !contains(r.ResultJSON(), `"truncated":true`) || !contains(r.ResultJSON(), `"output":"data"`) {
+		t.Fatalf("JSON 形态错误: %s", r.ResultJSON())
+	}
+}

--- a/internal/agentloop/run_turn.go
+++ b/internal/agentloop/run_turn.go
@@ -1,0 +1,350 @@
+package agentloop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"strings"
+	"time"
+
+	"grok_switch/internal/llm"
+)
+
+const (
+	defaultMaxSteps  = 100
+	defaultMaxRetry  = 3
+	baseRetryBackoff = 750 * time.Millisecond
+	maxRetryBackoff  = 30 * time.Second
+)
+
+// RunTurn 运行一个完整 turn：循环执行「模型步 → 工具执行」直到非 tool_use
+// 终止、abort、或步数耗尽（对应 Kimi run-turn.ts 的收敛职责）。
+func RunTurn(ctx context.Context, in RunTurnInput) (TurnResult, error) {
+	maxSteps := in.MaxSteps
+	if maxSteps <= 0 {
+		maxSteps = defaultMaxSteps
+	}
+	maxRetry := in.MaxRetries
+	if maxRetry <= 0 {
+		maxRetry = defaultMaxRetry
+	}
+
+	var usage llm.TokenUsage
+	steps := 0
+	stopReason := TurnEnd
+	var turnErr error
+
+	emit := func(ev Event) {
+		if in.Events != nil {
+			ev.TurnID = in.TurnID
+			in.Events.Dispatch(ev)
+		}
+	}
+
+	emit(Event{Type: EventTurnBegin})
+
+	// 主循环：abort 检查在循环边界。
+	for {
+		if err := ctx.Err(); err != nil {
+			reason := TurnAborted
+			if errors.Is(err, context.Canceled) {
+				reason = TurnUserAbort
+			}
+			stopReason = reason
+			emit(Event{Type: EventTurnInterrupt, StopReason: reason, Error: err.Error(), Step: steps})
+			return TurnResult{StopReason: reason, Steps: steps, Usage: usage}, nil
+		}
+		if steps >= maxSteps {
+			stopReason = TurnMaxSteps
+			turnErr = &MaxStepsExceededError{Max: maxSteps}
+			emit(Event{Type: EventTurnInterrupt, StopReason: stopReason, Error: turnErr.Error(), Step: steps})
+			return TurnResult{StopReason: stopReason, Steps: steps, Usage: usage, Error: turnErr}, turnErr
+		}
+		if in.Hooks.BeforeStep != nil {
+			if err := in.Hooks.BeforeStep(ctx, steps+1); err != nil {
+				stopReason = TurnError
+				turnErr = err
+				emit(Event{Type: EventTurnInterrupt, StopReason: stopReason, Error: err.Error(), Step: steps})
+				return TurnResult{StopReason: stopReason, Steps: steps, Usage: usage, Error: err}, err
+			}
+		}
+
+		steps++
+		stepRes, err := runModelStep(ctx, in, steps, maxRetry)
+		// usage 在 LLM 返回后立即累计（无论工具是否执行，abort 也报告）。
+		usage = usage.Add(stepRes.usage)
+		if stepRes.usage.GrandTotal() > 0 {
+			u := stepRes.usage
+			acc := stepRes.accuracy
+			emit(Event{Type: EventUsage, Step: steps, Usage: &u, UsageAccuracy: string(acc)})
+		}
+		if err != nil {
+			if isUserAbort(ctx, err) {
+				stopReason = TurnUserAbort
+				emit(Event{Type: EventTurnInterrupt, StopReason: stopReason, Step: steps})
+				return TurnResult{StopReason: stopReason, Steps: steps, Usage: usage}, nil
+			}
+			stopReason = TurnError
+			turnErr = err
+			emit(Event{Type: EventTurnInterrupt, StopReason: stopReason, Error: err.Error(), Step: steps})
+			return TurnResult{StopReason: stopReason, Steps: steps, Usage: usage, Error: err}, err
+		}
+
+		if stepRes.stopReason == StopToolUse {
+			// 先派发 tool_call 事件（保持 call→result 配对契约），再执行批次。
+			for _, call := range stepRes.message.ToolCalls {
+				args := json.RawMessage(call.Arguments)
+				emit(Event{Type: EventToolCall, Step: steps, ToolCall: &ToolCallEvent{ID: call.ID, Name: call.Name, Arguments: args}})
+			}
+			// 执行工具批次；结果追加进历史后进入下一步。
+			if in.Tools != nil {
+				execToolBatch(ctx, in, stepRes.message.ToolCalls, emit, steps)
+			} else {
+				// 无工具执行器：把调用结果标为错误回给模型，避免死循环。
+				for _, call := range stepRes.message.ToolCalls {
+					appendToolResult(in.Memory, call, ToolResult{Output: "模型请求了工具调用，但当前会话没有可用工具执行器。", IsError: true})
+					emit(Event{Type: EventToolResult, Step: steps, ToolResult: &ToolResultEvent{ID: call.ID, Name: call.Name, Output: "no executor", IsError: true}})
+				}
+			}
+			continue
+		}
+
+		stopReason = turnStopFromStep(stepRes.stopReason)
+		break
+	}
+
+	emit(Event{Type: EventTurnEnd, StopReason: stopReason, Step: steps, Usage: &usage})
+
+	// 宿主可选续跑（goal mode 切入点；一期不启用）。
+	if in.Hooks.ShouldContinueAfterStop != nil && in.Hooks.ShouldContinueAfterStop(ctx, ContinueCheck{
+		Step:       steps,
+		StopReason: stepStopFromTurn(stopReason),
+		Usage:      usage,
+	}) {
+		// 一期：递归续跑一次语义过于激进，返回由宿主自行再次调用 RunTurn。
+		return TurnResult{StopReason: stopReason, Steps: steps, Usage: usage}, nil
+	}
+	return TurnResult{StopReason: stopReason, Steps: steps, Usage: usage}, turnErr
+}
+
+// stepOutput 是单个模型步的结果。
+type stepOutput struct {
+	message    llm.Message
+	stopReason StepStopReason
+	usage      llm.TokenUsage
+	accuracy   llm.UsageAccuracy
+}
+
+// runModelStep 执行一次模型调用（含重试退避），并把 assistant 消息写入历史。
+func runModelStep(ctx context.Context, in RunTurnInput, step, maxRetry int) (stepOutput, error) {
+	emit := func(ev Event) {
+		if in.Events != nil {
+			ev.TurnID = in.TurnID
+			ev.Step = step
+			in.Events.Dispatch(ev)
+		}
+	}
+	emit(Event{Type: EventStepBegin})
+
+	opts := llm.GenerateOptions{Effort: in.Effort}
+	if in.Events != nil {
+		opts.OnDelta = func(part llm.StreamedPart) {
+			switch v := part.(type) {
+			case llm.TextDelta:
+				emit(Event{Type: EventTextDelta, Text: v.Text})
+			case llm.ThinkDelta:
+				emit(Event{Type: EventThinkDelta, Think: v.Text})
+			}
+		}
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= maxRetry; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return stepOutput{}, err
+		}
+		history := in.Memory.History()
+		res, err := in.Provider.Generate(ctx, in.SystemPrompt, toolSchemas(in.Tools), history, opts)
+		if err == nil {
+			in.Memory.Append(res.Message)
+			emit(Event{Type: EventStepEnd, StopReason: TurnStopReason(stepStopFromLLM(res.FinishReason))})
+			return stepOutput{
+				message:    res.Message,
+				stopReason: stepStopFromLLM(res.FinishReason),
+				usage:      res.Usage,
+				accuracy:   res.Accuracy,
+			}, nil
+		}
+		lastErr = err
+		if !shouldRetry(err) || attempt == maxRetry {
+			break
+		}
+		// 指数退避；ctx 取消立即返回。
+		if !sleepCtx(ctx, retryDelay(attempt, err)) {
+			return stepOutput{}, ctx.Err()
+		}
+	}
+	return stepOutput{}, lastErr
+}
+
+// toolSchemas 获取当前工具定义。
+func toolSchemas(t ToolExecutor) []llm.Tool {
+	if t == nil {
+		return nil
+	}
+	return t.Schemas()
+}
+
+// execToolBatch 顺序执行一个工具调用批次（P2 从简；只读并行是二期优化）。
+// 每个 call 必有配对 result 事件。
+func execToolBatch(ctx context.Context, in RunTurnInput, calls []llm.ToolCall, emit func(Event), step int) {
+	for _, call := range calls {
+		if err := ctx.Err(); err != nil {
+			// turn 已被取消：给剩余调用补终止结果，保持配对契约。
+			appendToolResult(in.Memory, call, ToolResult{Output: "用户取消了本次任务。", IsError: true})
+			emit(Event{Type: EventToolResult, Step: step, ToolResult: &ToolResultEvent{ID: call.ID, Name: call.Name, IsError: true}})
+			continue
+		}
+		// 权限闸。
+		decision := DecAllow
+		var denyReason string
+		if in.PermGate != nil {
+			switch in.PermGate.Check(call) {
+			case DecAllow:
+				decision = DecAllow
+			case DecDeny:
+				decision = DecDeny
+				denyReason = "权限规则拒绝了该操作。"
+			default:
+				permRes := in.PermGate.WaitForDecision(ctx, call)
+				decision = permRes.Decision
+				denyReason = permRes.Reason
+				if denyReason == "" {
+					denyReason = "用户拒绝了该操作。"
+				}
+			}
+		}
+
+		var result ToolResult
+		switch decision {
+		case DecDeny:
+			result = ToolResult{Output: denyReason, IsError: true}
+		default:
+			res, err := in.Tools.Execute(ctx, call)
+			if err != nil {
+				result = ToolResult{Output: "工具执行失败: " + err.Error(), IsError: true}
+			} else {
+				result = res
+			}
+		}
+		appendToolResult(in.Memory, call, result)
+		emit(Event{
+			Type: EventToolResult,
+			Step: step,
+			ToolResult: &ToolResultEvent{
+				ID: call.ID, Name: call.Name,
+				Output: result.Output, IsError: result.IsError, Truncated: result.Truncated,
+			},
+		})
+	}
+}
+
+// appendToolResult 把工具结果写进历史。
+func appendToolResult(mem Memory, call llm.ToolCall, result ToolResult) {
+	parts := []llm.ContentPart{llm.TextPart{Text: result.ResultJSON()}}
+	mem.Append(llm.Message{Role: llm.RoleTool, ToolCallID: call.ID, Parts: parts})
+}
+
+// shouldRetry 判断错误是否值得重试。
+func shouldRetry(err error) bool {
+	apiErr, ok := err.(*llm.APIError)
+	if !ok {
+		return false
+	}
+	return llm.RetryableKind(apiErr.Kind)
+}
+
+// retryDelay 计算指数退避时长；限流尊重 Retry-After。
+func retryDelay(attempt int, err error) time.Duration {
+	if apiErr, ok := err.(*llm.APIError); ok && apiErr.RetryAfter > 0 {
+		return apiErr.RetryAfter
+	}
+	d := time.Duration(float64(baseRetryBackoff) * math.Pow(2, float64(attempt)))
+	if d > maxRetryBackoff {
+		d = maxRetryBackoff
+	}
+	return d
+}
+
+// sleepCtx 可取消的 sleep；返回 false 表示 ctx 已结束。
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// isUserAbort 判断错误链是否为用户取消。
+func isUserAbort(ctx context.Context, err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	if ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled) {
+		return true
+	}
+	return false
+}
+
+func turnStopFromStep(r StepStopReason) TurnStopReason {
+	switch r {
+	case StopMaxToken:
+		return TurnMaxToken
+	case StopFiltered:
+		return TurnFiltered
+	default:
+		return TurnEnd
+	}
+}
+
+func stepStopFromTurn(r TurnStopReason) StepStopReason {
+	switch r {
+	case TurnMaxToken:
+		return StopMaxToken
+	case TurnFiltered:
+		return StopFiltered
+	default:
+		return StopEndTurn
+	}
+}
+
+func stepStopFromLLM(raw string) StepStopReason {
+	switch llm.NormalizeFinishReason(raw) {
+	case "tool_use":
+		return StopToolUse
+	case "max_tokens":
+		return StopMaxToken
+	case "filtered":
+		return StopFiltered
+	case "stop":
+		return StopEndTurn
+	default:
+		return StopUnknown
+	}
+}
+
+// compactJSON 截断 JSON 文本用于日志。
+func compactJSON(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 200 {
+		return s[:200] + "…"
+	}
+	return s
+}

--- a/internal/agentloop/run_turn_test.go
+++ b/internal/agentloop/run_turn_test.go
@@ -1,0 +1,464 @@
+package agentloop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"grok_switch/internal/llm"
+)
+
+// --- 测试基建：假 Provider / 工具 / Memory / 权限闸 ---
+
+// scriptProvider 按 prelude 脚本逐个返回预设响应（脚本耗尽后重复最后一个）。
+type scriptProvider struct {
+	mu       sync.Mutex
+	steps    []llm.StreamResult
+	idx      int
+	failures []error // 每次调用前先弹出的错误（nil 表示成功）
+	calls    int
+}
+
+func (p *scriptProvider) Name() string      { return "script" }
+func (p *scriptProvider) ModelName() string { return "test-model" }
+func (p *scriptProvider) Capability() llm.ModelCapability {
+	return llm.ModelCapability{ToolUse: true, Thinking: true, MaxContextTokens: 100000, UsageAccuracy: llm.UsageExact}
+}
+
+func (p *scriptProvider) Generate(ctx context.Context, systemPrompt string, tools []llm.Tool, history []llm.Message, opts llm.GenerateOptions) (*llm.StreamResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if len(p.failures) > 0 {
+		err := p.failures[0]
+		p.failures = p.failures[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	if p.idx >= len(p.steps) {
+		p.idx = len(p.steps) - 1
+	}
+	res := p.steps[p.idx]
+	p.idx++
+	if opts.OnDelta != nil && res.Message.Text() != "" {
+		opts.OnDelta(llm.TextDelta{Text: res.Message.Text()})
+	}
+	return &res, nil
+}
+
+func (p *scriptProvider) WithThinking(effort string) llm.Provider { return p }
+
+func (p *scriptProvider) WithMaxOutputTokens(n int64) llm.Provider { return p }
+
+func textResult(text string) llm.StreamResult {
+	return llm.StreamResult{
+		Message:      llm.Message{Role: llm.RoleAssistant, Parts: []llm.ContentPart{llm.TextPart{Text: text}}},
+		Usage:        llm.TokenUsage{InputOther: 100, Output: 10},
+		Accuracy:     llm.UsageExact,
+		FinishReason: "stop",
+	}
+}
+
+func toolCallResult(id, name, args string) llm.StreamResult {
+	return llm.StreamResult{
+		Message: llm.Message{
+			Role:      llm.RoleAssistant,
+			ToolCalls: []llm.ToolCall{{ID: id, Name: name, Arguments: json.RawMessage(args)}},
+		},
+		Usage:        llm.TokenUsage{InputOther: 120, Output: 15},
+		Accuracy:     llm.UsageExact,
+		FinishReason: "tool_use",
+	}
+}
+
+// fakeTools 是确定性工具执行器：read 返回文件内容，fail 返回错误。
+type fakeTools struct {
+	mu          sync.Mutex
+	calls       []llm.ToolCall
+	results     map[string]ToolResult
+	executeHook func() // 每次执行后回调（测试取消用）
+}
+
+func newFakeTools() *fakeTools {
+	return &fakeTools{results: map[string]ToolResult{}}
+}
+
+func (t *fakeTools) set(name, output string, isError bool) {
+	t.results[name] = ToolResult{Output: output, IsError: isError}
+}
+
+func (t *fakeTools) Schemas() []llm.Tool {
+	return []llm.Tool{
+		{Name: "read", Description: "读文件", Schema: map[string]any{"type": "object"}},
+		{Name: "bash", Description: "跑命令", Schema: map[string]any{"type": "object"}},
+	}
+}
+
+func (t *fakeTools) Execute(ctx context.Context, call llm.ToolCall) (ToolResult, error) {
+	t.mu.Lock()
+	t.calls = append(t.calls, call)
+	res, ok := t.results[call.Name]
+	hook := t.executeHook
+	t.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
+	if !ok {
+		return ToolResult{Output: "ok (default)"}, nil
+	}
+	return res, nil
+}
+
+// sliceMemory 是内存历史。
+type sliceMemory struct {
+	msgs []llm.Message
+}
+
+func (m *sliceMemory) History() []llm.Message { return m.msgs }
+
+func (m *sliceMemory) Append(msg llm.Message) { m.msgs = append(m.msgs, msg) }
+
+// gatePerm 权限闸：askTools 中的工具需要审批。
+type gatePerm struct {
+	askTools map[string]bool
+	decide   func(call llm.ToolCall) PermResult
+}
+
+func (g *gatePerm) Check(call llm.ToolCall) Decision {
+	if g.askTools[call.Name] {
+		return DecAsk
+	}
+	return DecAllow
+}
+
+func (g *gatePerm) WaitForDecision(ctx context.Context, call llm.ToolCall) PermResult {
+	return g.decide(call)
+}
+
+// --- 测试 ---
+
+func TestRunTurnSimpleText(t *testing.T) {
+	prov := &scriptProvider{steps: []llm.StreamResult{textResult("你好，我是引擎")}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "hi"}}}}}
+	rec := &MemoryRecorder{}
+
+	res, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t1", Provider: prov, SystemPrompt: "sys", Memory: mem, Events: rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StopReason != TurnEnd || res.Steps != 1 {
+		t.Fatalf("结果错误: %+v", res)
+	}
+	if got := mem.msgs[len(mem.msgs)-1].Text(); got != "你好，我是引擎" {
+		t.Fatalf("assistant 回复未入历史: %q", got)
+	}
+	if res.Usage.Output != 10 {
+		t.Fatalf("usage 聚合错误: %+v", res.Usage)
+	}
+	// 事件序列：turn_begin → step_begin → text_delta → step_end → usage → turn_end
+	types := eventTypeList(rec)
+	expect := []EventType{EventTurnBegin, EventStepBegin, EventTextDelta, EventStepEnd, EventUsage, EventTurnEnd}
+	if fmt.Sprint(types) != fmt.Sprint(expect) {
+		t.Fatalf("事件序列错误:\n got %v\nwant %v", types, expect)
+	}
+}
+
+func TestRunTurnToolLoop(t *testing.T) {
+	prov := &scriptProvider{steps: []llm.StreamResult{
+		toolCallResult("c1", "read", `{"path":"a.go"}`),
+		textResult("读完了"),
+	}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "读 a.go"}}}}}
+	tools := newFakeTools()
+	tools.set("read", "package main", false)
+	rec := &MemoryRecorder{}
+
+	res, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t2", Provider: prov, SystemPrompt: "sys", Memory: mem, Tools: tools, Events: rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StopReason != TurnEnd || res.Steps != 2 {
+		t.Fatalf("结果错误: %+v", res)
+	}
+	if len(tools.calls) != 1 || tools.calls[0].Name != "read" {
+		t.Fatalf("工具执行记录错误: %+v", tools.calls)
+	}
+	// 历史：user → assistant(tool_call) → tool → assistant(text)
+	if len(mem.msgs) != 4 {
+		t.Fatalf("历史长度错误: %d", len(mem.msgs))
+	}
+	toolMsg := mem.msgs[2]
+	if toolMsg.Role != llm.RoleTool || toolMsg.ToolCallID != "c1" {
+		t.Fatalf("工具结果消息错误: %+v", toolMsg)
+	}
+	if !contains(toolMsg.Text(), `"package main"`) {
+		t.Fatalf("工具结果 JSON 缺内容: %s", toolMsg.Text())
+	}
+	// tool_call 与 tool_result 必须配对。
+	calls := rec.FilterTypes(EventToolCall)
+	results := rec.FilterTypes(EventToolResult)
+	if len(calls) != 1 || len(results) != 1 {
+		t.Fatalf("call/result 配对错误: %d calls, %d results", len(calls), len(results))
+	}
+	if calls[0].ToolCall.ID != results[0].ToolResult.ID {
+		t.Fatalf("call/result ID 不配对")
+	}
+}
+
+func TestRunTurnToolErrorContinues(t *testing.T) {
+	prov := &scriptProvider{steps: []llm.StreamResult{
+		toolCallResult("c1", "bash", `{"cmd":"boom"}`),
+		textResult("命令失败了，我改用别的方法"),
+	}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "跑 boom"}}}}}
+	tools := newFakeTools()
+	tools.set("bash", "exit 1", true)
+
+	res, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t3", Provider: prov, Memory: mem, Tools: tools,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StopReason != TurnEnd {
+		t.Fatalf("工具失败不应终止 turn: %+v", res)
+	}
+	// 工具结果应带 error 标记回给模型。
+	toolMsg := mem.msgs[2]
+	if !contains(toolMsg.Text(), `"error":true`) {
+		t.Fatalf("错误标记缺失: %s", toolMsg.Text())
+	}
+}
+
+func TestRunTurnRateLimitRetry(t *testing.T) {
+	prov := &scriptProvider{
+		steps: []llm.StreamResult{textResult("重试后成功")},
+		failures: []error{
+			llm.NewAPIError("rate_limited", 429, "slow down", 10*time.Millisecond),
+		},
+	}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "hi"}}}}}
+
+	res, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t4", Provider: prov, Memory: mem,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StopReason != TurnEnd {
+		t.Fatalf("重试后应成功: %+v", res)
+	}
+	if prov.calls != 2 {
+		t.Fatalf("应调用两次（1 重试）, got %d", prov.calls)
+	}
+}
+
+func TestRunTurnRetryExhausted(t *testing.T) {
+	prov := &scriptProvider{
+		steps: []llm.StreamResult{textResult("never")},
+		failures: []error{
+			llm.NewAPIError("overloaded", 503, "down", 0),
+			llm.NewAPIError("overloaded", 503, "down", 0),
+			llm.NewAPIError("overloaded", 503, "down", 0),
+			llm.NewAPIError("overloaded", 503, "down", 0),
+		},
+	}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "hi"}}}}}
+	rec := &MemoryRecorder{}
+
+	// maxRetry=2 → 最多 3 次调用（初试+2 重试）；提供 4 个错误时第 4 个不会被消费。
+	_, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t5", Provider: prov, Memory: mem, Events: rec, MaxRetries: 2,
+	})
+	if err == nil {
+		t.Fatal("重试耗尽应返回错误")
+	}
+	var apiErr *llm.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("应保留 APIError: %v", err)
+	}
+	if prov.calls != 3 {
+		t.Fatalf("调用次数错误: %d", prov.calls)
+	}
+	interrupted := rec.FilterTypes(EventTurnInterrupt)
+	if len(interrupted) != 1 || interrupted[0].StopReason != TurnError {
+		t.Fatalf("中断事件错误: %+v", interrupted)
+	}
+}
+
+func TestRunTurnNonRetryableError(t *testing.T) {
+	prov := &scriptProvider{
+		steps:    []llm.StreamResult{textResult("never")},
+		failures: []error{llm.NewAPIError("auth", 401, "bad key", 0)},
+	}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "hi"}}}}}
+
+	_, err := RunTurn(context.Background(), RunTurnInput{TurnID: "t6", Provider: prov, Memory: mem})
+	if err == nil {
+		t.Fatal("auth 错误应直接失败")
+	}
+	if prov.calls != 1 {
+		t.Fatalf("不可重试错误不应重试: %d", prov.calls)
+	}
+}
+
+func TestRunTurnUserCancel(t *testing.T) {
+	prov := &scriptProvider{steps: []llm.StreamResult{textResult("never")}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "hi"}}}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res, err := RunTurn(ctx, RunTurnInput{TurnID: "t7", Provider: prov, Memory: mem})
+	if err != nil {
+		t.Fatalf("用户取消不应返回 error: %v", err)
+	}
+	if res.StopReason != TurnUserAbort {
+		t.Fatalf("应标记 user_cancelled: %+v", res)
+	}
+}
+
+func TestRunTurnMidTurnCancel(t *testing.T) {
+	// 第一步工具执行后取消：第二步模型调用前 abort。
+	prov := &scriptProvider{steps: []llm.StreamResult{
+		toolCallResult("c1", "read", `{}`),
+		textResult("never reached"),
+	}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "hi"}}}}}
+	tools := newFakeTools()
+	ctx, cancel := context.WithCancel(context.Background())
+	tools.executeHook = func() { cancel() }
+
+	res, err := RunTurn(ctx, RunTurnInput{TurnID: "t8", Provider: prov, Memory: mem, Tools: tools})
+	if err != nil {
+		t.Fatalf("取消应优雅返回: %v", err)
+	}
+	if res.StopReason != TurnUserAbort && res.StopReason != TurnAborted {
+		t.Fatalf("停止原因错误: %+v", res)
+	}
+	// 已取消后剩余工具调用也要有配对 result（若在同批次）。
+	calls := len(memHistoryToolCalls(mem))
+	results := 0
+	for _, m := range mem.msgs {
+		if m.Role == llm.RoleTool {
+			results++
+		}
+	}
+	if calls != results {
+		t.Fatalf("取消时 call/result 失配: %d calls, %d results", calls, results)
+	}
+}
+
+func TestRunTurnMaxSteps(t *testing.T) {
+	// 无限要求工具调用 → 步数上限终止。
+	prov := &scriptProvider{steps: []llm.StreamResult{toolCallResult("c", "read", `{}`)}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "loop"}}}}}
+	tools := newFakeTools()
+
+	res, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t9", Provider: prov, Memory: mem, Tools: tools, MaxSteps: 5,
+	})
+	if err == nil {
+		t.Fatal("超步数应返回错误")
+	}
+	var maxErr *MaxStepsExceededError
+	if !errors.As(err, &maxErr) {
+		t.Fatalf("应为 MaxStepsExceededError: %v", err)
+	}
+	if res.StopReason != TurnMaxSteps || res.Steps != 5 {
+		t.Fatalf("结果错误: %+v", res)
+	}
+}
+
+func TestRunTurnPermissionAsk(t *testing.T) {
+	prov := &scriptProvider{steps: []llm.StreamResult{
+		toolCallResult("c1", "bash", `{"cmd":"rm -rf /"}`),
+		textResult("好的，已跳过"),
+	}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "rm"}}}}}
+	tools := newFakeTools()
+	gate := &gatePerm{
+		askTools: map[string]bool{"bash": true},
+		decide: func(call llm.ToolCall) PermResult {
+			return PermResult{Decision: DecDeny, Reason: "危险命令，不允许。"}
+		},
+	}
+
+	_, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t10", Provider: prov, Memory: mem, Tools: tools, PermGate: gate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 拒绝应回给模型而不是执行。
+	if len(tools.calls) != 0 {
+		t.Fatalf("被拒工具不应执行: %+v", tools.calls)
+	}
+	toolMsg := mem.msgs[2]
+	if !contains(toolMsg.Text(), "危险命令") || !contains(toolMsg.Text(), `"error":true`) {
+		t.Fatalf("拒绝原因未回传模型: %s", toolMsg.Text())
+	}
+}
+
+func TestRunTurnToolCallEventOrder(t *testing.T) {
+	prov := &scriptProvider{steps: []llm.StreamResult{
+		toolCallResult("c1", "read", `{"path":"x"}`),
+		textResult("done"),
+	}}
+	mem := &sliceMemory{msgs: []llm.Message{{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: "x"}}}}}
+	rec := &MemoryRecorder{}
+
+	_, err := RunTurn(context.Background(), RunTurnInput{
+		TurnID: "t11", Provider: prov, Memory: mem, Tools: newFakeTools(), Events: rec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// tool_call 事件必须先于对应 tool_result。
+	var sawCall bool
+	for _, ev := range rec.Snapshot() {
+		if ev.Type == EventToolCall {
+			sawCall = true
+		}
+		if ev.Type == EventToolResult && !sawCall {
+			t.Fatal("tool_result 先于 tool_call")
+		}
+	}
+}
+
+// --- 辅助 ---
+
+func eventTypeList(rec *MemoryRecorder) []EventType {
+	var out []EventType
+	for _, ev := range rec.Snapshot() {
+		out = append(out, ev.Type)
+	}
+	return out
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+func memHistoryToolCalls(mem *sliceMemory) []llm.ToolCall {
+	var out []llm.ToolCall
+	for _, m := range mem.msgs {
+		out = append(out, m.ToolCalls...)
+	}
+	return out
+}

--- a/internal/agentloop/types.go
+++ b/internal/agentloop/types.go
@@ -1,0 +1,83 @@
+// Package agentloop 是自研 Agent 引擎的无状态循环（对标 Kimi Code 的 loop）。
+//
+// 边界契约（设计文档 §5，翻译自 loop/README.md 的纪律）：
+//   - 本包不 import 任何 UI/存储/权限实现；依赖通过接口注入。
+//   - 事件单出口：Dispatcher。录制与直播都在出口处分发，订阅者故障不影响 loop。
+//   - usage 在 LLM 返回后立即记录（不等工具执行完成）。
+//   - 每个 tool.call 必须有配对的 tool.result，除非 step 在派发点前被中断。
+package agentloop
+
+import (
+	"encoding/json"
+
+	"grok_switch/internal/llm"
+)
+
+// StepStopReason 是单个模型步的结束原因。"tool_use" 是 loop 控制信号：
+// 引擎执行工具后继续下一步；其余为当前 turn 的终止原因。
+type StepStopReason string
+
+const (
+	StopEndTurn  StepStopReason = "end_turn"
+	StopMaxToken StepStopReason = "max_tokens"
+	StopToolUse  StepStopReason = "tool_use"
+	StopFiltered StepStopReason = "filtered"
+	StopUnknown  StepStopReason = "unknown"
+)
+
+// TurnStopReason 是整个 turn 的结束原因（不含 tool_use——它不可能是终态）。
+type TurnStopReason string
+
+const (
+	TurnEnd       TurnStopReason = "end_turn"
+	TurnMaxToken  TurnStopReason = "max_tokens"
+	TurnFiltered  TurnStopReason = "filtered"
+	TurnAborted   TurnStopReason = "aborted"
+	TurnError     TurnStopReason = "error"
+	TurnMaxSteps  TurnStopReason = "max_steps"
+	TurnUserAbort TurnStopReason = "user_cancelled"
+)
+
+// ToolResult 是工具执行的统一结果。
+type ToolResult struct {
+	// Output 是回给模型的文本（已截断预算内）。
+	Output string
+	// IsError 为 true 时模型看到的是失败结果。
+	IsError bool
+	// Truncated 标记输出因预算被截断（后续通用预算不再重复截断）。
+	Truncated bool
+	// Media 是可选的图片/资源结果（如 generate_image 的产物）。
+	Media []llm.ContentPart
+}
+
+// ToolResultJSON 把结果序列化为回传模型的 JSON 文本。
+func (r ToolResult) ResultJSON() string {
+	payload := map[string]any{
+		"output": r.Output,
+		"error":  r.IsError,
+	}
+	if r.Truncated {
+		payload["truncated"] = true
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return r.Output
+	}
+	return string(b)
+}
+
+// TurnResult 是一次 turn 的最终结果。
+type TurnResult struct {
+	StopReason TurnStopReason
+	Steps      int
+	Usage      llm.TokenUsage
+	// Error 携带 TurnError 时的底层错误。
+	Error error
+}
+
+// MaxStepsExceededError 表示超过单 turn 步数上限。
+type MaxStepsExceededError struct{ Max int }
+
+func (e *MaxStepsExceededError) Error() string {
+	return "agentloop: 达到单轮步数上限"
+}

--- a/internal/llm/capability.go
+++ b/internal/llm/capability.go
@@ -1,0 +1,65 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// capabilityFor 依据 Profile 数据（ModelDef 字段的镜像）构造能力表。
+// server 层解析 Profile 时调用；引擎不 import profiles 包。
+// 参数语义与 profiles.ModelDef 一致；windows 为 0 表示未知。
+func capabilityFor(model string, supportsReasoningEffort bool, efforts []string, contextWindow, maxCompletion int64) ModelCapability {
+	cap := ModelCapability{
+		ToolUse:             true,
+		MaxContextTokens:    int(contextWindow),
+		MaxCompletionTokens: int(maxCompletion),
+		UsageAccuracy:       UsageExact,
+	}
+	if supportsReasoningEffort {
+		cap.Thinking = true
+		cap.ReasoningEfforts = efforts
+	}
+	if isVisionModelFamily(model) {
+		cap.ImageIn = true
+	}
+	return cap
+}
+
+// isVisionModelFamily 判断模型家族是否已知接受图片输入。
+// Grok 4.x 全系多模态；未知家族保守返回 false。
+func isVisionModelFamily(model string) bool {
+	family := NormalizeModelFamily(model)
+	return strings.HasPrefix(family, "grok-") || strings.HasPrefix(family, "grok ")
+}
+
+// validateEffort 把请求里的推理强度归一到模型支持列表；不支持时返回空串。
+func validateEffort(effort string, cap ModelCapability) string {
+	e := strings.ToLower(strings.TrimSpace(effort))
+	if e == "" || !cap.Thinking {
+		return ""
+	}
+	if len(cap.ReasoningEfforts) == 0 {
+		return e
+	}
+	for _, allowed := range cap.ReasoningEfforts {
+		if strings.EqualFold(allowed, e) {
+			return strings.ToLower(allowed)
+		}
+	}
+	return ""
+}
+
+// compactArgsForLog 截断工具参数用于日志。
+func compactArgsForLog(args json.RawMessage) string {
+	s := string(args)
+	if len(s) > 200 {
+		s = s[:200] + "…"
+	}
+	return s
+}
+
+// errToolUseUnsupported 构造模型不支持工具调用的明确错误。
+func errToolUseUnsupported(model string) error {
+	return fmt.Errorf("llm: 模型 %q 未声明 tool_use 能力，无法执行带工具的对话", model)
+}

--- a/internal/llm/estimate.go
+++ b/internal/llm/estimate.go
@@ -1,0 +1,67 @@
+package llm
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// EstimateTokens 按字符数近似估算 token（≈4 字符/token）。
+// 仅用于 chat/completions 后端拿不到真实 usage 时的 compaction 触发预算，
+// 以及测试；禁止用于计费口径。UTF-8 安全：按 rune 计数，非 ASCII 文本
+// 按 1.5 rune/token 收紧（Grok/中英混合语料的经验区间）。
+func EstimateTokens(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	runes := float64(utf8.RuneCountInString(s))
+	ascii := float64(len(s))/float64(utf8.RuneCountInString(s)) == 1
+	if ascii {
+		// 纯 ASCII：约 4 字符/token，另加每消息固定开销已在调用方计。
+		return int64(runes / 4)
+	}
+	// 混合/非 ASCII：CJK 常见约 1~2 字符/token，取 1.5。
+	return int64(runes / 1.5)
+}
+
+// EstimateMessageTokens 估算单条消息 token：文本部件 + 思考 + 工具调用参数。
+func EstimateMessageTokens(m Message) int64 {
+	var total int64
+	for _, p := range m.Parts {
+		switch part := p.(type) {
+		case TextPart:
+			total += EstimateTokens(part.Text)
+		case ThinkPart:
+			total += EstimateTokens(part.Text)
+		case ImagePart:
+			// 图片按中等分辨率经验值计。
+			total += 800
+		}
+	}
+	for _, tc := range m.ToolCalls {
+		total += EstimateTokens(string(tc.Arguments)) + 8
+	}
+	if m.ToolCallID != "" {
+		total += 8
+	}
+	return total
+}
+
+// EstimateHistoryTokens 估算整段历史的 token 预算（不含 system prompt）。
+func EstimateHistoryTokens(history []Message) int64 {
+	var total int64
+	for _, m := range history {
+		total += EstimateMessageTokens(m)
+	}
+	return total
+}
+
+// NormalizeModelFamily 从模型名提取家族前缀，用于能力表兜底匹配。
+func NormalizeModelFamily(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	for _, sep := range []string{"@", ":", "/"} {
+		if idx := strings.Index(m, sep); idx > 0 {
+			m = m[:idx]
+		}
+	}
+	return m
+}

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -1,0 +1,114 @@
+package llm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProfileBridge 是 server 层 Profile 数据的最小投影。定义在本包以避免
+// 引擎依赖 profiles 存储（分层契约，设计文档 §5）；server 层负责把
+// profiles.Profile 映射到这里。
+type ProfileBridge struct {
+	// UpstreamFormat 决定适配器："openai_responses"/"responses" → ResponsesProvider，
+	// 其余（含空）→ ChatCompletionsProvider（D7：中转默认按 chat/completions 适配）。
+	UpstreamFormat string
+	// WirePathOverride 覆盖请求路径；空按适配器默认（/responses | /chat/completions）。
+	// loopback 代理场景传空即可（代理按 /grok/v1 前缀分发）。
+	WirePathOverride string
+	BaseURL          string
+	APIKey           string
+	ExtraHeaders     map[string]string
+	ProxyURL         string
+	Model            string
+	SessionKey       string
+	// ModelDef 投影（能力表来源）。
+	SupportsReasoningEffort bool
+	ReasoningEfforts        []string
+	ContextWindow           int64
+	MaxCompletionTokens     int64
+}
+
+// NewProviderForProfile 是 Profile→Provider 的唯一工厂。
+// loopback 代理（127.0.0.1 的 /grok/v1）永远按 Responses 协议处理——那是
+// Grok 上游的真实 wire 格式，与 Profile 的 upstream_format 无关；该判定
+// 在这里集中做，server 层不需要重复。
+func NewProviderForProfile(p ProfileBridge) (Provider, error) {
+	target := UpstreamTarget{
+		BaseURL:      strings.TrimRight(p.BaseURL, "/"),
+		APIKey:       p.APIKey,
+		ExtraHeaders: p.ExtraHeaders,
+		ProxyURL:     p.ProxyURL,
+	}
+	if strings.TrimSpace(p.Model) == "" {
+		return nil, fmt.Errorf("llm: Profile 未配置模型")
+	}
+	cap := capabilityFor(p.Model, p.SupportsReasoningEffort, p.ReasoningEfforts, p.ContextWindow, p.MaxCompletionTokens)
+	format := normalizeFormat(p.UpstreamFormat)
+	declared := strings.TrimSpace(p.UpstreamFormat) != ""
+	// loopback 代理（本机 /grok/v1，即 Grok Auth 池）固定 Responses 协议——那是
+	// Grok 上游的真实 wire 格式（D2）；Profile 显式声明格式的自建配置除外。
+	if !declared && isLoopbackBase(target.BaseURL) {
+		format = "responses"
+	}
+	switch format {
+	case "responses":
+		return newResponsesProviderFull(target, p.Model, p.SessionKey, cap, "/responses", p.WirePathOverride)
+	default:
+		return newChatCompletionsProviderFull(target, p.Model, cap, "/chat/completions", p.WirePathOverride)
+	}
+}
+
+// newResponsesProviderFull 构造带路径覆盖的 Responses 适配器（工厂内部使用）。
+func newResponsesProviderFull(target UpstreamTarget, model, sessionKey string, cap ModelCapability, defaultPath, override string) (Provider, error) {
+	p, err := NewResponsesProvider(target, model, sessionKey, cap)
+	if err != nil {
+		return nil, err
+	}
+	if override != "" {
+		p.wirePath = override
+	} else {
+		p.wirePath = defaultPath
+	}
+	return p, nil
+}
+
+// newChatCompletionsProviderFull 构造带路径覆盖的 chat/completions 适配器。
+func newChatCompletionsProviderFull(target UpstreamTarget, model string, cap ModelCapability, defaultPath, override string) (Provider, error) {
+	p, err := NewChatCompletionsProvider(target, model, cap)
+	if err != nil {
+		return nil, err
+	}
+	if override != "" {
+		p.wirePath = override
+	} else {
+		p.wirePath = defaultPath
+	}
+	return p, nil
+}
+
+func normalizeFormat(f string) string {
+	switch strings.ToLower(strings.TrimSpace(f)) {
+	case "openai_responses", "responses":
+		return "responses"
+	case "openai", "openai_chat", "chat_completions", "chatcompletions":
+		return "chat_completions"
+	default:
+		// D7：未标注格式按 chat/completions 兜底（中转的最普遍形态）。
+		return "chat_completions"
+	}
+}
+
+// isLoopbackBase 判断上游是否指向本机代理。
+func isLoopbackBase(base string) bool {
+	u := strings.TrimPrefix(base, "http://")
+	u = strings.TrimPrefix(u, "https://")
+	u = strings.TrimSuffix(u, "/")
+	host := u
+	if idx := strings.Index(u, "/"); idx >= 0 {
+		host = u[:idx]
+	}
+	if idx := strings.Index(host, ":"); idx >= 0 {
+		host = host[:idx]
+	}
+	return host == "127.0.0.1" || host == "localhost" || host == "::1"
+}

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -1,0 +1,129 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFactoryLoopbackForcesResponses(t *testing.T) {
+	// loopback 且未声明格式 → 固定 Responses 协议（Grok Auth 池路径）。
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/grok/v1/responses" {
+			t.Errorf("loopback 应请求 Responses 端点, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "r1", "status": "completed", "output": []any{},
+			"usage": map[string]any{"input_tokens": 10, "output_tokens": 5},
+		})
+	}))
+	defer srv.Close()
+
+	p, err := NewProviderForProfile(ProfileBridge{
+		BaseURL:    srv.URL + "/grok/v1",
+		APIKey:     "k",
+		Model:      "grok-4.6",
+		SessionKey: "s1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "responses" {
+		t.Fatalf("loopback 应强制 responses, got %s", p.Name())
+	}
+	if _, err := p.Generate(context.Background(), "", nil, []Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "hi"}}}}, GenerateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFactoryThirdPartyDefaultsChatCompletions(t *testing.T) {
+	// 未标注 upstream_format：按 D7 兜底为 chat/completions。
+	// 用非 loopback 域名——httptest 绑定 127.0.0.1，会触发 loopback→responses
+	// 的强制规则；这里只验证第三方域名的兜底路径选择，不实际发请求。
+	p, err := NewProviderForProfile(ProfileBridge{
+		BaseURL: "http://relay.example.test:8080/v1",
+		Model:   "gpt-x",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "chat_completions" {
+		t.Fatalf("期望 chat_completions, got %s", p.Name())
+	}
+}
+
+func TestFactoryThirdPartyRealRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("显式声明的 chat/completions Profile 不应被改写, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	// 显式声明 openai 格式：即使 loopback 也按声明走（httptest 恰好验证这点）。
+	p, err := NewProviderForProfile(ProfileBridge{
+		UpstreamFormat: "openai",
+		BaseURL:        srv.URL + "/v1",
+		Model:          "gpt-x",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "chat_completions" {
+		t.Fatalf("期望 chat_completions, got %s", p.Name())
+	}
+	if _, err := p.Generate(context.Background(), "", nil, []Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "hi"}}}}, GenerateOptions{OnDelta: func(StreamedPart) {}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFactoryWirePathOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/custom/cc" {
+			t.Errorf("路径覆盖未生效: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	p, err := NewProviderForProfile(ProfileBridge{
+		UpstreamFormat:   "openai",
+		BaseURL:          srv.URL,
+		WirePathOverride: "/custom/cc",
+		Model:            "m",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Generate(context.Background(), "", nil, []Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "x"}}}}, GenerateOptions{OnDelta: func(StreamedPart) {}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFactoryEmptyModel(t *testing.T) {
+	if _, err := NewProviderForProfile(ProfileBridge{BaseURL: "http://example.com"}); err == nil {
+		t.Fatal("空模型应报错")
+	}
+}
+
+func TestNormalizeModelFamily(t *testing.T) {
+	cases := map[string]string{
+		"grok-4.6":               "grok-4.6",
+		"Grok 4.6":               "grok 4.6",
+		"grok-composer-2.5-fast": "grok-composer-2.5-fast",
+		"claude@20250101":        "claude",
+		"vendor:grok-3":          "vendor",
+		"ns/grok-3":              "ns",
+	}
+	for in, want := range cases {
+		if got := NormalizeModelFamily(in); got != want {
+			t.Fatalf("NormalizeModelFamily(%q)=%q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -1,0 +1,446 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// 能力表测试
+
+func TestCapabilityFor(t *testing.T) {
+	cap := capabilityFor("grok-4.6", true, []string{"low", "medium", "high"}, 500000, 65536)
+	if !cap.ToolUse || !cap.Thinking || !cap.ImageIn {
+		t.Fatalf("grok-4.6 应具备 tool_use/thinking/image_in: %+v", cap)
+	}
+	if cap.MaxContextTokens != 500000 || cap.MaxCompletionTokens != 65536 {
+		t.Fatalf("窗口字段未透传: %+v", cap)
+	}
+	unknown := capabilityFor("some-unknown-model", false, nil, 0, 0)
+	if unknown.ImageIn || unknown.Thinking {
+		t.Fatalf("未知模型应保守降级: %+v", unknown)
+	}
+}
+
+func TestValidateEffort(t *testing.T) {
+	cap := capabilityFor("grok-4.6", true, []string{"low", "medium", "high"}, 100, 100)
+	if got := validateEffort("HIGH", cap); got != "high" {
+		t.Fatalf("大写强度应归一, got %q", got)
+	}
+	if got := validateEffort("ultra", cap); got != "" {
+		t.Fatalf("不支持强度应返回空, got %q", got)
+	}
+	plain := capabilityFor("m2", false, nil, 100, 100)
+	if got := validateEffort("high", plain); got != "" {
+		t.Fatalf("不支持 thinking 的模型强度应为空, got %q", got)
+	}
+}
+
+func TestEstimateTokens(t *testing.T) {
+	if got := EstimateTokens("hello world"); got != 2 {
+		t.Fatalf("ASCII 11 字符应约 2 token, got %d", got)
+	}
+	if got := EstimateTokens("你好世界你好世界"); got == 0 {
+		t.Fatalf("CJK 应有非零估算")
+	}
+}
+
+// 通用断言辅助
+
+func assertStreamResult(t *testing.T, res *StreamResult, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Generate 失败: %v", err)
+	}
+	if res == nil {
+		t.Fatal("结果为空")
+	}
+	if res.Accuracy != UsageExact {
+		t.Fatalf("httptest 上游应回传 usage, got %v", res.Accuracy)
+	}
+	if res.FinishReason != "tool_use" {
+		t.Fatalf("期望 tool_use, got %q", res.FinishReason)
+	}
+	if len(res.Message.ToolCalls) != 1 {
+		t.Fatalf("期望 1 个工具调用, got %d", len(res.Message.ToolCalls))
+	}
+	tc := res.Message.ToolCalls[0]
+	if tc.Name != "read" {
+		t.Fatalf("工具名错误: %q", tc.Name)
+	}
+	if !strings.Contains(string(tc.Arguments), "internal/llm/types.go") {
+		t.Fatalf("参数拼接错误: %s", string(tc.Arguments))
+	}
+}
+
+// --- Responses 协议 ---
+
+func responsesUpstream(t *testing.T, nonStream bool, checkReq func(*testing.T, *http.Request, map[string]any)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/responses", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if checkReq != nil {
+			checkReq(t, r, body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		if nonStream {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":     "resp_1",
+				"status": "completed",
+				"output": []map[string]any{
+					{
+						"type":      "function_call",
+						"call_id":   "call_abc",
+						"name":      "read",
+						"arguments": `{"path":"internal/llm/types.go"}`,
+					},
+				},
+				"usage": map[string]any{
+					"input_tokens":         100,
+					"output_tokens":        20,
+					"input_tokens_details": map[string]any{"cached_tokens": 60},
+				},
+			})
+			return
+		}
+		f := w.(http.Flusher)
+		writeSSE := func(event string, payload string) {
+			_, _ = w.Write([]byte("event: " + event + "\ndata: " + payload + "\n\n"))
+			f.Flush()
+		}
+		writeSSE("response.output_text.delta", `{"type":"response.output_text.delta","delta":"查看"}`)
+		writeSSE("response.output_text.delta", `{"type":"response.output_text.delta","delta":"文件"}`)
+		writeSSE("response.output_item.added", `{"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","call_id":"call_abc","name":"read"}}`)
+		writeSSE("response.function_call_arguments.delta", `{"type":"response.function_call_arguments.delta","output_index":1,"delta":"{\"path\":\"internal/"}`)
+		writeSSE("response.function_call_arguments.delta", `{"type":"response.function_call_arguments.delta","output_index":1,"delta":"llm/types.go\"}"}`)
+		writeSSE("response.completed", `{"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":100,"output_tokens":20,"input_tokens_details":{"cached_tokens":60}}}}`)
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestResponsesProviderStream(t *testing.T) {
+	srv := responsesUpstream(t, false, nil)
+	defer srv.Close()
+
+	p, err := NewResponsesProvider(UpstreamTarget{BaseURL: srv.URL + "/v1", APIKey: "k-test"}, "grok-4.6", "sess-1", capabilityFor("grok-4.6", true, nil, 500000, 65536))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var deltas []string
+	res, err := p.Generate(context.Background(), "你是编码代理", []Tool{{Name: "read", Description: "读文件", Schema: map[string]any{"type": "object"}}},
+		[]Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "读一下 types.go"}}}},
+		GenerateOptions{OnDelta: func(part StreamedPart) {
+			switch v := part.(type) {
+			case TextDelta:
+				deltas = append(deltas, v.Text)
+			}
+		}})
+	assertStreamResult(t, res, err)
+	if strings.Join(deltas, "") != "查看文件" {
+		t.Fatalf("流式文本增量错误: %v", deltas)
+	}
+	if res.Usage.InputCacheRead != 60 || res.Usage.InputOther != 40 || res.Usage.Output != 20 {
+		t.Fatalf("usage 分解错误: %+v", res.Usage)
+	}
+}
+
+func TestResponsesProviderNonStream(t *testing.T) {
+	srv := responsesUpstream(t, true, nil)
+	defer srv.Close()
+	p, _ := NewResponsesProvider(UpstreamTarget{BaseURL: srv.URL + "/v1"}, "grok-4.6", "sess-1", capabilityFor("grok-4.6", true, nil, 500000, 65536))
+	res, err := p.Generate(context.Background(), "", nil, []Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "hi"}}}}, GenerateOptions{})
+	assertStreamResult(t, res, err)
+}
+
+func TestResponsesProviderWireShape(t *testing.T) {
+	srv := responsesUpstream(t, true, func(t *testing.T, r *http.Request, body map[string]any) {
+		if body["stream"] != false {
+			t.Fatalf("非流式请求 stream 应为 false")
+		}
+		if body["store"] != false {
+			t.Fatalf("无状态重放 store 应为 false (D1b)")
+		}
+		if _, has := body["previous_response_id"]; has {
+			t.Fatalf("不应发送 previous_response_id (D1b)")
+		}
+		if body["prompt_cache_key"] != "sess-9" {
+			t.Fatalf("sessionKey 应写入 prompt_cache_key")
+		}
+		input, _ := body["input"].([]any)
+		// user 消息 + assistant(function_call) + function_call_output = 3 条。
+		// assistant 的工具调用与文本分开成条目（Responses wire 形态）。
+		if len(input) != 3 {
+			t.Fatalf("期望 user + function_call + function_call_output 三条, got %d", len(input))
+		}
+		assistCall, _ := input[1].(map[string]any)
+		if assistCall["type"] != "function_call" || assistCall["call_id"] != "call_9" {
+			t.Fatalf("assistant function_call 翻译错误: %v", assistCall)
+		}
+		toolOut, _ := input[2].(map[string]any)
+		if toolOut["type"] != "function_call_output" || toolOut["call_id"] != "call_9" {
+			t.Fatalf("工具结果翻译错误: %v", toolOut)
+		}
+		if r.Header.Get("Authorization") != "Bearer k-test" {
+			t.Fatalf("鉴权头缺失")
+		}
+	})
+	defer srv.Close()
+
+	p, _ := NewResponsesProvider(UpstreamTarget{BaseURL: srv.URL + "/v1", APIKey: "k-test"}, "grok-4.6", "sess-9", capabilityFor("grok-4.6", true, nil, 500000, 65536))
+	history := []Message{
+		{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "读文件"}}},
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "call_9", Name: "read", Arguments: json.RawMessage(`{"path":"a.go"}`)}}},
+		{Role: RoleTool, ToolCallID: "call_9", Parts: []ContentPart{TextPart{Text: "package llm"}}},
+	}
+	res, err := p.Generate(context.Background(), "", nil, history, GenerateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res == nil {
+		t.Fatal("结果为空")
+	}
+}
+
+func TestResponsesProviderUpstreamError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/responses", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"message": "rate limited", "code": "429"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p, _ := NewResponsesProvider(UpstreamTarget{BaseURL: srv.URL + "/v1"}, "m", "s", capabilityFor("m", true, nil, 100, 100))
+	_, err := p.Generate(context.Background(), "", nil, []Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "x"}}}}, GenerateOptions{})
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("期望 *APIError, got %T: %v", err, err)
+	}
+	if apiErr.Kind != "rate_limited" || apiErr.RetryAfter != 2*1e9 {
+		t.Fatalf("错误分类错误: %+v", apiErr)
+	}
+	if !RetryableKind(apiErr.Kind) {
+		t.Fatal("限流应可重试")
+	}
+}
+
+// --- chat/completions 协议 ---
+
+func ccUpstream(t *testing.T, withUsage bool, checkReq func(*testing.T, map[string]any)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if checkReq != nil {
+			checkReq(t, body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+		writeSSE := func(payload string) {
+			_, _ = w.Write([]byte("data: " + payload + "\n\n"))
+			f.Flush()
+		}
+		base := func() map[string]any {
+			return map[string]any{
+				"choices": []map[string]any{
+					{"index": 0, "delta": map[string]any{}},
+				},
+			}
+		}
+		first := base()
+		first["choices"].([]map[string]any)[0]["delta"] = map[string]any{"role": "assistant", "content": "看看"}
+		writeSSE(mustJSON(first))
+		second := base()
+		second["choices"].([]map[string]any)[0]["delta"] = map[string]any{"content": "文件"}
+		writeSSE(mustJSON(second))
+		tool := base()
+		tool["choices"].([]map[string]any)[0]["delta"] = map[string]any{
+			"tool_calls": []map[string]any{
+				{"index": 0, "id": "call_cc1", "type": "function", "function": map[string]any{"name": "read", "arguments": "{\"path\":\"int"}},
+			},
+		}
+		writeSSE(mustJSON(tool))
+		tool2 := base()
+		tool2["choices"].([]map[string]any)[0]["delta"] = map[string]any{
+			"tool_calls": []map[string]any{
+				{"index": 0, "function": map[string]any{"arguments": "ernal/llm/types.go\"}"}},
+			},
+		}
+		writeSSE(mustJSON(tool2))
+		done := base()
+		finish := "tool_calls"
+		done["choices"].([]map[string]any)[0]["finish_reason"] = &finish
+		if withUsage {
+			done["usage"] = map[string]any{
+				"prompt_tokens": 90, "completion_tokens": 25,
+				"prompt_tokens_details": map[string]any{"cached_tokens": 30},
+			}
+		}
+		writeSSE(mustJSON(done))
+		writeSSE("[DONE]")
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestChatCompletionsStreamWithUsage(t *testing.T) {
+	srv := ccUpstream(t, true, func(t *testing.T, body map[string]any) {
+		if body["stream"] != true {
+			t.Fatal("应请求流式")
+		}
+		so, _ := body["stream_options"].(map[string]any)
+		if so == nil || so["include_usage"] != true {
+			t.Fatal("应请求 include_usage")
+		}
+	})
+	defer srv.Close()
+
+	p, err := NewChatCompletionsProvider(UpstreamTarget{BaseURL: srv.URL + "/v1"}, "grok-4.6", capabilityFor("grok-4.6", true, nil, 500000, 65536))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var texts strings.Builder
+	res, err := p.Generate(context.Background(), "sys", []Tool{{Name: "read", Schema: map[string]any{"type": "object"}}},
+		[]Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "读"}}}},
+		GenerateOptions{OnDelta: func(part StreamedPart) {
+			if v, ok := part.(TextDelta); ok {
+				texts.WriteString(v.Text)
+			}
+		}})
+	assertStreamResult(t, res, err)
+	if texts.String() != "看看文件" {
+		t.Fatalf("流式文本错误: %q", texts.String())
+	}
+	if res.Usage.InputCacheRead != 30 || res.Usage.InputOther != 60 || res.Usage.Output != 25 {
+		t.Fatalf("usage 错误: %+v", res.Usage)
+	}
+}
+
+func TestChatCompletionsStreamApproxUsage(t *testing.T) {
+	srv := ccUpstream(t, false, nil)
+	defer srv.Close()
+	p, _ := NewChatCompletionsProvider(UpstreamTarget{BaseURL: srv.URL + "/v1"}, "grok-4.6", capabilityFor("grok-4.6", true, nil, 500000, 65536))
+	res, err := p.Generate(context.Background(), "", nil, []Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "x"}}}}, GenerateOptions{OnDelta: func(StreamedPart) {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Accuracy != UsageApproximate {
+		t.Fatalf("未回传 usage 应标记近似: %v", res.Accuracy)
+	}
+	if res.Usage.Output <= 0 {
+		t.Fatalf("近似 usage 应有非零估算: %+v", res.Usage)
+	}
+}
+
+func TestChatCompletionsWireShape(t *testing.T) {
+	srv := ccUpstream(t, true, func(t *testing.T, body map[string]any) {
+		msgs, _ := body["messages"].([]any)
+		// system + user + assistant(tool_calls) + tool = 4 条。
+		if len(msgs) != 4 {
+			t.Fatalf("期望 system+user+assistant+tool 四条消息, got %d", len(msgs))
+		}
+		sys, _ := msgs[0].(map[string]any)
+		if sys["role"] != "system" {
+			t.Fatal("system prompt 应作为首条 system 消息")
+		}
+		assist, _ := msgs[2].(map[string]any)
+		if assist["role"] != "assistant" {
+			t.Fatalf("assistant 消息顺序错误: %v", assist)
+		}
+		toolMsg, _ := msgs[3].(map[string]any)
+		if toolMsg["role"] != "tool" || toolMsg["tool_call_id"] != "call_t9" {
+			t.Fatalf("tool 消息翻译错误: %v", toolMsg)
+		}
+	})
+	defer srv.Close()
+	p, _ := NewChatCompletionsProvider(UpstreamTarget{BaseURL: srv.URL + "/v1", APIKey: "kk"}, "m1", capabilityFor("m1", true, nil, 100, 100))
+	history := []Message{
+		{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "hi"}}},
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "call_t9", Name: "bash", Arguments: json.RawMessage(`{"cmd":"ls"}`)}}},
+		{Role: RoleTool, ToolCallID: "call_t9", Parts: []ContentPart{TextPart{Text: "file.go"}}},
+	}
+	if _, err := p.Generate(context.Background(), "sys", nil, history, GenerateOptions{OnDelta: func(StreamedPart) {}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestChatCompletionsImageContent(t *testing.T) {
+	var gotParts []any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		msgs, _ := body["messages"].([]any)
+		first, _ := msgs[0].(map[string]any)
+		content := first["content"]
+		if arr, ok := content.([]any); ok {
+			gotParts = arr
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p, _ := NewChatCompletionsProvider(UpstreamTarget{BaseURL: srv.URL + "/v1"}, "vision-m", capabilityFor("vision-m", false, nil, 100, 100))
+	msg := Message{Role: RoleUser, Parts: []ContentPart{
+		TextPart{Text: "这是什么图"},
+		ImagePart{Data: "aGVsbG8=", MimeType: "image/png"},
+	}}
+	if _, err := p.Generate(context.Background(), "", nil, []Message{msg}, GenerateOptions{OnDelta: func(StreamedPart) {}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(gotParts) != 2 {
+		t.Fatalf("图片消息应翻译为多部件数组, got %d", len(gotParts))
+	}
+	img, _ := gotParts[1].(map[string]any)
+	if img["type"] != "image_url" {
+		t.Fatalf("部件类型错误: %v", img)
+	}
+}
+
+func TestNormalizeFinishReason(t *testing.T) {
+	cases := map[string]string{
+		"stop": "stop", "end_turn": "stop", "tool_calls": "tool_use",
+		"length": "max_tokens", "content_filter": "filtered", "": "", "weird": "unknown",
+	}
+	for in, want := range cases {
+		if got := NormalizeFinishReason(in); got != want {
+			t.Fatalf("NormalizeFinishReason(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestScanSSEMultiLineData(t *testing.T) {
+	// 多行 data: 应拼接为单个事件负载（换行保留）。
+	var got sseEvent
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("event: e1\ndata: line1\ndata: line2\n\n"))
+	}))
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	err = scanSSE(context.Background(), resp, func(ev sseEvent) error {
+		got = ev
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Event != "e1" || string(got.Data) != "line1\nline2" {
+		t.Fatalf("SSE 解析错误: %+v", got)
+	}
+}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -207,6 +207,63 @@ func TestResponsesProviderWireShape(t *testing.T) {
 	}
 }
 
+// 回归：added 预设 "{}" 再追加 delta 会拼出 {}{...} 非法 JSON，
+// 导致工具参数解析必然失败、transcript 落盘 Marshal 报错。
+// 回归：done 携带完整 arguments，应覆盖中间态（含 added 缺失时的兜底）。
+func TestResponsesStreamToolCallArgumentsAccumulate(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/responses", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+		writeSSE := func(event string, payload string) {
+			_, _ = w.Write([]byte("event: " + event + "\ndata: " + payload + "\n\n"))
+			f.Flush()
+		}
+		// 场景 A：added → delta 增量（delta 前后各一段）。
+		writeSSE("response.output_item.added", `{"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","call_id":"call_a","name":"glob"}}`)
+		writeSSE("response.function_call_arguments.delta", `{"type":"response.function_call_arguments.delta","output_index":1,"delta":"{\"pat"}`)
+		writeSSE("response.function_call_arguments.delta", `{"type":"response.function_call_arguments.delta","output_index":1,"delta":"tern\":\"**/*.go\"}"}`)
+		writeSSE("response.output_item.done", `{"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","call_id":"call_a","name":"glob","arguments":"{\"pattern\":\"**/*.go\"}"}}`)
+		// 场景 B：done 兜底（added/delta 全缺失）。
+		writeSSE("response.output_item.done", `{"type":"response.output_item.done","output_index":2,"item":{"type":"function_call","call_id":"call_b","name":"read","arguments":"{\"path\":\"a.go\"}"}}`)
+		writeSSE("response.completed", `{"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":10,"output_tokens":5}}}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p, err := NewResponsesProvider(UpstreamTarget{BaseURL: srv.URL + "/v1"}, "grok-4.6", "sess-1", capabilityFor("grok-4.6", true, nil, 500000, 65536))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := p.Generate(context.Background(), "", nil, []Message{{Role: RoleUser, Parts: []ContentPart{TextPart{Text: "hi"}}}}, GenerateOptions{OnDelta: func(StreamedPart) {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Message.ToolCalls) != 2 {
+		t.Fatalf("期望 2 个工具调用, got %d", len(res.Message.ToolCalls))
+	}
+	var globArgs, readArgs json.RawMessage
+	for _, tc := range res.Message.ToolCalls {
+		switch tc.Name {
+		case "glob":
+			globArgs = tc.Arguments
+		case "read":
+			readArgs = tc.Arguments
+		}
+	}
+	if string(globArgs) != `{"pattern":"**/*.go"}` {
+		t.Fatalf("glob 参数拼接错误: %s", globArgs)
+	}
+	if string(readArgs) != `{"path":"a.go"}` {
+		t.Fatalf("read 参数兜底错误: %s", readArgs)
+	}
+	// 参数必须是合法 JSON 对象（历史 bug 在这里必然失败）。
+	var probe map[string]any
+	if err := json.Unmarshal(globArgs, &probe); err != nil {
+		t.Fatalf("glob 参数不是合法 JSON: %v (%s)", err, globArgs)
+	}
+}
+
 func TestResponsesProviderUpstreamError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/responses", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/llm/parse.go
+++ b/internal/llm/parse.go
@@ -1,0 +1,32 @@
+package llm
+
+import "errors"
+
+// stdErrorsAs 直接委托 errors.As；独立函数便于在 transport 内不重复 import。
+func stdErrorsAs(err error, target any) bool {
+	return errors.As(err, target)
+}
+
+// parseRetrySeconds 解析纯数字 Retry-After。
+func parseRetrySeconds(v string) (int64, error) {
+	var n int64
+	var dot bool
+	for i, r := range v {
+		if r == '.' && !dot && i > 0 {
+			dot = true
+			continue
+		}
+		if r < '0' || r > '9' {
+			return 0, errors.New("not numeric")
+		}
+	}
+	for _, r := range v {
+		if r >= '0' && r <= '9' {
+			n = n*10 + int64(r-'0')
+		}
+	}
+	if n == 0 && v != "0" {
+		return 0, errors.New("zero")
+	}
+	return n, nil
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -1,0 +1,41 @@
+package llm
+
+import "context"
+
+// Provider 是统一的上游对话接口（对标 kosong 的 ChatProvider）。
+// 实现必须：可并发安全使用；不保存历史（引擎是唯一的历史持有者，D1b）；
+// usage 如实标注 Accuracy。
+type Provider interface {
+	// Name 是适配器标识（"responses" / "chat_completions"）。
+	Name() string
+	// ModelName 是发送给上游的模型名。
+	ModelName() string
+	// Capability 返回模型能力表；未知字段返回零值，调用方自行 gate。
+	Capability() ModelCapability
+	// Generate 发起一次对话生成。history 为全量历史（无状态重放）。
+	Generate(ctx context.Context, systemPrompt string, tools []Tool, history []Message, opts GenerateOptions) (*StreamResult, error)
+	// WithThinking 返回设置推理强度后的浅拷贝。
+	WithThinking(effort string) Provider
+	// WithMaxOutputTokens 返回限制输出 token 后的浅拷贝；不支持实现原样返回自身。
+	WithMaxOutputTokens(n int64) Provider
+}
+
+// ModelCapability 声明模型能力（对标 kosong capability.ts）。
+// 零值/未登记模型用 UnknownCapability，调用方按最保守处理。
+type ModelCapability struct {
+	ImageIn  bool `json:"image_in"`
+	VideoIn  bool `json:"video_in"`
+	Thinking bool `json:"thinking"`
+	ToolUse  bool `json:"tool_use"`
+	// MaxContextTokens 是总上下文窗口（输入+输出）；0 表示未知。
+	MaxContextTokens int `json:"max_context_tokens"`
+	// MaxCompletionTokens 是输出上限；0 表示未知。
+	MaxCompletionTokens int `json:"max_completion_tokens"`
+	// ReasoningEfforts 是模型支持的推理强度列表；空表示不支持强度调节。
+	ReasoningEfforts []string `json:"reasoning_efforts,omitempty"`
+	// UsageAccuracy 预告该后端 usage 的可信度，适配器在结果里必须一致。
+	UsageAccuracy UsageAccuracy `json:"usage_accuracy,omitempty"`
+}
+
+// UnknownCapability 是能力未登记时的共享只读值。
+var UnknownCapability = ModelCapability{}

--- a/internal/llm/provider_chatcompletions.go
+++ b/internal/llm/provider_chatcompletions.go
@@ -1,0 +1,547 @@
+package llm
+
+// ChatCompletionsProvider 适配 OpenAI chat/completions wire 协议（POST {base}/chat/completions，SSE）。
+// 覆盖第三方中转（one-api/new-api 系）与任何 OpenAI 兼容后端（见设计文档 D7）。
+//
+// 会话状态模型与 Responses 相同：无状态重放（D1b），历史全量进 messages。
+// usage：流式请求带 stream_options.include_usage，上游多数会回传；
+// 拿不到时按字符估算并标记 UsageApproximate（D3）。
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type ChatCompletionsProvider struct {
+	target    UpstreamTarget
+	model     string
+	effort    string
+	maxTokens int64
+	cap       ModelCapability
+	// wirePath 是请求路径；默认 "/chat/completions"，工厂可覆盖。
+	wirePath string
+
+	client httpClient
+}
+
+// NewChatCompletionsProvider 构造适配器。capability 由 server 层从 Profile 汇出；
+// 该后端 usage 可信度按上游回传动态判定，初始标记见 Generate。
+func NewChatCompletionsProvider(target UpstreamTarget, model string, cap ModelCapability) (*ChatCompletionsProvider, error) {
+	client, err := newHTTPClient(target)
+	if err != nil {
+		return nil, err
+	}
+	return &ChatCompletionsProvider{
+		target: target,
+		model:  model,
+		cap:    cap,
+		client: client,
+	}, nil
+}
+
+func (p *ChatCompletionsProvider) Name() string      { return "chat_completions" }
+func (p *ChatCompletionsProvider) ModelName() string { return p.model }
+func (p *ChatCompletionsProvider) Capability() ModelCapability {
+	return p.cap
+}
+
+func (p *ChatCompletionsProvider) WithThinking(effort string) Provider {
+	clone := *p
+	clone.effort = effort
+	return &clone
+}
+
+func (p *ChatCompletionsProvider) WithMaxOutputTokens(n int64) Provider {
+	clone := *p
+	clone.maxTokens = n
+	return &clone
+}
+
+// --- wire 请求/响应结构 ---
+
+type ccRequest struct {
+	Model           string           `json:"model"`
+	Messages        []ccMessage      `json:"messages"`
+	Tools           []ccTool         `json:"tools,omitempty"`
+	Stream          bool             `json:"stream"`
+	StreamOptions   *ccStreamOptions `json:"stream_options,omitempty"`
+	MaxTokens       int64            `json:"max_tokens,omitempty"`
+	ReasoningEffort string           `json:"reasoning_effort,omitempty"`
+}
+
+type ccStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type ccTool struct {
+	Type     string    `json:"type"`
+	Function ccToolDef `json:"function"`
+}
+
+type ccToolDef struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+type ccMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content,omitempty"`
+	ToolCalls  []ccToolCall    `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+}
+
+type ccToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"` // "function"
+	Function ccFunc `json:"function"`
+}
+
+type ccFunc struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// --- 统一消息 → chat/completions messages 翻译 ---
+
+// ccContentPart 是 content 数组部件（多模态形态）。
+type ccContentPart struct {
+	Type     string      `json:"type"` // text | image_url
+	Text     string      `json:"text,omitempty"`
+	ImageURL *ccImageURL `json:"image_url,omitempty"`
+}
+
+type ccImageURL struct {
+	URL string `json:"url"`
+}
+
+func buildCCMessages(systemPrompt string, history []Message) []ccMessage {
+	msgs := make([]ccMessage, 0, len(history)+1)
+	if strings.TrimSpace(systemPrompt) != "" {
+		msgs = append(msgs, ccMessage{Role: "system", Content: mustJSONRaw(systemPrompt)})
+	}
+	for _, m := range history {
+		switch m.Role {
+		case RoleUser:
+			msgs = append(msgs, ccMessage{Role: "user", Content: buildCCContent(m)})
+		case RoleSystem:
+			msgs = append(msgs, ccMessage{Role: "system", Content: buildCCContent(m)})
+		case RoleAssistant:
+			cm := ccMessage{Role: "assistant"}
+			if txt := m.Text(); txt != "" {
+				cm.Content = mustJSONRaw(txt)
+			}
+			for _, tc := range m.ToolCalls {
+				cm.ToolCalls = append(cm.ToolCalls, ccToolCall{
+					ID:   tc.ID,
+					Type: "function",
+					Function: ccFunc{
+						Name:      tc.Name,
+						Arguments: string(tc.Arguments),
+					},
+				})
+			}
+			if cm.Content == nil && len(cm.ToolCalls) == 0 {
+				cm.Content = mustJSONRaw("")
+			}
+			msgs = append(msgs, cm)
+		case RoleTool:
+			msgs = append(msgs, ccMessage{
+				Role:       "tool",
+				Content:    mustJSONRaw(m.Text()),
+				ToolCallID: m.ToolCallID,
+			})
+		}
+	}
+	return msgs
+}
+
+// buildCCContent 把消息部件翻译成 content：纯文本 → 字符串；含图 → 数组。
+func buildCCContent(m Message) json.RawMessage {
+	hasImage := false
+	texts := make([]string, 0, len(m.Parts))
+	for _, p := range m.Parts {
+		switch part := p.(type) {
+		case TextPart:
+			if part.Text != "" {
+				texts = append(texts, part.Text)
+			}
+		case ImagePart:
+			hasImage = true
+		case ThinkPart:
+			// 思考内容不重放（同 Responses 适配器的决策）。
+		}
+	}
+	if hasImage {
+		parts := make([]ccContentPart, 0, len(m.Parts))
+		for _, p := range m.Parts {
+			switch part := p.(type) {
+			case TextPart:
+				if part.Text != "" {
+					parts = append(parts, ccContentPart{Type: "text", Text: part.Text})
+				}
+			case ImagePart:
+				url := part.URI
+				if part.Data != "" {
+					url = "data:" + imageMime(part) + ";base64," + part.Data
+				}
+				if url != "" {
+					parts = append(parts, ccContentPart{Type: "image_url", ImageURL: &ccImageURL{URL: url}})
+				}
+			}
+		}
+		if len(parts) == 0 {
+			return mustJSONRaw("")
+		}
+		b, _ := json.Marshal(parts)
+		return b
+	}
+	return mustJSONRaw(strings.Join(texts, "\n"))
+}
+
+func mustJSONRaw(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}
+
+func buildCCTools(tools []Tool) []ccTool {
+	out := make([]ccTool, 0, len(tools))
+	for _, t := range tools {
+		schema := t.Schema
+		if schema == nil {
+			schema = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
+		out = append(out, ccTool{
+			Type: "function",
+			Function: ccToolDef{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  schema,
+			},
+		})
+	}
+	return out
+}
+
+// --- Generate ---
+
+func (p *ChatCompletionsProvider) buildRequest(systemPrompt string, tools []Tool, history []Message, opts GenerateOptions) ([]byte, error) {
+	if len(tools) > 0 && !p.cap.ToolUse {
+		return nil, errToolUseUnsupported(p.model)
+	}
+	req := ccRequest{
+		Model:     p.model,
+		Messages:  buildCCMessages(systemPrompt, history),
+		Tools:     buildCCTools(tools),
+		Stream:    opts.OnDelta != nil,
+		MaxTokens: p.maxTokens,
+	}
+	if opts.OnDelta != nil {
+		req.StreamOptions = &ccStreamOptions{IncludeUsage: true}
+	}
+	if effort := validateEffort(effectiveEffort(p.effort, opts.Effort), p.cap); effort != "" {
+		req.ReasoningEffort = effort
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (p *ChatCompletionsProvider) Generate(ctx context.Context, systemPrompt string, tools []Tool, history []Message, opts GenerateOptions) (*StreamResult, error) {
+	body, err := p.buildRequest(systemPrompt, tools, history, opts)
+	if err != nil {
+		return nil, err
+	}
+	path := p.wirePath
+	if path == "" {
+		path = "/chat/completions"
+	}
+	resp, err := doJSON(ctx, p.client, p.target, path, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, NewAPIError(ClassifyStatus(resp.StatusCode), resp.StatusCode, decodeJSONBody(upstreamErrorBody(resp)), retryAfterFrom(resp))
+	}
+	if opts.OnDelta == nil {
+		return decodeCCNonStream(resp)
+	}
+	return decodeCCStream(ctx, resp, opts.OnDelta)
+}
+
+// --- 非流式解析 ---
+
+type ccResponse struct {
+	Choices []struct {
+		Message struct {
+			Content          any          `json:"content"`
+			ToolCalls        []ccToolCall `json:"tool_calls"`
+			ReasoningContent string       `json:"reasoning_content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens        int64 `json:"prompt_tokens"`
+		CompletionTokens    int64 `json:"completion_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int64 `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+	} `json:"usage"`
+}
+
+func decodeCCNonStream(resp *http.Response) (*StreamResult, error) {
+	var parsed ccResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("llm: 解析 chat/completions 响应失败: %w", err)
+	}
+	return assembleCCChoice(len(parsed.Choices) > 0, &parsed.Choices[0], &parsed.Usage), nil
+}
+
+// assembleCCChoice 把单个 choice 装配成统一结果（流式/非流式共用）。
+func assembleCCChoice(hasChoice bool, choice *struct {
+	Message struct {
+		Content          any          `json:"content"`
+		ToolCalls        []ccToolCall `json:"tool_calls"`
+		ReasoningContent string       `json:"reasoning_content"`
+	} `json:"message"`
+	FinishReason string `json:"finish_reason"`
+}, usage *struct {
+	PromptTokens        int64 `json:"prompt_tokens"`
+	CompletionTokens    int64 `json:"completion_tokens"`
+	PromptTokensDetails *struct {
+		CachedTokens int64 `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+}) *StreamResult {
+	msg := Message{Role: RoleAssistant}
+	if hasChoice {
+		switch c := choice.Message.Content.(type) {
+		case string:
+			if c != "" {
+				msg.Parts = append(msg.Parts, TextPart{Text: c})
+			}
+		case []any:
+			for _, item := range c {
+				if obj, ok := item.(map[string]any); ok {
+					if t, _ := obj["text"].(string); t != "" {
+						msg.Parts = append(msg.Parts, TextPart{Text: t})
+					}
+				}
+			}
+		}
+		if rc := choice.Message.ReasoningContent; rc != "" {
+			msg.Parts = append(msg.Parts, ThinkPart{Text: rc})
+		}
+		for _, tc := range choice.Message.ToolCalls {
+			msg.ToolCalls = append(msg.ToolCalls, ToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: json.RawMessage(orEmptyJSON(tc.Function.Arguments)),
+			})
+		}
+	}
+	result := &StreamResult{
+		Message:      msg,
+		FinishReason: NormalizeFinishReason(choiceFinish(hasChoice, choice)),
+	}
+	if usage != nil && usage.PromptTokens > 0 {
+		cached := int64(0)
+		if usage.PromptTokensDetails != nil {
+			cached = usage.PromptTokensDetails.CachedTokens
+		}
+		result.Usage = TokenUsage{
+			InputOther:     usage.PromptTokens - cached,
+			Output:         usage.CompletionTokens,
+			InputCacheRead: cached,
+		}
+		result.Accuracy = UsageExact
+	} else {
+		result.Usage = TokenUsage{Output: EstimateMessageTokens(msg)}
+		result.Accuracy = UsageApproximate
+	}
+	return result
+}
+
+func choiceFinish(hasChoice bool, choice *struct {
+	Message struct {
+		Content          any          `json:"content"`
+		ToolCalls        []ccToolCall `json:"tool_calls"`
+		ReasoningContent string       `json:"reasoning_content"`
+	} `json:"message"`
+	FinishReason string `json:"finish_reason"`
+}) string {
+	if !hasChoice {
+		return "unknown"
+	}
+	return choice.FinishReason
+}
+
+// --- 流式解析 ---
+
+// ccChunk 是 chat/completions 流式 chunk。
+type ccChunk struct {
+	Choices []struct {
+		Index int `json:"index"`
+		Delta struct {
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+			ToolCalls        []struct {
+				Index    int    `json:"index"`
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+			Role string `json:"role"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens        int64 `json:"prompt_tokens"`
+		CompletionTokens    int64 `json:"completion_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int64 `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+	} `json:"usage"`
+	Error *struct {
+		Message string `json:"message"`
+		Code    any    `json:"code"`
+	} `json:"error"`
+}
+
+func decodeCCStream(ctx context.Context, resp *http.Response, onDelta func(StreamedPart)) (*StreamResult, error) {
+	state := newCCStreamState()
+	err := scanSSE(ctx, resp, func(ev sseEvent) error {
+		if ev.Event != "" && ev.Event != "message" && ev.Event != "data" {
+			// chat/completions SSE 通常无 event 字段；非标准 event 忽略。
+			return nil
+		}
+		return state.handle(ev.Data, onDelta)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return state.result()
+}
+
+type ccStreamState struct {
+	msg      Message
+	usage    TokenUsage
+	hasUsage bool
+	finish   string
+	// toolIndex 把上游工具调用 index 映射到 msg.ToolCalls 下标。
+	toolIndex map[int]int
+	// callArgs 按下标累积参数增量，保证拼接顺序稳定。
+	callArgs map[int]string
+}
+
+func newCCStreamState() *ccStreamState {
+	return &ccStreamState{
+		toolIndex: map[int]int{},
+		callArgs:  map[int]string{},
+	}
+}
+
+func (s *ccStreamState) handle(data []byte, onDelta func(StreamedPart)) error {
+	if string(data) == "[DONE]" {
+		return nil
+	}
+	var chunk ccChunk
+	if json.Unmarshal(data, &chunk) != nil {
+		return nil
+	}
+	if chunk.Error != nil {
+		return NewAPIError("unknown", 0, chunk.Error.Message, 0)
+	}
+	if chunk.Usage != nil {
+		cached := int64(0)
+		if chunk.Usage.PromptTokensDetails != nil {
+			cached = chunk.Usage.PromptTokensDetails.CachedTokens
+		}
+		s.usage = TokenUsage{
+			InputOther:     chunk.Usage.PromptTokens - cached,
+			Output:         chunk.Usage.CompletionTokens,
+			InputCacheRead: cached,
+		}
+		if s.usage.InputOther < 0 {
+			s.usage.InputOther = chunk.Usage.PromptTokens
+		}
+		s.hasUsage = true
+	}
+	for _, ch := range chunk.Choices {
+		d := ch.Delta
+		if d.ReasoningContent != "" {
+			onDelta(ThinkDelta{Text: d.ReasoningContent})
+			s.msg.Parts = append(s.msg.Parts, ThinkPart{Text: d.ReasoningContent})
+		}
+		if d.Content != "" {
+			onDelta(TextDelta{Text: d.Content})
+			s.appendText(d.Content)
+		}
+		for _, tcd := range d.ToolCalls {
+			idx, ok := s.toolIndex[tcd.Index]
+			if !ok {
+				idx = len(s.msg.ToolCalls)
+				s.toolIndex[tcd.Index] = idx
+				s.msg.ToolCalls = append(s.msg.ToolCalls, ToolCall{
+					ID:        tcd.ID,
+					Name:      tcd.Function.Name,
+					Arguments: json.RawMessage("{}"),
+				})
+				onDelta(ToolCallBegin{Call: s.msg.ToolCalls[idx]})
+			}
+			if tcd.Function.Arguments != "" {
+				s.callArgs[idx] += tcd.Function.Arguments
+				s.msg.ToolCalls[idx].Arguments = json.RawMessage(s.callArgs[idx])
+				onDelta(ToolCallDelta{CallIndex: idx, ArgumentsDelta: tcd.Function.Arguments})
+			}
+			if tcd.Function.Name != "" {
+				s.msg.ToolCalls[idx].Name = tcd.Function.Name
+			}
+			if tcd.ID != "" {
+				s.msg.ToolCalls[idx].ID = tcd.ID
+			}
+		}
+		if ch.FinishReason != nil && *ch.FinishReason != "" {
+			s.finish = *ch.FinishReason
+		}
+	}
+	return nil
+}
+
+func (s *ccStreamState) appendText(delta string) {
+	if n := len(s.msg.Parts); n > 0 {
+		if t, ok := s.msg.Parts[n-1].(TextPart); ok {
+			s.msg.Parts[n-1] = TextPart{Text: t.Text + delta}
+			return
+		}
+	}
+	s.msg.Parts = append(s.msg.Parts, TextPart{Text: delta})
+}
+
+func (s *ccStreamState) result() (*StreamResult, error) {
+	accuracy := UsageExact
+	if !s.hasUsage {
+		s.usage = TokenUsage{Output: EstimateMessageTokens(s.msg)}
+		accuracy = UsageApproximate
+	}
+	// 工具调用优先于 finish_reason：部分中转不带 finish_reason 或提前给 stop。
+	if len(s.msg.ToolCalls) > 0 {
+		s.finish = "tool_use"
+	} else if s.finish == "" {
+		s.finish = "stop"
+	}
+	return &StreamResult{
+		Message:      s.msg,
+		Usage:        s.usage,
+		Accuracy:     accuracy,
+		FinishReason: NormalizeFinishReason(s.finish),
+	}, nil
+}

--- a/internal/llm/provider_responses.go
+++ b/internal/llm/provider_responses.go
@@ -46,12 +46,16 @@ type responsesStreamState struct {
 	callIndex map[int64]int
 	// callBegin 已通告过的 output_index，避免重复 ToolCallBegin。
 	callBegin map[int64]bool
+	// callArgs 按 output_index 原样累积 function_call_arguments.delta；
+	// 存字符串而不是直接写 RawMessage，保证中间态非法 JSON 也不影响回放序列化。
+	callArgs map[int64]string
 }
 
 func newResponsesStreamState() *responsesStreamState {
 	return &responsesStreamState{
 		callIndex: map[int64]int{},
 		callBegin: map[int64]bool{},
+		callArgs:  map[int64]string{},
 	}
 }
 
@@ -68,7 +72,8 @@ type responseCompleted struct {
 
 // outputItemDone 携带单个 output 条目（function_call 的兜底路径）。
 type outputItemDone struct {
-	Item struct {
+	OutputIndex int64 `json:"output_index"`
+	Item        struct {
 		Type      string `json:"type"`
 		CallID    string `json:"call_id"`
 		Name      string `json:"name"`
@@ -105,18 +110,22 @@ func (s *responsesStreamState) handle(data []byte, onDelta func(StreamedPart)) e
 		var e struct {
 			OutputIndex int64 `json:"output_index"`
 			Item        struct {
-				Type   string `json:"type"`
-				CallID string `json:"call_id"`
-				Name   string `json:"name"`
+				Type      string `json:"type"`
+				CallID    string `json:"call_id"`
+				Name      string `json:"name"`
+				Arguments string `json:"arguments"`
 			} `json:"item"`
 		}
 		if json.Unmarshal(data, &e) == nil && e.Item.Type == "function_call" {
 			idx := len(s.msg.ToolCalls)
 			s.callIndex[e.OutputIndex] = idx
+			// added 自带部分 arguments 时以它为初值；不要预设 "{}"——
+			// 否则后续 delta 追加会拼出 {}{...} 的非法 JSON。
+			s.callArgs[e.OutputIndex] = e.Item.Arguments
 			s.msg.ToolCalls = append(s.msg.ToolCalls, ToolCall{
 				ID:        e.Item.CallID,
 				Name:      e.Item.Name,
-				Arguments: json.RawMessage("{}"),
+				Arguments: json.RawMessage(e.Item.Arguments),
 			})
 			if !s.callBegin[e.OutputIndex] {
 				s.callBegin[e.OutputIndex] = true
@@ -130,16 +139,24 @@ func (s *responsesStreamState) handle(data []byte, onDelta func(StreamedPart)) e
 		}
 		if json.Unmarshal(data, &e) == nil && e.Delta != "" {
 			if idx, ok := s.callIndex[e.OutputIndex]; ok {
-				s.msg.ToolCalls[idx].Arguments = json.RawMessage(string(s.msg.ToolCalls[idx].Arguments) + e.Delta)
+				s.callArgs[e.OutputIndex] += e.Delta
+				s.msg.ToolCalls[idx].Arguments = json.RawMessage(s.callArgs[e.OutputIndex])
 				onDelta(ToolCallDelta{CallIndex: idx, ArgumentsDelta: e.Delta})
 			}
 		}
 	case "response.output_item.done":
 		var e outputItemDone
 		if json.Unmarshal(data, &e) == nil && e.Item.Type == "function_call" {
-			// 兜底：若 added 事件缺失（部分代理实现），在此补齐。
-			if s.findCall(e.Item.CallID) < 0 {
+			// done 携带完整 arguments：无论 added/delta 走过没有，都以它为准，
+			// 修正部分代理增量流不完整或缺失的中间态。
+			if idx := s.findCall(e.Item.CallID); idx >= 0 {
+				s.callArgs[e.OutputIndex] = e.Item.Arguments
+				s.msg.ToolCalls[idx].Arguments = json.RawMessage(orEmptyJSON(e.Item.Arguments))
+			} else {
+				// 兜底：若 added 事件缺失（部分代理实现），在此补齐。
 				idx := len(s.msg.ToolCalls)
+				s.callIndex[e.OutputIndex] = idx
+				s.callArgs[e.OutputIndex] = e.Item.Arguments
 				s.msg.ToolCalls = append(s.msg.ToolCalls, ToolCall{
 					ID:        e.Item.CallID,
 					Name:      e.Item.Name,

--- a/internal/llm/provider_responses.go
+++ b/internal/llm/provider_responses.go
@@ -1,0 +1,615 @@
+package llm
+
+// ResponsesProvider 适配 OpenAI Responses wire 协议（POST {base}/responses，SSE）。
+// 上游预期是 loopback /grok/v1 代理（见设计文档 D2/D1b）；也可指向任何
+// Responses 兼容端点。
+//
+// 会话状态模型：无状态重放。每步发送完整 input 数组；不使用
+// previous_response_id（D1b）。prompt_cache_key 由调用方通过 SessionKey 注入，
+// 交给代理层做账号粘性。
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// httpClient 抽象 *http.Client 便于测试注入。
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// decodeStream 解析 SSE 流并装配结果；onDelta 逐段回调。
+func (p *ResponsesProvider) decodeStream(ctx context.Context, resp *http.Response, onDelta func(StreamedPart)) (*StreamResult, error) {
+	state := newResponsesStreamState()
+	err := scanSSE(ctx, resp, func(ev sseEvent) error {
+		if ev.Event != "" && !strings.HasPrefix(ev.Event, "response.") {
+			return nil
+		}
+		return state.handle(ev.Data, onDelta)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return state.result()
+}
+
+// responsesStreamState 累积流式事件并装配最终消息。
+type responsesStreamState struct {
+	msg      Message
+	usage    TokenUsage
+	hasUsage bool
+	finish   string
+	// callIndex 把上游 output_index 映射到 msg.ToolCalls 下标。
+	callIndex map[int64]int
+	// callBegin 已通告过的 output_index，避免重复 ToolCallBegin。
+	callBegin map[int64]bool
+}
+
+func newResponsesStreamState() *responsesStreamState {
+	return &responsesStreamState{
+		callIndex: map[int64]int{},
+		callBegin: map[int64]bool{},
+	}
+}
+
+// streamEnvelope 是 Responses SSE 事件的最外层。
+type streamEnvelope struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// responseCompleted 事件携带完整响应对象。
+type responseCompleted struct {
+	Response responsesResponse `json:"response"`
+}
+
+// outputItemDone 携带单个 output 条目（function_call 的兜底路径）。
+type outputItemDone struct {
+	Item struct {
+		Type      string `json:"type"`
+		CallID    string `json:"call_id"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"item"`
+}
+
+func (s *responsesStreamState) handle(data []byte, onDelta func(StreamedPart)) error {
+	// 事件负载本身是完整 JSON 对象（含 type 字段）；兼容 data 为 envelope 的两种形态。
+	var typed struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return nil // 忽略无法解析的事件（心跳等）
+	}
+	switch typed.Type {
+	case "response.output_text.delta":
+		var e struct {
+			Delta string `json:"delta"`
+		}
+		if json.Unmarshal(data, &e) == nil && e.Delta != "" {
+			onDelta(TextDelta{Text: e.Delta})
+			s.appendText(e.Delta)
+		}
+	case "response.reasoning_summary_text.delta":
+		var e struct {
+			Delta string `json:"delta"`
+		}
+		if json.Unmarshal(data, &e) == nil && e.Delta != "" {
+			onDelta(ThinkDelta{Text: e.Delta})
+			s.msg.Parts = append(s.msg.Parts, ThinkPart{Text: e.Delta})
+		}
+	case "response.output_item.added":
+		var e struct {
+			OutputIndex int64 `json:"output_index"`
+			Item        struct {
+				Type   string `json:"type"`
+				CallID string `json:"call_id"`
+				Name   string `json:"name"`
+			} `json:"item"`
+		}
+		if json.Unmarshal(data, &e) == nil && e.Item.Type == "function_call" {
+			idx := len(s.msg.ToolCalls)
+			s.callIndex[e.OutputIndex] = idx
+			s.msg.ToolCalls = append(s.msg.ToolCalls, ToolCall{
+				ID:        e.Item.CallID,
+				Name:      e.Item.Name,
+				Arguments: json.RawMessage("{}"),
+			})
+			if !s.callBegin[e.OutputIndex] {
+				s.callBegin[e.OutputIndex] = true
+				onDelta(ToolCallBegin{Call: s.msg.ToolCalls[idx]})
+			}
+		}
+	case "response.function_call_arguments.delta":
+		var e struct {
+			OutputIndex int64  `json:"output_index"`
+			Delta       string `json:"delta"`
+		}
+		if json.Unmarshal(data, &e) == nil && e.Delta != "" {
+			if idx, ok := s.callIndex[e.OutputIndex]; ok {
+				s.msg.ToolCalls[idx].Arguments = json.RawMessage(string(s.msg.ToolCalls[idx].Arguments) + e.Delta)
+				onDelta(ToolCallDelta{CallIndex: idx, ArgumentsDelta: e.Delta})
+			}
+		}
+	case "response.output_item.done":
+		var e outputItemDone
+		if json.Unmarshal(data, &e) == nil && e.Item.Type == "function_call" {
+			// 兜底：若 added 事件缺失（部分代理实现），在此补齐。
+			if s.findCall(e.Item.CallID) < 0 {
+				idx := len(s.msg.ToolCalls)
+				s.msg.ToolCalls = append(s.msg.ToolCalls, ToolCall{
+					ID:        e.Item.CallID,
+					Name:      e.Item.Name,
+					Arguments: json.RawMessage(orEmptyJSON(e.Item.Arguments)),
+				})
+				onDelta(ToolCallBegin{Call: s.msg.ToolCalls[idx]})
+			}
+		}
+	case "response.completed", "response.incomplete", "response.failed":
+		var e responseCompleted
+		if json.Unmarshal(data, &e) == nil {
+			parsed := e.Response
+			// 流式下 output 已逐段累积；仅采纳 usage 与状态。
+			s.usage = TokenUsage{
+				InputOther:     parsed.Usage.InputTokens - parsed.Usage.InputTokensDetails.CachedTokens,
+				Output:         parsed.Usage.OutputTokens,
+				InputCacheRead: parsed.Usage.InputTokensDetails.CachedTokens,
+			}
+			if s.usage.InputOther < 0 {
+				s.usage.InputOther = parsed.Usage.InputTokens
+			}
+			s.hasUsage = true
+			s.finish = responsesFinishReason(parsed.Status, parsed.IncompleteDetails)
+			// 流式装配置信度高于逐段累积：若累积为空而响应带输出，兜底装配。
+			if len(s.msg.Parts) == 0 && len(s.msg.ToolCalls) == 0 {
+				result := assembleResponsesOutput(&parsed)
+				s.msg = result.Message
+			}
+		}
+		if typed.Type == "response.failed" {
+			var e struct {
+				Response struct {
+					Error *struct {
+						Message string `json:"message"`
+						Code    string `json:"code"`
+					} `json:"error"`
+				} `json:"response"`
+			}
+			if json.Unmarshal(data, &e) == nil && e.Response.Error != nil {
+				return NewAPIError("unknown", 0, decodeJSONBody(mustJSON(e.Response.Error)), 0)
+			}
+		}
+	case "error":
+		var e struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(data, &e) == nil {
+			return NewAPIError("unknown", 0, e.Message+" ["+e.Code+"]", 0)
+		}
+	}
+	return nil
+}
+
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func (s *responsesStreamState) findCall(callID string) int {
+	for i, tc := range s.msg.ToolCalls {
+		if tc.ID == callID {
+			return i
+		}
+	}
+	return -1
+}
+
+func (s *responsesStreamState) appendText(delta string) {
+	if n := len(s.msg.Parts); n > 0 {
+		if t, ok := s.msg.Parts[n-1].(TextPart); ok {
+			s.msg.Parts[n-1] = TextPart{Text: t.Text + delta}
+			return
+		}
+	}
+	s.msg.Parts = append(s.msg.Parts, TextPart{Text: delta})
+}
+
+func (s *responsesStreamState) result() (*StreamResult, error) {
+	accuracy := UsageExact
+	if !s.hasUsage {
+		// 上游未回传 usage（部分中转代理）：按估算标记近似。
+		total := EstimateMessageTokens(s.msg)
+		s.usage = TokenUsage{Output: total}
+		accuracy = UsageApproximate
+	}
+	// 工具调用优先于状态字段：completed 状态下携带 function_call 时，
+	// loop 必须继续执行工具，finish 判定不能是 stop。
+	if len(s.msg.ToolCalls) > 0 {
+		s.finish = "tool_use"
+	} else if s.finish == "" {
+		s.finish = "stop"
+	}
+	return &StreamResult{
+		Message:      s.msg,
+		Usage:        s.usage,
+		Accuracy:     accuracy,
+		FinishReason: NormalizeFinishReason(s.finish),
+	}, nil
+}
+
+type ResponsesProvider struct {
+	target     UpstreamTarget
+	model      string
+	sessionKey string
+	effort     string
+	maxTokens  int64
+	cap        ModelCapability
+	// wirePath 是请求路径；默认 "/responses"，工厂可覆盖。
+	wirePath string
+
+	client httpClient
+}
+
+// NewResponsesProvider 构造适配器。capability 由 server 层从 Profile 汇出。
+func NewResponsesProvider(target UpstreamTarget, model, sessionKey string, cap ModelCapability) (*ResponsesProvider, error) {
+	client, err := newHTTPClient(target)
+	if err != nil {
+		return nil, err
+	}
+	return &ResponsesProvider{
+		target:     target,
+		model:      model,
+		sessionKey: sessionKey,
+		cap:        cap,
+		client:     client,
+	}, nil
+}
+
+func (p *ResponsesProvider) Name() string      { return "responses" }
+func (p *ResponsesProvider) ModelName() string { return p.model }
+func (p *ResponsesProvider) Capability() ModelCapability {
+	return p.cap
+}
+
+func (p *ResponsesProvider) WithThinking(effort string) Provider {
+	clone := *p
+	clone.effort = effort
+	return &clone
+}
+
+func (p *ResponsesProvider) WithMaxOutputTokens(n int64) Provider {
+	clone := *p
+	clone.maxTokens = n
+	return &clone
+}
+
+// responsesRequest 是 Responses wire 请求体的最小集。
+type responsesRequest struct {
+	Model           string              `json:"model"`
+	Input           []responsesInput    `json:"input"`
+	Instructions    string              `json:"instructions,omitempty"`
+	Tools           []responsesTool     `json:"tools,omitempty"`
+	Stream          bool                `json:"stream"`
+	Store           bool                `json:"store"`
+	MaxOutputTokens int64               `json:"max_output_tokens,omitempty"`
+	Reasoning       *responsesReasoning `json:"reasoning,omitempty"`
+	PromptCacheKey  string              `json:"prompt_cache_key,omitempty"`
+}
+
+type responsesReasoning struct {
+	Effort  string `json:"effort,omitempty"`
+	Summary string `json:"summary,omitempty"`
+}
+
+type responsesTool struct {
+	Type        string         `json:"type"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+	Strict      bool           `json:"strict,omitempty"`
+}
+
+// responsesInput 是 input 数组的一个条目。Responses wire 对消息、function_call、
+// function_call_output 用不同的字段集，统一在一个 struct 里按需填充。
+type responsesInput struct {
+	Type string `json:"type,omitempty"` // message | function_call | function_call_output | reasoning
+
+	Role    string          `json:"role,omitempty"`
+	Content []responsesPart `json:"content,omitempty"`
+
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	Output    string `json:"output,omitempty"`
+
+	// reasoning 条目（回放 assistant 思考）：
+	ID               string             `json:"id,omitempty"`
+	Summary          []responsesSummary `json:"summary,omitempty"`
+	EncryptedContent string             `json:"encrypted_content,omitempty"`
+}
+
+type responsesSummary struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type responsesPart struct {
+	Type     string `json:"type"` // input_text | output_text | input_image
+	Text     string `json:"text,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
+}
+
+// --- 统一消息 → Responses input 翻译 ---
+
+func buildResponsesInput(history []Message) []responsesInput {
+	items := make([]responsesInput, 0, len(history))
+	for _, m := range history {
+		switch m.Role {
+		case RoleUser, RoleSystem:
+			items = append(items, responsesInput{
+				Type:    "message",
+				Role:    string(m.Role),
+				Content: buildResponsesContent(m, "input_text", "input_image"),
+			})
+		case RoleAssistant:
+			if len(m.ToolCalls) > 0 {
+				// 文本与 function_call 分开成条目；先文本后调用。
+				if txt := m.Text(); txt != "" {
+					items = append(items, responsesInput{
+						Type:    "message",
+						Role:    "assistant",
+						Content: []responsesPart{{Type: "output_text", Text: txt}},
+					})
+				}
+				for _, tc := range m.ToolCalls {
+					items = append(items, responsesInput{
+						Type:      "function_call",
+						CallID:    tc.ID,
+						Name:      tc.Name,
+						Arguments: string(tc.Arguments),
+					})
+				}
+			} else {
+				items = append(items, responsesInput{
+					Type:    "message",
+					Role:    "assistant",
+					Content: buildResponsesContent(m, "output_text", ""),
+				})
+			}
+		case RoleTool:
+			items = append(items, responsesInput{
+				Type:   "function_call_output",
+				CallID: m.ToolCallID,
+				Output: m.Text(),
+			})
+		}
+	}
+	return items
+}
+
+func buildResponsesContent(m Message, textType, imageType string) []responsesPart {
+	parts := make([]responsesPart, 0, len(m.Parts))
+	for _, p := range m.Parts {
+		switch part := p.(type) {
+		case TextPart:
+			if part.Text != "" {
+				parts = append(parts, responsesPart{Type: textType, Text: part.Text})
+			}
+		case ImagePart:
+			if imageType == "" {
+				continue
+			}
+			if part.Data != "" {
+				parts = append(parts, responsesPart{Type: imageType, ImageURL: "data:" + imageMime(part) + ";base64," + part.Data})
+			} else if part.URI != "" {
+				parts = append(parts, responsesPart{Type: imageType, ImageURL: part.URI})
+			}
+		case ThinkPart:
+			// 思考内容不作为消息内容重放：上游服务端 reasoning 状态在无状态
+			// 重放下不可恢复，重发明文可能污染上下文。引擎在 compaction 层
+			// 用摘要继承（ctxmem），这里直接丢弃。
+		}
+	}
+	return parts
+}
+
+func imageMime(p ImagePart) string {
+	if p.MimeType != "" {
+		return p.MimeType
+	}
+	return "image/png"
+}
+
+// buildResponsesTools 翻译统一 Tool 定义。空 Schema 补 object。
+func buildResponsesTools(tools []Tool) []responsesTool {
+	out := make([]responsesTool, 0, len(tools))
+	for _, t := range tools {
+		schema := t.Schema
+		if schema == nil {
+			schema = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
+		out = append(out, responsesTool{
+			Type:        "function",
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  schema,
+			Strict:      false,
+		})
+	}
+	return out
+}
+
+// --- 请求体组装与响应解析 ---
+
+func (p *ResponsesProvider) buildRequest(systemPrompt string, tools []Tool, history []Message, opts GenerateOptions) ([]byte, error) {
+	if len(tools) > 0 && !p.cap.ToolUse {
+		return nil, errToolUseUnsupported(p.model)
+	}
+	req := responsesRequest{
+		Model:           p.model,
+		Input:           buildResponsesInput(history),
+		Instructions:    systemPrompt,
+		Tools:           buildResponsesTools(tools),
+		Stream:          opts.OnDelta != nil,
+		Store:           false, // 无状态重放：上游不存会话（D1b）
+		MaxOutputTokens: p.maxTokens,
+		PromptCacheKey:  p.sessionKey,
+	}
+	if effort := validateEffort(effectiveEffort(p.effort, opts.Effort), p.cap); effort != "" {
+		req.Reasoning = &responsesReasoning{Effort: effort, Summary: "auto"}
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func effectiveEffort(defaultEffort, perCall string) string {
+	if perCall != "" {
+		return perCall
+	}
+	return defaultEffort
+}
+
+func (p *ResponsesProvider) Generate(ctx context.Context, systemPrompt string, tools []Tool, history []Message, opts GenerateOptions) (*StreamResult, error) {
+	body, err := p.buildRequest(systemPrompt, tools, history, opts)
+	if err != nil {
+		return nil, err
+	}
+	path := p.wirePath
+	if path == "" {
+		path = "/responses"
+	}
+	resp, err := doJSON(ctx, p.client, p.target, path, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, NewAPIError(ClassifyStatus(resp.StatusCode), resp.StatusCode, decodeJSONBody(upstreamErrorBody(resp)), retryAfterFrom(resp))
+	}
+
+	if opts.OnDelta == nil {
+		return p.decodeNonStream(resp)
+	}
+	return p.decodeStream(ctx, resp, opts.OnDelta)
+}
+
+// --- 非流式解析 ---
+
+type responsesResponse struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Output []struct {
+		Type    string `json:"type"`
+		ID      string `json:"id"`
+		Role    string `json:"role"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		Summary []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"summary"`
+		CallID    string `json:"call_id"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"output"`
+	Usage struct {
+		InputTokens        int64 `json:"input_tokens"`
+		OutputTokens       int64 `json:"output_tokens"`
+		InputTokensDetails struct {
+			CachedTokens int64 `json:"cached_tokens"`
+		} `json:"input_tokens_details"`
+		OutputTokensDetails struct {
+			ReasoningTokens int64 `json:"reasoning_tokens"`
+		} `json:"output_tokens_details"`
+	} `json:"usage"`
+	IncompleteDetails *struct {
+		Reason string `json:"reason"`
+	} `json:"incomplete_details"`
+}
+
+func (p *ResponsesProvider) decodeNonStream(resp *http.Response) (*StreamResult, error) {
+	var parsed responsesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("llm: 解析 Responses 响应失败: %w", err)
+	}
+	result := assembleResponsesOutput(&parsed)
+	result.Usage = TokenUsage{
+		InputOther:     parsed.Usage.InputTokens - parsed.Usage.InputTokensDetails.CachedTokens,
+		Output:         parsed.Usage.OutputTokens,
+		InputCacheRead: parsed.Usage.InputTokensDetails.CachedTokens,
+	}
+	if result.Usage.InputOther < 0 {
+		result.Usage.InputOther = parsed.Usage.InputTokens
+	}
+	result.Accuracy = UsageExact
+	result.FinishReason = responsesFinishReason(parsed.Status, parsed.IncompleteDetails)
+	// 工具调用优先于状态字段：completed 状态携带 function_call 时必须继续执行工具。
+	if len(result.Message.ToolCalls) > 0 {
+		result.FinishReason = "tool_use"
+	}
+	return result, nil
+}
+
+// assembleResponsesOutput 把 output 数组装配成统一消息（流式/非流式共用）。
+func assembleResponsesOutput(parsed *responsesResponse) *StreamResult {
+	msg := Message{Role: RoleAssistant}
+	finish := ""
+	for _, item := range parsed.Output {
+		switch item.Type {
+		case "message":
+			for _, c := range item.Content {
+				if c.Text != "" {
+					msg.Parts = append(msg.Parts, TextPart{Text: c.Text})
+				}
+			}
+		case "reasoning":
+			for _, s := range item.Summary {
+				if s.Text != "" {
+					msg.Parts = append(msg.Parts, ThinkPart{Text: s.Text})
+				}
+			}
+		case "function_call":
+			msg.ToolCalls = append(msg.ToolCalls, ToolCall{
+				ID:        item.CallID,
+				Name:      item.Name,
+				Arguments: json.RawMessage(orEmptyJSON(item.Arguments)),
+			})
+		}
+	}
+	if len(msg.ToolCalls) > 0 {
+		finish = "tool_use"
+	}
+	return &StreamResult{Message: msg, FinishReason: finish}
+}
+
+func orEmptyJSON(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "{}"
+	}
+	return s
+}
+
+func responsesFinishReason(status string, incomplete *struct {
+	Reason string `json:"reason"`
+}) string {
+	switch strings.ToLower(status) {
+	case "completed":
+		return "stop"
+	case "incomplete":
+		if incomplete != nil && strings.Contains(incomplete.Reason, "token") {
+			return "max_tokens"
+		}
+		return "filtered"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/llm/transport.go
+++ b/internal/llm/transport.go
@@ -1,0 +1,218 @@
+package llm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTimeout = 10 * time.Minute
+	// sseIdleTimeout 是两次 SSE 事件之间的最大等待；上游停流超过它即失败。
+	sseIdleTimeout = 120 * time.Second
+	maxErrorBody   = 8 << 10
+)
+
+// transport 构造共享 HTTP 客户端（两个适配器复用）。
+func newHTTPClient(target UpstreamTarget) (*http.Client, error) {
+	transport := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConns:        16,
+		MaxIdleConnsPerHost: 8,
+		IdleConnTimeout:     90 * time.Second,
+		ForceAttemptHTTP2:   true,
+	}
+	if strings.TrimSpace(target.ProxyURL) != "" {
+		pu, err := url.Parse(target.ProxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("解析代理地址失败: %w", err)
+		}
+		switch pu.Scheme {
+		case "http", "https", "socks5", "socks5h":
+			transport.Proxy = http.ProxyURL(pu)
+		default:
+			return nil, fmt.Errorf("不支持的代理协议 %q", pu.Scheme)
+		}
+	}
+	timeout := target.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	return &http.Client{Transport: transport, Timeout: timeout}, nil
+}
+
+// doJSON 发起 POST JSON 请求，返回 resp（调用方负责关闭 body）。
+// 4xx/5xx 不视为传输错误，由调用方按协议解析错误体。
+func doJSON(ctx context.Context, client httpClient, target UpstreamTarget, path string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(target.BaseURL, "/")+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if target.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+target.APIKey)
+	}
+	for k, v := range target.ExtraHeaders {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, wrapNetworkError(err)
+	}
+	return resp, nil
+}
+
+// wrapNetworkError 把传输层错误归类为 APIError{Kind: network/timeout}。
+func wrapNetworkError(err error) error {
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return NewAPIError("timeout", 0, err.Error(), 0)
+	}
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled
+	}
+	return NewAPIError("network", 0, err.Error(), 0)
+}
+
+// upstreamErrorBody 读取错误响应体并截断。
+func upstreamErrorBody(resp *http.Response) string {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	return strings.TrimSpace(string(body))
+}
+
+// retryAfterFrom 解析 Retry-After 响应头（秒数或 HTTP 日期）。
+func retryAfterFrom(resp *http.Response) time.Duration {
+	v := strings.TrimSpace(resp.Header.Get("Retry-After"))
+	if v == "" {
+		return 0
+	}
+	if secs, err := parseRetrySeconds(v); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// sseEvent 是一条 SSE 事件（event 字段 + data 负载）。
+type sseEvent struct {
+	Event string
+	Data  []byte
+}
+
+// scanSSE 逐事件读取 SSE 流。上游连接按 sseIdleTimeout 卡死判定。
+func scanSSE(ctx context.Context, resp *http.Response, handle func(sseEvent) error) error {
+	idle := time.NewTimer(sseIdleTimeout)
+	defer idle.Stop()
+	events := make(chan sseEvent, 8)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(events)
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4<<20)
+		var event string
+		var data bytes.Buffer
+		flush := func() {
+			if data.Len() == 0 && event == "" {
+				return
+			}
+			payload := make([]byte, data.Len())
+			copy(payload, data.Bytes())
+			events <- sseEvent{Event: event, Data: payload}
+			event = ""
+			data.Reset()
+		}
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case line == "":
+				flush()
+			case strings.HasPrefix(line, "event:"):
+				event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				if data.Len() > 0 {
+					data.WriteByte('\n')
+				}
+				data.WriteString(strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+			}
+		}
+		flush()
+		if err := scanner.Err(); err != nil {
+			errCh <- err
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case err := <-errCh:
+			return NewAPIError("network", 0, err.Error(), 0)
+		case <-idle.C:
+			return NewAPIError("timeout", 0, "SSE 流空闲超时", 0)
+		case ev, ok := <-events:
+			if !ok {
+				return nil
+			}
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
+			}
+			idle.Reset(sseIdleTimeout)
+			if err := handle(ev); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// decodeJSONBody 把错误体按常见错误 envelope 解出人类可读消息。
+func decodeJSONBody(body string) string {
+	var raw any
+	if json.Unmarshal([]byte(body), &raw) != nil {
+		return body
+	}
+	return compactJSONError(raw)
+}
+
+func compactJSONError(raw any) string {
+	switch v := raw.(type) {
+	case map[string]any:
+		// OpenAI 风格: {"error": {"message": ..., "code": ...}}
+		if inner, ok := v["error"].(map[string]any); ok {
+			msg, _ := inner["message"].(string)
+			code, _ := inner["code"].(string)
+			if code != "" {
+				return fmt.Sprintf("%s [%s]", msg, code)
+			}
+			return msg
+		}
+		if msg, ok := v["message"].(string); ok {
+			return msg
+		}
+		if detail, ok := v["detail"].(string); ok {
+			return detail
+		}
+		b, _ := json.Marshal(v)
+		return string(b)
+	default:
+		b, _ := json.Marshal(raw)
+		return string(b)
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -1,0 +1,210 @@
+// Package llm 是自研 Agent 引擎的模型抽象层（对标 Kimi Code 的 kosong）。
+//
+// 引擎内部只使用本包的类型与 Provider 接口，不感知上游 wire 协议；
+// 每个上游协议（OpenAI Responses / chat/completions）由独立适配器翻译。
+// 关键决策见 docs/design/native-agent-engine.md（D1/D1b/D7）。
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Role 是统一消息模型里的角色。
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+// TextPart 是普通文本内容。
+type TextPart struct {
+	Text string `json:"text"`
+}
+
+// ThinkPart 是模型的推理/思考内容（如上游 reasoning summary）。
+// 适配器负责把上游格式映射进来；回放历史时是否重发由各协议适配器决定。
+type ThinkPart struct {
+	Text      string `json:"text"`
+	Signature string `json:"signature,omitempty"`
+}
+
+// ImagePart 是图片输入内容。Data 与 URI 二选一：Data 为 base64（不带 data: 前缀），
+// URI 为可访问地址。
+type ImagePart struct {
+	MimeType string `json:"mime_type,omitempty"`
+	Data     string `json:"data,omitempty"`
+	URI      string `json:"uri,omitempty"`
+}
+
+// ContentPart 是统一内容部件。Go 1.26 无 sealed interface，约定：包外只允许
+// 构造 TextPart/ThinkPart/ImagePart；未知类型一律按 TextPart{Text: fmt.Sprint} 降级。
+type ContentPart interface {
+	contentPart()
+}
+
+func (TextPart) contentPart()  {}
+func (ThinkPart) contentPart() {}
+func (ImagePart) contentPart() {}
+
+// ToolCall 是模型发起的一次工具调用。
+type ToolCall struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// Message 是引擎统一的消息表示（无状态重放的唯一事实来源，见 D1b）。
+// ToolCallID 仅在 Role == RoleTool 时使用，对应被回复的 ToolCall.ID。
+type Message struct {
+	Role       Role          `json:"role"`
+	Parts      []ContentPart `json:"parts,omitempty"`
+	ToolCalls  []ToolCall    `json:"tool_calls,omitempty"`
+	ToolCallID string        `json:"tool_call_id,omitempty"`
+}
+
+// Text 返回消息中全部 TextPart 拼接结果（仅用于日志/调试/标题派生）。
+func (m Message) Text() string {
+	var b strings.Builder
+	for _, p := range m.Parts {
+		if t, ok := p.(TextPart); ok {
+			b.WriteString(t.Text)
+		}
+	}
+	return b.String()
+}
+
+// TokenUsage 是单次 LLM 生成的用量分解，字段语义对齐 kosong 的 TokenUsage。
+type TokenUsage struct {
+	// InputOther 是未命中 prompt cache 的输入 token。
+	InputOther int64 `json:"input_other"`
+	// Output 是输出（completion）token。
+	Output int64 `json:"output"`
+	// InputCacheRead 是由上游 prompt cache 服务的输入 token。
+	InputCacheRead int64 `json:"input_cache_read"`
+	// InputCacheCreation 是写入上游 prompt cache 的输入 token。
+	InputCacheCreation int64 `json:"input_cache_creation"`
+}
+
+func (u TokenUsage) InputTotal() int64 {
+	return u.InputOther + u.InputCacheRead + u.InputCacheCreation
+}
+
+func (u TokenUsage) GrandTotal() int64 {
+	return u.InputTotal() + u.Output
+}
+
+func (u TokenUsage) Add(other TokenUsage) TokenUsage {
+	return TokenUsage{
+		InputOther:         u.InputOther + other.InputOther,
+		Output:             u.Output + other.Output,
+		InputCacheRead:     u.InputCacheRead + other.InputCacheRead,
+		InputCacheCreation: u.InputCacheCreation + other.InputCacheCreation,
+	}
+}
+
+// UsageAccuracy 标记用量数字的可信度（见设计文档 D3/D7）。
+type UsageAccuracy string
+
+const (
+	// UsageExact 表示来自上游真实回传的 usage 计数。
+	UsageExact UsageAccuracy = "exact"
+	// UsageApproximate 表示流式通道未回传 usage，按字符数/4 估算。
+	// 使用近似值的调用方（compaction 触发器）应放宽阈值。
+	UsageApproximate UsageAccuracy = "approximate"
+)
+
+// Tool 是暴露给模型的工具定义。Schema 为该工具参数的 JSON Schema 对象。
+type Tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Schema      map[string]any `json:"schema"`
+}
+
+// GenerateOptions 是一次生成的可选项。Stream 由 Provider 实现约定：
+// 回调不为空即流式，否则 Provider 自行装配完整结果后一次性回调。
+type GenerateOptions struct {
+	// Effort 为推理强度（"low"/"medium"/"high"/"off"…），空串表示不指定。
+	Effort string
+	// MaxOutputTokens 限制输出 token；0 表示不限制。
+	MaxOutputTokens int64
+	// OnDelta 在流式过程中被调用，part 为增量片段；实现必须可容忍并发回调
+	// 前的乱序（适配器保证同一字段顺序回调）。为空表示非流式。
+	OnDelta func(part StreamedPart)
+}
+
+// StreamedPart 是流式增量。Adapter 会回调 TextDelta / ThinkDelta / ToolCallDelta /
+// ToolCallBegin 之一。
+type StreamedPart interface{ streamedPart() }
+
+type TextDelta struct{ Text string }
+
+type ThinkDelta struct{ Text string }
+
+// ToolCallBegin 宣告一个新工具调用及其最终 ID/名称（参数随后增量到达）。
+type ToolCallBegin struct {
+	Call ToolCall
+}
+
+// ToolCallDelta 是工具调用参数的 JSON 文本增量。
+type ToolCallDelta struct {
+	CallIndex      int
+	ArgumentsDelta string
+}
+
+func (TextDelta) streamedPart()     {}
+func (ThinkDelta) streamedPart()    {}
+func (ToolCallBegin) streamedPart() {}
+func (ToolCallDelta) streamedPart() {}
+
+// StreamResult 是一次生成的最终装配结果。
+type StreamResult struct {
+	// Message 是装配完成的 assistant 消息（文本/思考/工具调用合并）。
+	Message Message
+	// Usage 为本次生成用量；Accuracy 由适配器如实标注。
+	Usage    TokenUsage
+	Accuracy UsageAccuracy
+	// FinishReason 是上游给出的结束原因的归一化表示，空表示未提供。
+	// 约定值："stop" | "tool_use" | "max_tokens" | "filtered" | "unknown"。
+	FinishReason string
+}
+
+// NormalizeFinishReason 把各协议的结束原因归一到约定值。
+func NormalizeFinishReason(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "stop", "end_turn", "end", "complete":
+		return "stop"
+	case "tool_use", "tool_calls", "function_call", "tool":
+		return "tool_use"
+	case "max_tokens", "length", "max_output_tokens", "incomplete":
+		return "max_tokens"
+	case "content_filter", "filtered", "safety":
+		return "filtered"
+	case "":
+		return ""
+	default:
+		return "unknown"
+	}
+}
+
+// APIError 是 Provider 返回的归一化上游错误。Kind 供重试策略分类：
+// rate_limited / auth / invalid_request / overloaded / network / unknown。
+type APIError struct {
+	Kind       string
+	StatusCode int
+	Upstream   string // 上游原始错误消息（已脱敏截断）
+	RetryAfter time.Duration
+}
+
+func (e *APIError) Error() string {
+	if e.StatusCode != 0 {
+		return fmt.Sprintf("llm: 上游错误 %s (kind=%s): %s", http.StatusText(e.StatusCode), e.Kind, e.Upstream)
+	}
+	return fmt.Sprintf("llm: 上游错误 (kind=%s): %s", e.Kind, e.Upstream)
+}

--- a/internal/llm/upstream.go
+++ b/internal/llm/upstream.go
@@ -1,0 +1,68 @@
+package llm
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// UpstreamTarget 描述一次 Generate 的上游连接参数，由 server 层从当前
+// 生效 Profile 解析得到；Provider 不直接依赖 profiles 包，保持引擎与
+// 存储层解耦（设计文档 §5 分层契约）。
+type UpstreamTarget struct {
+	// BaseURL 是上游根地址（loopback 代理或第三方中转），不带尾斜杠。
+	BaseURL string
+	// APIKey 是本地代理 key 或上游 key。
+	APIKey string
+	// ExtraHeaders 附加到每个请求（如 UA 覆写）。
+	ExtraHeaders map[string]string
+	// Timeout 单请求超时；0 用适配器默认。
+	Timeout time.Duration
+	// ProxyURL 可选 HTTP/SOCKS5 代理；空直连。
+	ProxyURL string
+}
+
+// NewAPIError 构造归一化上游错误。retryAfter 仅在限流等场景非零。
+func NewAPIError(kind string, status int, upstream string, retryAfter time.Duration) *APIError {
+	return &APIError{Kind: kind, StatusCode: status, Upstream: truncateUpstream(upstream), RetryAfter: retryAfter}
+}
+
+// ClassifyStatus 把 HTTP 状态码归类为 APIError.Kind。
+func ClassifyStatus(status int) string {
+	switch {
+	case status == http.StatusTooManyRequests:
+		return "rate_limited"
+	case status == http.StatusRequestTimeout, status == http.StatusGatewayTimeout:
+		return "timeout"
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		return "auth"
+	case status == http.StatusRequestEntityTooLarge:
+		return "too_large"
+	case status == http.StatusBadGateway, status == http.StatusServiceUnavailable, status == http.StatusInsufficientStorage:
+		return "overloaded"
+	case status >= 400 && status < 500:
+		return "invalid_request"
+	case status >= 500:
+		return "overloaded"
+	default:
+		return "unknown"
+	}
+}
+
+// RetryableKind 判断错误类别是否值得指数退避重试（代理层 failover 之外的引擎侧重试）。
+func RetryableKind(kind string) bool {
+	switch kind {
+	case "rate_limited", "timeout", "overloaded", "network":
+		return true
+	default:
+		return false
+	}
+}
+
+func truncateUpstream(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) > 512 {
+		s = s[:512]
+	}
+	return s
+}

--- a/internal/permission/engine.go
+++ b/internal/permission/engine.go
@@ -1,0 +1,257 @@
+package permission
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Engine 是权限决策器：模式 + 两级规则表。并发安全。
+type Engine struct {
+	mu   sync.RWMutex
+	mode Mode
+
+	session []parsedRule
+	user    []parsedRule
+
+	path string // user 规则持久化文件；空 = 不持久化（测试）
+}
+
+// NewEngine 构造引擎。path 非空时加载既有 user 规则。
+func NewEngine(path string) (*Engine, error) {
+	e := &Engine{mode: ModeManual, path: path}
+	if path != "" {
+		if err := e.loadUser(); err != nil {
+			return nil, err
+		}
+	}
+	return e, nil
+}
+
+// SetMode 切换姿态。
+func (e *Engine) SetMode(m Mode) {
+	if m != ModeManual && m != ModeYolo && m != ModeAuto {
+		m = ModeManual
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.mode = m
+}
+
+// Mode 返回当前姿态。
+func (e *Engine) Mode() Mode {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.mode
+}
+
+// Check 是决策入口：deny 规则 > 模式 > allow 规则 > ask。
+// 返回值语义对齐 agentloop.Decision（allow/deny/ask 的字符串一致）。
+func (e *Engine) Check(tool string, args json.RawMessage) string {
+	tool = lower(tool)
+	e.mu.RLock()
+	mode := e.mode
+	session := e.session
+	user := e.user
+	e.mu.RUnlock()
+
+	rules := append(append([]parsedRule{}, user...), session...)
+
+	// 1. deny 规则永远优先（任何模式）。
+	for _, r := range rules {
+		if r.decision == Deny && r.tool == tool && matchArg(r, tool, argOf(tool, args)) {
+			return "deny"
+		}
+	}
+	// 2. 模式短路。
+	switch mode {
+	case ModeAuto:
+		return "allow"
+	case ModeYolo:
+		return "allow"
+	}
+	// 3. allow 规则。
+	for _, r := range rules {
+		if r.decision == Allow && r.tool == tool && matchArg(r, tool, argOf(tool, args)) {
+			return "allow"
+		}
+	}
+	return "ask"
+}
+
+// DenyReason 返回命中的 deny 规则原因（Check 返回 deny 后调用）。
+func (e *Engine) DenyReason(tool string, args json.RawMessage) string {
+	tool = lower(tool)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	rules := append(append([]parsedRule{}, e.user...), e.session...)
+	for _, r := range rules {
+		if r.decision == Deny && r.tool == tool && matchArg(r, tool, argOf(tool, args)) {
+			if r.reason != "" {
+				return r.reason
+			}
+			return "被权限规则 " + r.String() + " 拒绝。"
+		}
+	}
+	return ""
+}
+
+// AddSessionRule 添加会话级规则（内存）。
+func (e *Engine) AddSessionRule(pattern string, decision Decision) error {
+	r, err := Parse(pattern, decision)
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.session = append(e.session, r)
+	return nil
+}
+
+// AddUserRule 添加并持久化 user 级规则。
+func (e *Engine) AddUserRule(pattern string, decision Decision) error {
+	r, err := Parse(pattern, decision)
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// 同 pattern 同决定去重。
+	for _, exist := range e.user {
+		if exist.String() == r.String() && exist.decision == r.decision {
+			return nil
+		}
+	}
+	e.user = append(e.user, r)
+	return e.persistLocked()
+}
+
+// RemoveUserRule 按 DSL 文本移除 user 规则。
+func (e *Engine) RemoveUserRule(pattern string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	kept := e.user[:0]
+	removed := false
+	for _, r := range e.user {
+		if r.String() == lower(strings.TrimSpace(pattern)) {
+			removed = true
+			continue
+		}
+		kept = append(kept, r)
+	}
+	if !removed {
+		return nil
+	}
+	e.user = kept
+	return e.persistLocked()
+}
+
+// Rules 返回两级规则的 DSL 文本（调试/未来 UI 编辑器）。
+func (e *Engine) Rules() (session, user []string) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for _, r := range e.session {
+		session = append(session, r.String())
+	}
+	for _, r := range e.user {
+		user = append(user, r.String())
+	}
+	return session, user
+}
+
+// ClearSession 清空会话级规则（新会话/Stop 时调用）。
+func (e *Engine) ClearSession() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.session = nil
+}
+
+// --- 持久化 ---
+
+type persistFile struct {
+	Version int      `json:"version"`
+	Rules   []string `json:"rules"` // "allow:Tool(pattern)" / "deny:Tool(pattern)"
+}
+
+func (e *Engine) loadUser() error {
+	data, err := os.ReadFile(e.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var pf persistFile
+	if json.Unmarshal(data, &pf) != nil {
+		// 损坏：重命名为备份并从默认开始（与项目 recovery 语义一致）。
+		_ = os.Rename(e.path, e.path+".corrupt.bak")
+		return nil
+	}
+	for _, line := range pf.Rules {
+		decision := Allow
+		text := line
+		if idx := strings.Index(line, ":"); idx > 0 {
+			switch lower(line[:idx]) {
+			case "allow":
+				decision = Allow
+			case "deny":
+				decision = Deny
+			default:
+				continue
+			}
+			text = line[idx+1:]
+		}
+		r, err := Parse(text, decision)
+		if err != nil {
+			continue
+		}
+		e.user = append(e.user, r)
+	}
+	return nil
+}
+
+func (e *Engine) persistLocked() error {
+	if e.path == "" {
+		return nil
+	}
+	pf := persistFile{Version: 1}
+	for _, r := range e.user {
+		pf.Rules = append(pf.Rules, string(r.decision)+":"+r.String())
+	}
+	data, err := json.MarshalIndent(pf, "", "  ")
+	if err != nil {
+		return err
+	}
+	if dir := filepath.Dir(e.path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(e.path), ".perm-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, e.path)
+}
+
+func lower(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 32
+		}
+	}
+	return string(b)
+}

--- a/internal/permission/match.go
+++ b/internal/permission/match.go
@@ -1,0 +1,156 @@
+package permission
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+)
+
+// argOf 从工具参数 JSON 提取匹配字段：bash→command，文件类→path，其余→""。
+func argOf(tool string, args json.RawMessage) string {
+	var payload map[string]any
+	if json.Unmarshal(args, &payload) != nil {
+		return ""
+	}
+	switch tool {
+	case "bash":
+		if cmd, ok := payload["command"].(string); ok {
+			return cmd
+		}
+	case "read", "write", "edit", "glob", "grep":
+		if p, ok := payload["path"].(string); ok && p != "" {
+			return p
+		}
+		if p, ok := payload["pattern"].(string); ok && (tool == "glob") {
+			return p
+		}
+	}
+	return ""
+}
+
+// matchArg 判断参数是否命中规则参数部分。
+//   - 规则无参数部分（裸工具名）：匹配任何参数；
+//   - bash：命令前缀通配（"git *" 匹配 "git push -f"，"* rm" 不要求）；
+//   - 路径类：glob 匹配（** 跨目录）；参数为空视作不匹配（工具级规则除外）。
+func matchArg(rule parsedRule, tool, arg string) bool {
+	if !rule.hasArg {
+		return true
+	}
+	pattern := rule.arg
+	if pattern == "**" || pattern == "*" {
+		return true
+	}
+	if arg == "" {
+		return false
+	}
+	switch tool {
+	case "bash":
+		return matchCommand(pattern, arg)
+	default:
+		return MatchGlob(pattern, arg) || MatchGlob(pattern, filepath.ToSlash(arg))
+	}
+}
+
+// matchCommand 用通配语义匹配命令行：'*' 匹配任意字符（含空格），
+// 其余字符按字面匹配，且整体前缀语义（pattern 比 command 短时按前缀处理）。
+func matchCommand(pattern, command string) bool {
+	pattern = strings.TrimSpace(pattern)
+	command = strings.TrimSpace(command)
+	if pattern == "" {
+		return false
+	}
+	// 纯前缀（无通配符）：pattern 是 command 的前缀且停在词边界。
+	if !strings.Contains(pattern, "*") {
+		if strings.HasPrefix(command, pattern) {
+			rest := command[len(pattern):]
+			return rest == "" || strings.HasPrefix(rest, " ")
+		}
+		return false
+	}
+	// 整串通配（命令不是路径，不按 / 分段）：'*' 匹配任意字符。
+	if wildcardMatch(pattern, command) {
+		return true
+	}
+	// "cmd *" 的宽松语义：命令本体恰好等于 cmd（无参数）也视为命中。
+	if rest := strings.TrimSuffix(pattern, " *"); rest != pattern {
+		return command == strings.TrimSpace(rest)
+	}
+	return false
+}
+
+// MatchGlob 是纯字符串 glob：'*' 匹配一段，'**' 匹配任意（含 '/'），
+// '?' 匹配单字符。大小写不敏感（Windows 路径习惯）。
+func MatchGlob(pattern, target string) bool {
+	return globMatch(strings.ToLower(strings.TrimSpace(pattern)), strings.ToLower(strings.TrimSpace(target)))
+}
+
+// globMatch 实现 ** 的分段匹配：把 pattern 按 '/' 切分，遇到 '**' 时
+// 尝试吞掉任意数量的目标段。
+func globMatch(pattern, target string) bool {
+	patSegs := splitSegs(pattern)
+	tgtSegs := splitSegs(target)
+	return segMatch(patSegs, 0, tgtSegs, 0)
+}
+
+func splitSegs(s string) []string {
+	var out []string
+	for _, seg := range strings.Split(s, "/") {
+		if seg == "" {
+			continue
+		}
+		out = append(out, seg)
+	}
+	return out
+}
+
+func segMatch(pat []string, pi int, tgt []string, ti int) bool {
+	for {
+		if pi == len(pat) {
+			return ti == len(tgt)
+		}
+		if pat[pi] == "**" {
+			// '**' 尝试吞 0..n 段。
+			for k := ti; k <= len(tgt); k++ {
+				if segMatch(pat, pi+1, tgt, k) {
+					return true
+				}
+			}
+			return false
+		}
+		if ti == len(tgt) {
+			return false
+		}
+		if !wildcardMatch(pat[pi], tgt[ti]) {
+			return false
+		}
+		pi++
+		ti++
+	}
+}
+
+// wildcardMatch 单段通配：* 与 ? 支持。
+func wildcardMatch(pattern, s string) bool {
+	px, sx := 0, 0
+	starPx, starSx := -1, -1
+	for sx < len(s) {
+		switch {
+		case px < len(pattern) && (pattern[px] == s[sx] || pattern[px] == '?'):
+			px++
+			sx++
+		case px < len(pattern) && pattern[px] == '*':
+			starPx = px
+			starSx = sx
+			px++
+		case starPx >= 0:
+			px = starPx + 1
+			starSx++
+			sx = starSx
+		default:
+			return false
+		}
+	}
+	for px < len(pattern) && pattern[px] == '*' {
+		px++
+	}
+	return px == len(pattern)
+}

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -1,0 +1,211 @@
+package permission
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	r, err := Parse("Bash(git *)", Allow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.tool != "bash" || !r.hasArg || r.arg != "git *" {
+		t.Fatalf("解析错误: %+v", r)
+	}
+	if r.String() != "bash(git *)" {
+		t.Fatalf("String 错误: %s", r.String())
+	}
+	bare, _ := Parse("read", Allow)
+	if bare.hasArg {
+		t.Fatal("裸工具名不应有参数部分")
+	}
+	if _, err := Parse("bash(git", Allow); err == nil {
+		t.Fatal("未闭合括号应报错")
+	}
+	if _, err := Parse("(git)", Allow); err == nil {
+		t.Fatal("空工具名应报错")
+	}
+	if _, err := Parse("rm -rf; echo", Allow); err == nil {
+		t.Fatal("非法字符应报错（注入防护）")
+	}
+}
+
+func TestMatchGlob(t *testing.T) {
+	cases := []struct {
+		pattern, target string
+		want            bool
+	}{
+		{"**", "anything/goes/here.txt", true},
+		{"**/*.go", "internal/llm/types.go", true},
+		{"**/*.go", "types.go", true},
+		{"internal/**", "internal/llm/types.go", true},
+		{"internal/**/*.md", "internal/llm/x.md", true},
+		{"internal/**", "cmd/main.go", false},
+		{"*.go", "sub/types.go", false}, // 单星不跨目录
+		{"~/.ssh/**", "~/.ssh/id_ed25519", true},
+		{"docs/*", "docs/usage.md", true},
+	}
+	for _, c := range cases {
+		if got := MatchGlob(c.pattern, c.target); got != c.want {
+			t.Fatalf("MatchGlob(%q,%q)=%v, want %v", c.pattern, c.target, got, c.want)
+		}
+	}
+}
+
+func TestMatchCommand(t *testing.T) {
+	cases := []struct {
+		pattern, command string
+		want             bool
+	}{
+		{"git *", "git push -f origin main", true},
+		{"git *", "git", true},             // 前缀词边界：'git' 本体也算（rest 为空）
+		{"git *", "github-cli run", false}, // 非词边界
+		{"git status", "git status --short", true},
+		{"git status", "git stash", false},
+		{"*rm*", "echo rm-dry", true}, // 通配
+		{"npm *", "npm test", true},
+	}
+	for _, c := range cases {
+		r, _ := Parse("bash("+c.pattern+")", Allow)
+		if got := matchArg(r, "bash", c.command); got != c.want {
+			t.Fatalf("matchCommand(%q,%q)=%v, want %v", c.pattern, c.command, got, c.want)
+		}
+	}
+}
+
+func TestEngineDecisionOrder(t *testing.T) {
+	engine, err := NewEngine(filepath.Join(t.TempDir(), "permissions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// allow 规则命中 → allow。
+	if err := engine.AddUserRule("read(**)", Allow); err != nil {
+		t.Fatal(err)
+	}
+	if got := engine.Check("read", json.RawMessage(`{"path":"a/b.go"}`)); got != "allow" {
+		t.Fatalf("read 应 allow, got %s", got)
+	}
+	if got := engine.Check("write", json.RawMessage(`{"path":"a.go"}`)); got != "ask" {
+		t.Fatalf("未命中应 ask, got %s", got)
+	}
+
+	// deny 优先于 allow。
+	if err := engine.AddUserRule("write(~/.ssh/**)", Deny); err != nil {
+		t.Fatal(err)
+	}
+	if got := engine.Check("write", json.RawMessage(`{"path":"~/.ssh/id_x"}`)); got != "deny" {
+		t.Fatalf("ssh 路径应 deny, got %s", got)
+	}
+	if reason := engine.DenyReason("write", json.RawMessage(`{"path":"~/.ssh/id_x"}`)); reason == "" {
+		t.Fatal("deny reason 不应为空")
+	}
+	if got := engine.Check("write", json.RawMessage(`{"path":"~/project/a.go"}`)); got != "ask" {
+		t.Fatalf("非 ssh 路径仍应 ask, got %s", got)
+	}
+
+	// session 规则与 user 规则共存。
+	if err := engine.AddSessionRule("grep", Allow); err != nil {
+		t.Fatal(err)
+	}
+	if got := engine.Check("grep", json.RawMessage(`{"pattern":"x"}`)); got != "allow" {
+		t.Fatalf("裸工具名规则应匹配任何参数, got %s", got)
+	}
+	engine.ClearSession()
+	if got := engine.Check("grep", json.RawMessage(`{"pattern":"x"}`)); got != "ask" {
+		t.Fatalf("清空 session 后应 ask, got %s", got)
+	}
+
+	// yolo：只有 deny 能拦。
+	engine.SetMode(ModeYolo)
+	if got := engine.Check("bash", json.RawMessage(`{"command":"npm install"}`)); got != "allow" {
+		t.Fatalf("yolo 应放行, got %s", got)
+	}
+	if got := engine.Check("write", json.RawMessage(`{"path":"~/.ssh/id_x"}`)); got != "deny" {
+		t.Fatalf("yolo 下 deny 仍生效, got %s", got)
+	}
+	// auto：全放行。
+	engine.SetMode(ModeAuto)
+	if got := engine.Check("bash", json.RawMessage(`{"command":"rm -rf /"}`)); got != "allow" {
+		t.Fatalf("auto 全放行, got %s", got)
+	}
+	// 回 manual。
+	engine.SetMode(ModeManual)
+	if got := engine.Check("bash", json.RawMessage(`{"command":"rm -rf /"}`)); got != "ask" {
+		t.Fatalf("manual 未命中应 ask, got %s", got)
+	}
+}
+
+func TestEnginePersistRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "permissions.json")
+	engine, err := NewEngine(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.AddUserRule("bash(git *)", Allow); err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.AddUserRule("bash(rm *)", Deny); err != nil {
+		t.Fatal(err)
+	}
+	// 去重。
+	if err := engine.AddUserRule("bash(git *)", Allow); err != nil {
+		t.Fatal(err)
+	}
+	_, userRules := engine.Rules()
+	if len(userRules) != 2 {
+		t.Fatalf("去重失败: %v", userRules)
+	}
+
+	// 重开加载。
+	engine2, err := NewEngine(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := engine2.Check("bash", json.RawMessage(`{"command":"git log"}`)); got != "allow" {
+		t.Fatalf("重载后 git 应 allow, got %s", got)
+	}
+	if got := engine2.Check("bash", json.RawMessage(`{"command":"rm -rf x"}`)); got != "deny" {
+		t.Fatalf("重载后 rm 应 deny, got %s", got)
+	}
+	// 移除。
+	if err := engine2.RemoveUserRule("bash(rm *)"); err != nil {
+		t.Fatal(err)
+	}
+	if got := engine2.Check("bash", json.RawMessage(`{"command":"rm -rf x"}`)); got != "ask" {
+		t.Fatalf("移除后应 ask, got %s", got)
+	}
+}
+
+func TestEngineCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "permissions.json")
+	if err := os.WriteFile(path, []byte("{broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	engine, err := NewEngine(path)
+	if err != nil {
+		t.Fatalf("损坏文件不应致命: %v", err)
+	}
+	if got := engine.Check("read", nil); got != "ask" {
+		t.Fatalf("损坏后应回到默认, got %s", got)
+	}
+	if _, err := os.Stat(path + ".corrupt.bak"); err != nil {
+		t.Fatal("损坏原件应保留备份")
+	}
+}
+
+func TestBareToolRule(t *testing.T) {
+	engine, _ := NewEngine("")
+	_ = engine.AddSessionRule("todo_list", Allow)
+	// todo_list 参数任意 → allow。
+	if got := engine.Check("todo_list", json.RawMessage(`{"items":[]}`)); got != "allow" {
+		t.Fatalf("裸规则应放行, got %s", got)
+	}
+	// 其它工具不受影响。
+	if got := engine.Check("bash", json.RawMessage(`{"command":"ls"}`)); got != "ask" {
+		t.Fatalf("其它工具应 ask, got %s", got)
+	}
+}

--- a/internal/permission/rule.go
+++ b/internal/permission/rule.go
@@ -1,0 +1,111 @@
+// Package permission 是原生引擎的权限规则引擎（设计文档 D5）。
+//
+// 规则 DSL：`Tool(pattern)`，如
+//
+//	read(**)          允许读任何文件
+//	bash(git *)       允许 git 只读命令（前缀匹配）
+//	bash(rm *)        拒绝递归删除
+//	write(**)         允许写任何文件
+//	grep              裸工具名 = 任意参数都匹配
+//
+// 决策顺序：deny 规则 > 模式(yolo/auto) > allow 规则 > 默认 ask。
+// 两级 scope：session（内存，重启即失）与 user（permissions.json 持久）。
+package permission
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Decision 是规则决定。
+type Decision string
+
+const (
+	Allow Decision = "allow"
+	Deny  Decision = "deny"
+)
+
+// Mode 是顶层权限姿态（对齐 Kimi manual/yolo/auto）。
+type Mode string
+
+const (
+	// ModeManual：规则驱动，未命中 ask（默认）。
+	ModeManual Mode = "manual"
+	// ModeYolo：只有 deny 规则能拦。
+	ModeYolo Mode = "yolo"
+	// ModeAuto：全放行（等价旧桥的 session_auto_approve）。
+	ModeAuto Mode = "auto"
+)
+
+// Rule 是一条权限规则。
+type Rule struct {
+	Decision Decision `json:"decision"`
+	// Pattern 是 DSL 形态：`Tool(argPattern)` 或裸 `Tool`。
+	Pattern string `json:"pattern"`
+	// Reason 拒绝时回给模型的说明（可选）。
+	Reason string `json:"reason,omitempty"`
+}
+
+// parsedRule 是编译后的规则。
+type parsedRule struct {
+	decision Decision
+	tool     string
+	arg      string // 空串 = 不看参数
+	reason   string
+	hasArg   bool
+}
+
+// Parse 解析 DSL。合法形态：
+//   - "read"              → 工具级
+//   - "read(**)"          → 工具 + 参数 glob
+//   - "Bash(git *)"       → 工具名大小写不敏感
+func Parse(pattern string, decision Decision) (parsedRule, error) {
+	p := strings.TrimSpace(pattern)
+	if p == "" {
+		return parsedRule{}, fmt.Errorf("permission: 空规则")
+	}
+	if invalid := invalidChars(p); invalid {
+		return parsedRule{}, fmt.Errorf("permission: 规则含非法字符 %q", p)
+	}
+	tool := p
+	arg := ""
+	hasArg := false
+	if open := strings.Index(p, "("); open >= 0 {
+		if !strings.HasSuffix(p, ")") {
+			return parsedRule{}, fmt.Errorf("permission: 规则括号不闭合 %q", p)
+		}
+		tool = p[:open]
+		arg = p[open+1 : len(p)-1]
+		hasArg = true
+	}
+	tool = strings.ToLower(strings.TrimSpace(tool))
+	if tool == "" {
+		return parsedRule{}, fmt.Errorf("permission: 规则缺工具名 %q", p)
+	}
+	if decision != Allow && decision != Deny {
+		return parsedRule{}, fmt.Errorf("permission: 非法决定 %q", decision)
+	}
+	return parsedRule{decision: decision, tool: tool, arg: strings.TrimSpace(arg), hasArg: hasArg, reason: ""}, nil
+}
+
+func invalidChars(p string) bool {
+	// DSL 只允许工具名字符、glob 通配与括号空格。
+	for _, r := range p {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '_', r == '-', r == '*', r == '(', r == ')', r == ' ',
+			r == '/', r == '.', r == '~', r == '?', r == '[', r == ']':
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+// String 还原 DSL 形态（带参数时）。
+func (r parsedRule) String() string {
+	if r.hasArg {
+		return fmt.Sprintf("%s(%s)", r.tool, r.arg)
+	}
+	return r.tool
+}

--- a/internal/server/agent.go
+++ b/internal/server/agent.go
@@ -578,6 +578,10 @@ func (s *Server) rememberAgentCwd(cwd string) {
 	if s.Settings == nil || strings.TrimSpace(cwd) == "" {
 		return
 	}
+	// 不持久化已失效的目录（浏览器端 localStorage 可能回传旧路径）。
+	if info, err := os.Stat(cwd); err != nil || !info.IsDir() {
+		return
+	}
 	current, err := s.Settings.Get()
 	if err != nil || current.AgentDefaultCwd == cwd {
 		return

--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -1,0 +1,810 @@
+package server
+
+// nativeAgentService 用自研引擎（agentloop + tools + agentkit）实现
+// AgentService 接口。WS 协议、REST 路由与前端零改动（设计文档 D6）。
+//
+// 状态机：idle（未启动）→ ready（会话就绪）→ busy（turn 进行中）→ ready。
+// 一个服务实例同一时刻持有一个活动会话（与 acp 桥的 ErrBusy 语义一致）。
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"grok_switch/internal/agentbridge"
+	"grok_switch/internal/agentfs"
+	"grok_switch/internal/agentkit"
+	"grok_switch/internal/agentloop"
+	"grok_switch/internal/llm"
+	"grok_switch/internal/permission"
+	"grok_switch/internal/tools"
+)
+
+// EngineDeps 是 native 引擎在 server 层的依赖（main.go 注入）。
+type EngineDeps struct {
+	SessionsRoot string
+	// ProviderFor 返回当前会话应使用的 Provider（按当前生效 Profile 构造）。
+	// 返回 error 时 Prompt 报"引擎未配置"。
+	ProviderFor func() (llm.Provider, error)
+	// SystemPrompt 组装系统提示词（含工具文档）。
+	SystemPrompt func(toolDoc string) string
+	// ImageGen 为 nil 时不注册 generate_image。
+	ImageGen tools.ImageGenerator
+	// DefaultCwd 兜底工作目录。
+	DefaultCwd string
+}
+
+// permissionOptionFor 构造与 acp 桥一致的审批选项。
+var nativePermissionOptions = []agentbridge.PermissionOption{
+	{ID: "allow_once", Name: "允许本次", Kind: "allow_once"},
+	{ID: "allow_always", Name: "本会话总是允许", Kind: "allow_always"},
+	{ID: "reject_once", Name: "拒绝", Kind: "reject_once"},
+}
+
+type nativeAgentService struct {
+	deps EngineDeps
+	st   *agentkit.Store
+	perm *permission.Engine
+
+	mu sync.Mutex
+	// 会话状态。
+	sessionID string
+	cwd       string
+	memory    *agentkit.CtxMemory
+	registry  *tools.Registry
+	state     string // idle | ready | busy
+	autoAppr  bool
+	model     string
+	effort    string
+	errText   string
+
+	// turn 控制。
+	turnCancel context.CancelFunc
+	turnSeq    int64
+
+	// 审批挂起：requestID → 等待通道 + 工具名（allow_always 写规则用）。
+	permMu      sync.Mutex
+	pendingPerm map[string]*pendingPermReq
+	planMu      sync.Mutex
+	pendingPlan map[string]chan agentbridge.PlanDecision
+	planSeq     int64
+
+	// 订阅者。
+	subMu   sync.Mutex
+	nextSub int
+	subs    map[int]chan agentbridge.Event
+
+	// 会话级 usage 观测（compaction 触发依据，跨 turn 保持）。
+	usageHolder     *turnUsageHolder
+	usageHolderOnce sync.Once
+}
+
+func newNativeAgentService(deps EngineDeps) (*nativeAgentService, error) {
+	st, err := agentkit.NewStore(deps.SessionsRoot)
+	if err != nil {
+		return nil, err
+	}
+	// user 级权限规则持久化在会话存储根的上级（agent2/permissions.json）。
+	perm, err := permission.NewEngine(filepath.Dir(strings.TrimSuffix(deps.SessionsRoot, "/")) + "/permissions.json")
+	if err != nil {
+		return nil, err
+	}
+	return &nativeAgentService{
+		deps:        deps,
+		st:          st,
+		perm:        perm,
+		state:       "idle",
+		pendingPerm: map[string]*pendingPermReq{},
+		pendingPlan: map[string]chan agentbridge.PlanDecision{},
+		subs:        map[int]chan agentbridge.Event{},
+	}, nil
+}
+
+// --- 事件广播（对齐 agentbridge 的 Subscribe 模式） ---
+
+func (n *nativeAgentService) Subscribe() (string, <-chan agentbridge.Event) {
+	n.subMu.Lock()
+	defer n.subMu.Unlock()
+	id := n.nextSub
+	n.nextSub++
+	ch := make(chan agentbridge.Event, 256)
+	n.subs[id] = ch
+	// 订阅即推当前状态（与 acp 桥行为一致）。
+	status := n.Status()
+	ch <- agentbridge.Event{
+		Type: "agent_status", SessionID: status.SessionID, Status: status.State,
+		Model: status.Model, Error: status.Error, SessionAutoApprove: &status.SessionAutoApprove,
+	}
+	return fmt.Sprintf("sub-%d", id), ch
+}
+
+func (n *nativeAgentService) Unsubscribe(id string) {
+	var num int
+	if _, err := fmt.Sscanf(id, "sub-%d", &num); err != nil {
+		return
+	}
+	n.subMu.Lock()
+	defer n.subMu.Unlock()
+	if ch, ok := n.subs[num]; ok {
+		close(ch)
+		delete(n.subs, num)
+	}
+}
+
+func (n *nativeAgentService) broadcast(ev agentbridge.Event) {
+	n.subMu.Lock()
+	defer n.subMu.Unlock()
+	for _, ch := range n.subs {
+		select {
+		case ch <- ev:
+		default:
+			// 订阅者消费不及则丢弃（UI 只关心最新状态；录制在 transcript）。
+		}
+	}
+}
+
+func (n *nativeAgentService) broadcastStatus() {
+	n.mu.Lock()
+	status := agentbridge.Event{
+		Type: "agent_status", SessionID: n.sessionID, Status: n.state,
+		Model: n.model, Error: n.errText, SessionAutoApprove: &n.autoAppr,
+	}
+	n.mu.Unlock()
+	n.broadcast(status)
+}
+
+// --- AgentService 实现 ---
+
+func (n *nativeAgentService) Status() agentbridge.Status {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return agentbridge.Status{
+		Available:          true,
+		Running:            n.state == "ready" || n.state == "busy",
+		State:              n.state,
+		SessionID:          n.sessionID,
+		Cwd:                n.cwd,
+		DefaultCwd:         n.deps.DefaultCwd,
+		Busy:               n.state == "busy",
+		SessionAutoApprove: n.autoAppr,
+		Model:              n.model,
+		Error:              n.errText,
+		UserTurnCount:      n.memoryUserTurnsLocked(),
+	}
+}
+
+func (n *nativeAgentService) memoryUserTurnsLocked() int {
+	if n.memory == nil {
+		return 0
+	}
+	return n.memory.UserTurns()
+}
+
+// Start 初始化引擎会话（不 spawn 进程——原生引擎无需子进程）。
+func (n *nativeAgentService) Start(ctx context.Context, opts agentbridge.StartOptions) error {
+	n.mu.Lock()
+	if opts.SessionID != "" && opts.SessionID == n.sessionID && n.state == "ready" {
+		n.mu.Unlock()
+		return nil // 已就绪（幂等）
+	}
+	if opts.Cwd == "" {
+		opts.Cwd = n.deps.DefaultCwd
+	}
+	n.state = "starting"
+	n.errText = ""
+	cwd := opts.Cwd
+	sessionID := opts.SessionID
+	n.mu.Unlock()
+	n.broadcastStatus()
+
+	// cwd 必须真实存在：否则会话会在死路径上静默运行并被 rememberAgentCwd
+	// 持久化，形成"路径不可用"的坏项目卡片。
+	if info, statErr := os.Stat(cwd); statErr != nil || !info.IsDir() {
+		n.mu.Lock()
+		n.state = "dead"
+		n.errText = "工作目录不存在: " + cwd
+		n.mu.Unlock()
+		n.broadcastStatus()
+		return fmt.Errorf("工作目录不存在: %s", cwd)
+	}
+
+	// 恢复既有会话或新建。
+	if sessionID != "" && n.st.Exists(sessionID) {
+		records, err := n.st.LoadRecords(sessionID)
+		if err == nil {
+			mem := agentkit.NewCtxMemory()
+			mem.Restore(records)
+			meta, _ := n.st.GetMeta(sessionID)
+			n.mu.Lock()
+			n.memory = mem
+			n.sessionID = sessionID
+			n.cwd = cwd
+			n.model = meta.Model
+			n.state = "ready"
+			n.mu.Unlock()
+			n.broadcastStatus()
+			return nil
+		}
+	}
+
+	meta, err := n.st.Create(agentkit.SessionMeta{Cwd: cwd})
+	if err != nil {
+		n.mu.Lock()
+		n.state = "dead"
+		n.errText = err.Error()
+		n.mu.Unlock()
+		n.broadcastStatus()
+		return err
+	}
+	n.mu.Lock()
+	n.memory = agentkit.NewCtxMemory()
+	n.sessionID = meta.ID
+	n.cwd = cwd
+	n.state = "ready"
+	n.mu.Unlock()
+	n.broadcastStatus()
+	return nil
+}
+
+func (n *nativeAgentService) Stop() error {
+	n.mu.Lock()
+	if n.turnCancel != nil {
+		n.turnCancel()
+		n.turnCancel = nil
+	}
+	n.state = "idle"
+	n.sessionID = ""
+	n.memory = nil
+	n.mu.Unlock()
+	n.broadcastStatus()
+	return nil
+}
+
+func (n *nativeAgentService) NewSession(ctx context.Context, cwd string) error {
+	n.mu.Lock()
+	if n.turnCancel != nil {
+		n.turnCancel()
+		n.turnCancel = nil
+	}
+	if cwd == "" {
+		cwd = n.deps.DefaultCwd
+	}
+	if info, statErr := os.Stat(cwd); statErr != nil || !info.IsDir() {
+		n.mu.Unlock()
+		return fmt.Errorf("工作目录不存在: %s", cwd)
+	}
+	n.cwd = cwd
+	n.memory = agentkit.NewCtxMemory()
+	n.errText = ""
+	n.mu.Unlock()
+	meta, err := n.st.Create(agentkit.SessionMeta{Cwd: cwd})
+	if err != nil {
+		return err
+	}
+	n.mu.Lock()
+	n.sessionID = meta.ID
+	if n.state != "busy" {
+		n.state = "ready"
+	}
+	n.mu.Unlock()
+	n.broadcastStatus()
+	return nil
+}
+
+// Prompt 启动一个 turn（异步）；事件经引擎回调翻译成 agentbridge.Event。
+func (n *nativeAgentService) Prompt(text string, attachments []agentbridge.Attachment) error {
+	n.mu.Lock()
+	if n.state == "busy" {
+		n.mu.Unlock()
+		return agentbridge.ErrBusy
+	}
+	if n.state != "ready" || n.memory == nil {
+		n.mu.Unlock()
+		return agentbridge.ErrNotRunning
+	}
+	provider, err := n.deps.ProviderFor()
+	if err != nil {
+		n.mu.Unlock()
+		return fmt.Errorf("引擎未就绪: %w", err)
+	}
+	if n.model == "" {
+		n.model = provider.ModelName()
+	}
+	// turn 独立 ctx（与 Start/Stop 的生命周期解耦）。
+	turnCtx, cancel := context.WithCancel(context.Background())
+	n.turnCancel = cancel
+	n.turnSeq++
+	turnID := fmt.Sprintf("turn-%d-%d", time.Now().UnixNano(), n.turnSeq)
+	sessionID := n.sessionID
+	mem := n.memory
+	env := agentfs.Env{Cwd: n.cwd}
+	n.state = "busy"
+	n.mu.Unlock()
+	n.broadcastStatus()
+
+	// 组装用户消息（文本 + 附件）。
+	userMsg := buildUserMessage(text, attachments)
+	mem.AppendWithOrigin(userMsg, agentkit.OriginUser)
+	n.persist(sessionID, agentkit.Record{
+		Origin: agentkit.OriginUser, Role: llm.RoleUser,
+		Text: text, TurnID: turnID, UserTurn: mem.UserTurns(),
+		Media: attachmentsToMediaRefs(attachments),
+	})
+	n.broadcast(agentbridge.Event{
+		Type: "user_message", SessionID: sessionID, Text: text,
+	})
+
+	// 工具注册表（每 turn 重建：生图开关即时生效）。
+	registry := tools.DefaultRegistry(func() agentfs.Env { return env }, n.deps.ImageGen, &nativePlanApprover{n: n}, &tools.TodoStore{})
+
+	// 引擎事件 → WS 事件翻译。usage 观测挂在服务上（跨 turn 保持）。
+	n.usageHolderOnce.Do(func() { n.usageHolder = &turnUsageHolder{} })
+	loopEvents := &nativeEventTranslator{svc: n, sessionID: sessionID, turnID: turnID, registry: registry, usage: n.usageHolder}
+
+	// compaction hook（D3/§6.4）：无状态重放下「上一步 input tokens」≈ 当前
+	// 全量历史体积；超阈值时在步边界压实（摘要走当前 Provider 一次调用）。
+	compactionCfg := agentkit.DefaultCompactionConfig()
+	compactionCap := provider.Capability()
+	hooks := agentloop.Hooks{BeforeStep: func(ctx context.Context, step int) error {
+		// 每个 step 边界（含 turn 起始）都检查：上一步 usage 已含上一 turn
+		// 的真实 input；新会话 usage 为 0 自然不触发。
+		if !compactionCfg.ShouldCompact(n.usageHolder.lastInputTokens(), int64(compactionCap.MaxContextTokens)) {
+			return nil
+		}
+		msgs, origins := mem.Snapshot()
+		out, outOrigins, stats, err := agentkit.Compact(msgs, origins, func(dropped []llm.Message) (string, error) {
+			return compactViaLLM(ctx, provider, dropped)
+		}, compactionCfg)
+		if err != nil || stats.CompactedCount == 0 {
+			return nil // 压实失败不终止 turn；下一步仍会重试
+		}
+		mem.CompactInPlace(out, outOrigins, stats)
+		n.persist(sessionID, agentkit.Record{
+			Origin: agentkit.OriginInjection, Role: llm.RoleUser,
+			Text:   fmt.Sprintf("[上下文已压实: 折叠 %d 条，%d → %d tokens]", stats.CompactedCount, stats.TokensBefore, stats.TokensAfter),
+			TurnID: turnID,
+		})
+		n.broadcast(agentbridge.Event{Type: "notice", SessionID: sessionID, Text: fmt.Sprintf("长对话已自动压缩（折叠 %d 条消息）", stats.CompactedCount)})
+		return nil
+	}}
+
+	go func() {
+		defer cancel()
+		res, runErr := agentloop.RunTurn(turnCtx, agentloop.RunTurnInput{
+			TurnID:       turnID,
+			Provider:     provider,
+			SystemPrompt: n.deps.SystemPrompt(registry.SystemPromptDoc()),
+			Memory:       mem,
+			Tools:        &tools.ToolsAdapter{Registry: registry},
+			PermGate:     &nativePermGate{svc: n, registry: registry},
+			Events:       loopEvents,
+			MaxSteps:     100,
+			MaxRetries:   3,
+			Hooks:        hooks,
+		})
+		// turn 收尾。
+		n.mu.Lock()
+		n.turnCancel = nil
+		if n.state == "busy" {
+			n.state = "ready"
+		}
+		n.mu.Unlock()
+		switch {
+		case runErr != nil && res.StopReason == agentloop.TurnUserAbort:
+			n.broadcast(agentbridge.Event{Type: "turn_done", SessionID: sessionID, StopReason: "cancelled"})
+		case runErr != nil:
+			n.mu.Lock()
+			n.errText = runErr.Error()
+			n.mu.Unlock()
+			n.broadcast(agentbridge.Event{Type: "error", SessionID: sessionID, Error: "Grok 对话失败: " + runErr.Error()})
+			n.broadcast(agentbridge.Event{Type: "turn_done", SessionID: sessionID, StopReason: "error"})
+		default:
+			n.broadcast(agentbridge.Event{Type: "turn_done", SessionID: sessionID, StopReason: string(res.StopReason)})
+		}
+		n.broadcastStatus()
+	}()
+	return nil
+}
+
+func buildUserMessage(text string, attachments []agentbridge.Attachment) llm.Message {
+	msg := llm.Message{Role: llm.RoleUser}
+	if strings.TrimSpace(text) != "" {
+		msg.Parts = append(msg.Parts, llm.TextPart{Text: text})
+	}
+	for _, a := range attachments {
+		if a.Kind == "image" && a.Data != "" {
+			msg.Parts = append(msg.Parts, llm.ImagePart{Data: a.Data, MimeType: a.MimeType})
+		} else if a.Path != "" {
+			// 路径附件作为文本上下文注入（P3 决策：不推 base64）。
+			msg.Parts = append(msg.Parts, llm.TextPart{Text: fmt.Sprintf("[附件 %s: %s]", a.Name, a.Path)})
+		}
+	}
+	return msg
+}
+
+func attachmentsToMediaRefs(attachments []agentbridge.Attachment) []agentkit.MediaRef {
+	var out []agentkit.MediaRef
+	for _, a := range attachments {
+		if a.Kind == "image" && a.Path != "" {
+			out = append(out, agentkit.MediaRef{Kind: "image", URI: a.Path, Name: a.Name, MimeType: a.MimeType})
+		}
+	}
+	return out
+}
+
+// persist 落盘记录；失败仅记 errText（不阻塞对话）。
+func (n *nativeAgentService) persist(sessionID string, rec agentkit.Record) {
+	if sessionID == "" {
+		return
+	}
+	if err := n.st.AppendRecord(sessionID, rec); err != nil {
+		n.mu.Lock()
+		n.errText = "会话记录写入失败: " + err.Error()
+		n.mu.Unlock()
+	}
+}
+
+func (n *nativeAgentService) CancelPrompt() error {
+	n.mu.Lock()
+	cancel := n.turnCancel
+	n.mu.Unlock()
+	if cancel == nil {
+		return nil
+	}
+	cancel()
+	// 权限/计划审批挂起也一并唤醒。
+	n.resolveAllPending()
+	return nil
+}
+
+// --- 审批（权限/计划） ---
+
+// nativePermGate 实现 agentloop.PermissionGate：manual 模式下写类工具需要审批。
+type nativePermGate struct {
+	svc      *nativeAgentService
+	registry *tools.Registry
+}
+
+// readOnlyTools 默认免审批工具（D5：manual 模式下其余工具 ask）。
+var readOnlyTools = map[string]bool{"read": true, "glob": true, "grep": true, "todo_list": true, "enter_plan_mode": true}
+
+func (g *nativePermGate) Check(call llm.ToolCall) agentloop.Decision {
+	// 规则引擎优先：deny > 模式 > allow > ask（D5 决策顺序）。
+	// autoAppr 映射为 ModeAuto；手动模式走规则表。
+	if g.svc.perm != nil {
+		if g.svc.Status().SessionAutoApprove {
+			g.svc.perm.SetMode(permission.ModeAuto)
+		} else {
+			g.svc.perm.SetMode(permission.ModeManual)
+		}
+		switch g.svc.perm.Check(call.Name, call.Arguments) {
+		case "deny":
+			return agentloop.DecDeny
+		case "allow":
+			return agentloop.DecAllow
+		}
+	} else if g.svc.Status().SessionAutoApprove {
+		return agentloop.DecAllow
+	}
+	if readOnlyTools[call.Name] {
+		return agentloop.DecAllow
+	}
+	if call.Name == "exit_plan_mode" {
+		return agentloop.DecAllow // 计划审批走 plan_request 流
+	}
+	return agentloop.DecAsk
+}
+
+// pendingPermReq 是一条挂起的审批。
+type pendingPermReq struct {
+	ch   chan agentloop.PermResult
+	tool string
+}
+
+func (g *nativePermGate) WaitForDecision(ctx context.Context, call llm.ToolCall) agentloop.PermResult {
+	requestID := fmt.Sprintf("perm-%d", time.Now().UnixNano())
+	req := &pendingPermReq{ch: make(chan agentloop.PermResult, 1), tool: call.Name}
+	g.svc.permMu.Lock()
+	g.svc.pendingPerm[requestID] = req
+	g.svc.permMu.Unlock()
+	defer func() {
+		g.svc.permMu.Lock()
+		delete(g.svc.pendingPerm, requestID)
+		g.svc.permMu.Unlock()
+	}()
+
+	g.svc.broadcast(agentbridge.Event{
+		Type: "permission_request", SessionID: g.svc.Status().SessionID,
+		Permission: &agentbridge.PermissionEvent{
+			RequestID: requestID,
+			Summary:   fmt.Sprintf("工具 %s 请求执行", call.Name),
+			Tool: agentbridge.ToolEvent{
+				ID: call.ID, Title: call.Name, Kind: call.Name,
+				Status: "pending", RawInput: json.RawMessage(call.Arguments),
+			},
+			Options: nativePermissionOptions,
+		},
+	})
+
+	select {
+	case res := <-req.ch:
+		return res
+	case <-ctx.Done():
+		return agentloop.PermResult{Decision: agentloop.DecDeny, Reason: "用户取消了任务。"}
+	}
+}
+
+func (n *nativeAgentService) resolveAllPending() {
+	n.permMu.Lock()
+	for _, req := range n.pendingPerm {
+		req.ch <- agentloop.PermResult{Decision: agentloop.DecDeny, Reason: "用户取消了任务。"}
+	}
+	n.pendingPerm = map[string]*pendingPermReq{}
+	n.permMu.Unlock()
+	n.planMu.Lock()
+	for _, ch := range n.pendingPlan {
+		ch <- agentbridge.PlanDecision{Outcome: "cancelled"}
+	}
+	n.pendingPlan = map[string]chan agentbridge.PlanDecision{}
+	n.planMu.Unlock()
+}
+
+func (n *nativeAgentService) RespondPermission(requestID string, allow bool) error {
+	return n.RespondPermissionEx(requestID, allow, false)
+}
+
+func (n *nativeAgentService) RespondPermissionEx(requestID string, allow bool, remember bool) error {
+	decision := agentloop.DecDeny
+	reason := "用户拒绝了该操作。"
+	if allow {
+		decision = agentloop.DecAllow
+		reason = ""
+	}
+	var toolName string
+	if allow && remember {
+		n.SetSessionAutoApprove(true)
+	}
+	n.permMu.Lock()
+	req, ok := n.pendingPerm[requestID]
+	if ok {
+		toolName = req.tool
+		delete(n.pendingPerm, requestID)
+	}
+	n.permMu.Unlock()
+	if !ok {
+		return agentbridge.ErrPermissionNotFound
+	}
+	// allow_always 同时沉淀工具级会话规则（D5）：用户关闭会话级自动批准后，
+	// 该工具仍保持放行。
+	if allow && remember && n.perm != nil && toolName != "" {
+		_ = n.perm.AddSessionRule(toolName+"(*)", permission.Allow)
+	}
+	req.ch <- agentloop.PermResult{Decision: decision, Reason: reason}
+	return nil
+}
+
+func (n *nativeAgentService) RespondPermissionOption(requestID, optionID string, remember bool) error {
+	switch optionID {
+	case "allow_once":
+		return n.RespondPermissionEx(requestID, true, false)
+	case "allow_always":
+		return n.RespondPermissionEx(requestID, true, true)
+	default:
+		return n.RespondPermissionEx(requestID, false, false)
+	}
+}
+
+// nativePlanApprover 实现 tools.PlanApprover，桥到 plan_request WS 事件。
+type nativePlanApprover struct{ n *nativeAgentService }
+
+func (p *nativePlanApprover) RequestPlanMode(ctx context.Context) bool {
+	// 原生引擎一期：进入计划模式不阻塞审批（只读探索本身安全）。
+	return true
+}
+
+func (p *nativePlanApprover) ExitPlanWithPlan(ctx context.Context, plan string) (bool, string) {
+	requestID := fmt.Sprintf("plan-%d", time.Now().UnixNano())
+	ch := make(chan agentbridge.PlanDecision, 1)
+	p.n.planMu.Lock()
+	p.n.pendingPlan[requestID] = ch
+	p.n.planMu.Unlock()
+	defer func() {
+		p.n.planMu.Lock()
+		delete(p.n.pendingPlan, requestID)
+		p.n.planMu.Unlock()
+	}()
+
+	p.n.broadcast(agentbridge.Event{
+		Type: "plan_request", SessionID: p.n.Status().SessionID,
+		Plan: &agentbridge.PlanEvent{RequestID: requestID, Body: plan, Waiting: true},
+	})
+
+	select {
+	case res := <-ch:
+		return res.Outcome == "approved", res.Feedback
+	case <-ctx.Done():
+		return false, "用户取消了任务。"
+	}
+}
+
+func (n *nativeAgentService) RespondPlan(requestID string, decision agentbridge.PlanDecision) error {
+	n.planMu.Lock()
+	ch, ok := n.pendingPlan[requestID]
+	if ok {
+		delete(n.pendingPlan, requestID)
+	}
+	n.planMu.Unlock()
+	if !ok {
+		return agentbridge.ErrPlanNotFound
+	}
+	ch <- decision
+	return nil
+}
+
+// --- 会话配置与控制 ---
+
+func (n *nativeAgentService) SetSessionAutoApprove(enabled bool) {
+	n.mu.Lock()
+	n.autoAppr = enabled
+	n.mu.Unlock()
+	n.broadcastStatus()
+}
+
+func (n *nativeAgentService) SetSessionConfig(ctx context.Context, model, strength string) error {
+	n.mu.Lock()
+	if model != "" {
+		n.model = model
+	}
+	if strength != "" {
+		n.effort = strength
+	}
+	sessionID := n.sessionID
+	currentModel := n.model
+	n.mu.Unlock()
+	if sessionID != "" {
+		_ = n.st.Touch(sessionID, func(m *agentkit.SessionMeta) { m.Model = currentModel })
+	}
+	n.broadcastStatus()
+	return nil
+}
+
+func (n *nativeAgentService) RewindDropLastUser(ctx context.Context, restoreFiles bool) agentbridge.RewindResult {
+	n.mu.Lock()
+	mem := n.memory
+	sessionID := n.sessionID
+	busy := n.state == "busy"
+	n.mu.Unlock()
+	if busy || mem == nil {
+		return agentbridge.RewindResult{OK: false, Error: "会话进行中，无法回退"}
+	}
+	target := mem.UserTurns()
+	if !mem.RewindToUserTurn(target) {
+		return agentbridge.RewindResult{OK: false, Error: "没有可回退的用户消息"}
+	}
+	n.mu.Lock()
+	n.errText = ""
+	n.mu.Unlock()
+	_ = sessionID
+	return agentbridge.RewindResult{OK: true, UserTurnCount: mem.UserTurns()}
+}
+
+func (n *nativeAgentService) ClearBootstrap()                      {}
+func (n *nativeAgentService) ArmBootstrapFromSession(string) error { return nil }
+
+// --- 历史存储（ListStoredSessions 等映射到 agentkit.Store） ---
+
+func (n *nativeAgentService) ListStoredSessions(cwd string, limit int) ([]agentbridge.SessionSummary, error) {
+	metas, err := n.st.List(limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]agentbridge.SessionSummary, 0, len(metas))
+	for _, m := range metas {
+		if cwd != "" && m.Cwd != cwd {
+			continue
+		}
+		out = append(out, agentbridge.SessionSummary{
+			ID: m.ID, Title: m.Title, Cwd: m.Cwd,
+			CreatedAt: m.CreatedAt, UpdatedAt: m.UpdatedAt,
+			Model: m.Model, MessageCount: m.MessageCount,
+			CwdMissing: !dirExists(m.Cwd),
+		})
+	}
+	return out, nil
+}
+
+func dirExists(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return true
+	}
+	st, err := os.Stat(path)
+	return err == nil && st.IsDir()
+}
+
+func (n *nativeAgentService) StoredSessionHistory(id string) (agentbridge.SessionHistory, error) {
+	meta, err := n.st.GetMeta(id)
+	if err != nil {
+		return agentbridge.SessionHistory{}, err
+	}
+	records, err := n.st.LoadRecords(id)
+	if err != nil {
+		return agentbridge.SessionHistory{}, err
+	}
+	summary := agentbridge.SessionSummary{
+		ID: meta.ID, Title: meta.Title, Cwd: meta.Cwd,
+		CreatedAt: meta.CreatedAt, UpdatedAt: meta.UpdatedAt,
+		Model: meta.Model, MessageCount: meta.MessageCount,
+		CwdMissing: !dirExists(meta.Cwd),
+	}
+	msgs := make([]agentbridge.HistoryMessage, 0, len(records))
+	for _, r := range records {
+		switch r.Origin {
+		case agentkit.OriginUser:
+			msgs = append(msgs, agentbridge.HistoryMessage{Role: "user", Content: r.Text, Media: mediaRefsToBridge(r.Media)})
+		case agentkit.OriginAssistant:
+			if r.Text != "" {
+				msgs = append(msgs, agentbridge.HistoryMessage{Role: "assistant", Content: r.Text, Model: meta.Model})
+			}
+			if len(r.ToolCalls) > 0 {
+				for _, tc := range r.ToolCalls {
+					msgs = append(msgs, agentbridge.HistoryMessage{
+						Role: "tool",
+						Tool: &agentbridge.ToolEvent{ID: tc.ID, Title: tc.Name, Kind: tc.Name, Status: "completed", RawInput: json.RawMessage(tc.Arguments)},
+					})
+				}
+			}
+		case agentkit.OriginTool:
+			var payload struct {
+				Output string `json:"output"`
+				Error  bool   `json:"error"`
+			}
+			_ = json.Unmarshal([]byte(r.Text), &payload)
+			msgs = append(msgs, agentbridge.HistoryMessage{
+				Role:    "tool_result",
+				Content: payload.Output,
+				Tool:    &agentbridge.ToolEvent{ID: r.ToolCallID, Status: toolStatusFromPayload(payload.Error)},
+			})
+		}
+	}
+	return agentbridge.SessionHistory{Session: summary, Messages: msgs}, nil
+}
+
+func toolStatusFromPayload(isErr bool) string {
+	if isErr {
+		return "failed"
+	}
+	return "completed"
+}
+
+func mediaRefsToBridge(refs []agentkit.MediaRef) []agentbridge.MediaContent {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]agentbridge.MediaContent, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, agentbridge.MediaContent{Kind: r.Kind, MimeType: r.MimeType, URI: r.URI, Name: r.Name})
+	}
+	return out
+}
+
+func (n *nativeAgentService) RenameStoredSession(id, title string) error {
+	return n.st.Rename(id, title)
+}
+
+func (n *nativeAgentService) DeleteStoredSession(id string) error {
+	n.mu.Lock()
+	active := n.sessionID == id
+	n.mu.Unlock()
+	if active {
+		_ = n.Stop()
+	}
+	return n.st.Delete(id)
+}
+
+// 编译期确保实现完整接口。
+var _ AgentService = (*nativeAgentService)(nil)

--- a/internal/server/nativeagent_events.go
+++ b/internal/server/nativeagent_events.go
@@ -1,0 +1,165 @@
+package server
+
+// nativeEventTranslator 把 agentloop.Event 翻译成 agentbridge.Event（WS 协议），
+// 同时把 assistant/tool 消息持久化到 transcript。
+// 翻译表（UI 合同，见 ui/app.js handleAgentEvent）：
+//
+//	text_delta       → assistant_chunk
+//	think_delta      → thought_chunk
+//	tool_call        → tool_call（回显参数）
+//	tool_result      → tool_update（含结果）
+//	usage            → （仅录制，不推 UI）
+//	step_* / turn_*  → （UI 由 turn_done 收口）
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+
+	"grok_switch/internal/agentbridge"
+	"grok_switch/internal/agentkit"
+	"grok_switch/internal/agentloop"
+	"grok_switch/internal/llm"
+	"grok_switch/internal/tools"
+)
+
+type nativeEventTranslator struct {
+	svc       *nativeAgentService
+	sessionID string
+	turnID    string
+	registry  *tools.Registry
+
+	// 累积当前步的 assistant 文本/思考，turn 结束时一次性落盘。
+	mu           sync.Mutex
+	textBuf      strings.Builder
+	thinkBuf     strings.Builder
+	pendingCalls []llm.ToolCall
+	usage        *turnUsageHolder
+}
+
+func (t *nativeEventTranslator) Dispatch(ev agentloop.Event) {
+	switch ev.Type {
+	case agentloop.EventTextDelta:
+		t.mu.Lock()
+		t.textBuf.WriteString(ev.Text)
+		t.mu.Unlock()
+		t.svc.broadcast(agentbridge.Event{Type: "assistant_chunk", SessionID: t.sessionID, Text: ev.Text})
+	case agentloop.EventThinkDelta:
+		t.mu.Lock()
+		t.thinkBuf.WriteString(ev.Think)
+		t.mu.Unlock()
+		t.svc.broadcast(agentbridge.Event{Type: "thought_chunk", SessionID: t.sessionID, Text: ev.Think})
+	case agentloop.EventToolCall:
+		if ev.ToolCall != nil {
+			t.mu.Lock()
+			t.pendingCalls = append(t.pendingCalls, llm.ToolCall{ID: ev.ToolCall.ID, Name: ev.ToolCall.Name, Arguments: ev.ToolCall.Arguments})
+			t.mu.Unlock()
+		}
+		// UI 的 tool_call 渲染在 ACP 侧带 Status；原生引擎派发时即"运行中"。
+		if ev.ToolCall != nil {
+			t.svc.broadcast(agentbridge.Event{
+				Type: "tool_call", SessionID: t.sessionID,
+				Tool: &agentbridge.ToolEvent{
+					ID: ev.ToolCall.ID, Title: ev.ToolCall.Name, Kind: ev.ToolCall.Name,
+					Status: "in_progress", RawInput: json.RawMessage(ev.ToolCall.Arguments),
+				},
+			})
+		}
+	case agentloop.EventToolResult:
+		if ev.ToolResult != nil {
+			t.svc.broadcast(agentbridge.Event{
+				Type: "tool_update", SessionID: t.sessionID,
+				Tool: &agentbridge.ToolEvent{
+					ID: ev.ToolResult.ID, Title: ev.ToolResult.Name, Kind: ev.ToolResult.Name,
+					Status:    toolEventStatus(ev.ToolResult.IsError),
+					RawOutput: ev.ToolResult.Output,
+				},
+			})
+			// 工具结果落盘（含回显的 call 参数）。
+			t.mu.Lock()
+			var call *llm.ToolCall
+			for i := range t.pendingCalls {
+				if t.pendingCalls[i].ID == ev.ToolResult.ID {
+					call = &t.pendingCalls[i]
+					t.pendingCalls = append(t.pendingCalls[:i], t.pendingCalls[i+1:]...)
+					break
+				}
+			}
+			t.mu.Unlock()
+			if call != nil {
+				t.svc.persist(t.sessionID, agentkit.Record{
+					Origin: agentkit.OriginAssistant, Role: llm.RoleAssistant,
+					ToolCalls: []llm.ToolCall{{ID: call.ID, Name: call.Name, Arguments: call.Arguments}},
+					TurnID:    t.turnID,
+				})
+			}
+			t.svc.persist(t.sessionID, agentkit.Record{
+				Origin: agentkit.OriginTool, Role: llm.RoleTool,
+				ToolCallID: ev.ToolResult.ID,
+				Text:       agentloop.ToolResult{Output: ev.ToolResult.Output, IsError: ev.ToolResult.IsError, Truncated: ev.ToolResult.Truncated}.ResultJSON(),
+				TurnID:     t.turnID,
+			})
+		}
+	case agentloop.EventUsage:
+		if ev.Usage != nil && t.usage != nil {
+			t.usage.record(*ev.Usage)
+		}
+	case agentloop.EventTurnEnd, agentloop.EventTurnInterrupt:
+		// flush 累积文本（一段 assistant 回复一次落盘）。
+		t.mu.Lock()
+		text := t.textBuf.String()
+		think := t.thinkBuf.String()
+		t.textBuf.Reset()
+		t.thinkBuf.Reset()
+		t.mu.Unlock()
+		if text != "" || think != "" {
+			t.svc.persist(t.sessionID, agentkit.Record{
+				Origin: agentkit.OriginAssistant, Role: llm.RoleAssistant,
+				Text: text, Thinking: think, TurnID: t.turnID,
+			})
+		}
+	}
+}
+
+func toolEventStatus(isErr bool) string {
+	if isErr {
+		return "failed"
+	}
+	return "completed"
+}
+
+// turnUsageHolder 记录本 turn 最近一步的真实 input tokens（D3：无状态重放下
+// 该值 ≈ 当前全量历史体积，是 compaction 的触发依据）。
+type turnUsageHolder struct {
+	mu     sync.Mutex
+	tokens int64
+}
+
+func (h *turnUsageHolder) record(u llm.TokenUsage) {
+	h.mu.Lock()
+	h.tokens = u.InputTotal()
+	h.mu.Unlock()
+}
+
+func (h *turnUsageHolder) lastInputTokens() int64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.tokens
+}
+
+// compactViaLLM 用当前 Provider 生成一次压实摘要（非流式单调用）。
+func compactViaLLM(ctx context.Context, provider llm.Provider, dropped []llm.Message) (string, error) {
+	const maxInputChars = 60000
+	instruction := "请把以下是一段被折叠的 agent 对话历史压缩成一份交接摘要，供后续对话接续使用。" +
+		"摘要必须保留：用户的原始任务与目标、已完成的步骤与结果、重要文件路径与关键决定、" +
+		"未完成的事项与下一步。不要新增对话中不存在的内容。直接输出摘要正文。"
+	input := agentkit.CompactInputText(dropped, maxInputChars)
+	res, err := provider.Generate(ctx, "", nil, []llm.Message{{
+		Role:  llm.RoleUser,
+		Parts: []llm.ContentPart{llm.TextPart{Text: instruction + "\n\n<folded_history>\n" + input + "\n</folded_history>"}},
+	}}, llm.GenerateOptions{})
+	if err != nil {
+		return "", err
+	}
+	return res.Message.Text(), nil
+}

--- a/internal/server/nativeagent_setup.go
+++ b/internal/server/nativeagent_setup.go
@@ -1,0 +1,193 @@
+package server
+
+// 原生引擎的 server 层装配：Provider 工厂（从当前生效 Profile 构造）、
+// 系统提示词与生图工具适配。main.go 按 settings.AgentEngine 选择引擎时调用。
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"grok_switch/internal/agentbridge"
+	"grok_switch/internal/agentkit"
+	"grok_switch/internal/llm"
+	"grok_switch/internal/profiles"
+	"grok_switch/internal/tools"
+)
+
+// NewNativeAgentService 构造原生引擎服务（EngineDeps 绑定到本 Server）。
+func (s *Server) NewNativeAgentService() (AgentService, error) {
+	return newNativeAgentService(EngineDeps{
+		SessionsRoot: s.Paths.DataDir + "/agent2/sessions",
+		ProviderFor:  s.nativeProviderFor,
+		SystemPrompt: nativeSystemPrompt,
+		ImageGen:     s.nativeImageGen(),
+		DefaultCwd:   s.agentDefaultCwd(),
+	})
+}
+
+// nativeProviderFor 从当前生效 Profile 构造 Provider。
+// Grok Auth 池 Profile 的 base_url 是 loopback 代理；实际端口与本 Profile
+// 记录值可能不同（端口冲突顺延），这里用 ActualPort 重写。
+func (s *Server) nativeProviderFor() (llm.Provider, error) {
+	if s.Switcher == nil {
+		return nil, fmt.Errorf("供应商系统未初始化")
+	}
+	profile, ok, err := s.Switcher.ActiveStatus()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("没有生效的供应商 Profile")
+	}
+	bridge := profileToBridge(profile, s.ActualPort)
+	return llm.NewProviderForProfile(bridge)
+}
+
+// profileToBridge 把 profiles.Profile 投影成 llm.ProfileBridge。
+// 模型定义取第一个启用的 [model.*]；没有时用 Profile 级字段。
+func profileToBridge(p profiles.Profile, actualPort int) llm.ProfileBridge {
+	baseURL := p.BaseURL
+	apiKey := p.APIKey
+	model := p.DefaultModel
+	var contextWindow, maxCompletion int64
+	supportsEffort := p.DefaultReasoningEffort != ""
+	efforts := []string{"low", "medium", "high"}
+	if len(p.Models) > 0 {
+		m := p.Models[0]
+		if m.BaseURL != "" {
+			baseURL = m.BaseURL
+		}
+		if m.APIKey != "" {
+			apiKey = m.APIKey
+		}
+		if m.Model != "" {
+			model = m.Model
+		}
+		contextWindow = m.ContextWindow
+		maxCompletion = m.MaxCompletionTokens
+		supportsEffort = m.SupportsReasoningEffort
+		if len(m.ReasoningEfforts) > 0 {
+			efforts = m.ReasoningEfforts
+		}
+	}
+	// loopback 代理端口跟随实际端口（Profile 里记录的是首选端口）。
+	if isLoopbackURL(baseURL) && actualPort > 0 {
+		baseURL = rewriteLoopbackPort(baseURL, actualPort)
+	}
+	return llm.ProfileBridge{
+		UpstreamFormat:          p.UpstreamFormat,
+		BaseURL:                 baseURL,
+		APIKey:                  apiKey,
+		Model:                   model,
+		SessionKey:              p.ID,
+		SupportsReasoningEffort: supportsEffort,
+		ReasoningEfforts:        efforts,
+		ContextWindow:           contextWindow,
+		MaxCompletionTokens:     maxCompletion,
+	}
+}
+
+func isLoopbackURL(u string) bool {
+	return strings.Contains(u, "127.0.0.1") || strings.Contains(u, "localhost")
+}
+
+func rewriteLoopbackPort(u string, port int) string {
+	idx := strings.Index(u, "://")
+	if idx < 0 {
+		return u
+	}
+	scheme := u[:idx+3]
+	rest := u[idx+3:]
+	slash := strings.Index(rest, "/")
+	host := rest
+	path := ""
+	if slash >= 0 {
+		host, path = rest[:slash], rest[slash:]
+	}
+	colon := strings.LastIndex(host, ":")
+	if colon >= 0 {
+		host = host[:colon]
+	}
+	return fmt.Sprintf("%s%s:%d%s", scheme, host, port, path)
+}
+
+// nativeImageGen 返回生图工具适配；生图全局开关关闭或号池无账号时返回 nil
+// （工具不注册，模型回到无生图状态，与 acp 引擎的 MCP 移除语义一致）。
+// Registry 每 turn 重建，开关切换即时生效。
+func (s *Server) nativeImageGen() tools.ImageGenerator {
+	if s.Settings != nil {
+		if current, err := s.Settings.Get(); err != nil || !current.ImageGenEnabled {
+			return nil
+		}
+	}
+	if s.Imagine == nil || s.Imagine.AccountCount() == 0 {
+		return nil
+	}
+	return &imagineToolAdapter{server: s}
+}
+
+// imagineToolAdapter 把 ImagineEngine 适配成 tools.ImageGenerator。
+type imagineToolAdapter struct{ server *Server }
+
+func (a *imagineToolAdapter) Generate(ctx context.Context, prompt, model, aspect string, count int) ([]string, error) {
+	var paths []string
+	for i := 0; i < count; i++ {
+		res := a.server.Imagine.Generate(ctx, prompt, model, aspect)
+		if !res.OK || len(res.Images) == 0 {
+			if i == 0 {
+				return nil, fmt.Errorf("%s", orEmpty(res.ErrMsg, "生图失败"))
+			}
+			break
+		}
+		paths = append(paths, res.Images...)
+	}
+	return paths, nil
+}
+
+func (s *Server) agentDefaultCwd() string {
+	if s.Settings == nil {
+		return ""
+	}
+	current, err := s.Settings.Get()
+	if err != nil {
+		return ""
+	}
+	return current.AgentDefaultCwd
+}
+
+// nativeSystemPrompt 组装原生引擎系统提示词。
+// 骨架借鑑 Kimi 内置工具文档的组织方式（§6.3）；文案用中文，
+// 与本工具用户群一致。toolDoc 由注册表汇总（含每个工具的用法契约）。
+func nativeSystemPrompt(toolDoc string) string {
+	var b strings.Builder
+	b.WriteString(`你是 grok_switch 内置的软件工程 Agent，运行在用户的本机，直接操作他们的项目。
+
+# 工作方式
+
+- 先理解再动手：改动前读相关代码，确认最近的结构与约定；不确定时先问。
+- 从事实出发：以代码为准，不要凭文档或猜测断言。
+- 改动聚焦：只做当前任务要求的事，不顺手重构。
+- 验证闭环：改完代码后运行构建/测试验证；无法验证时明确说明。
+
+# 工具使用
+
+- 能用专用工具就不要用 bash：读文件用 read、改文件用 edit/write、找文件用 glob、搜内容用 grep。
+- 多个独立的只读操作放在同一轮并行发起。
+- 长命令（构建、测试、安装依赖）设置合理的 timeout。
+- 危险操作（删除、覆盖用户数据、全局安装）先说明再执行。
+
+# 输出
+
+- 用用户使用的语言回复。
+- 解释改了什么、为什么这么改；引用代码给出路径与行号。
+- 遇到阻塞如实说明，不要编造结果。
+
+`)
+	b.WriteString(toolDoc)
+	return b.String()
+}
+
+// 编译期引用（保持 import 最小化：agentbridge 用于 Status 语义对齐）。
+var _ = agentbridge.Event{}
+var _ = agentkit.OriginUser

--- a/internal/server/nativeagent_test.go
+++ b/internal/server/nativeagent_test.go
@@ -533,3 +533,71 @@ func TestNativeServiceRejectsMissingCwd(t *testing.T) {
 		t.Fatal("失效路径不应写入状态")
 	}
 }
+
+// 回归：turn 挂起审批时状态为 busy，旧实现 NewSession 保留 busy 不复位，
+// 一次无人应答的审批会把服务永久锁死（UI 无限转圈），新建会话也被吞掉。
+// 修复后 NewSession 应取消进行中的 turn 并复位到 ready。
+func TestNativeServiceNewSessionUnblocksBusy(t *testing.T) {
+	// write 工具需要审批：turn 停在 permission_request 上，不会自己结束。
+	prov := &stubProvider{steps: []llm.StreamResult{
+		toolStep("c1", "write", `{"path":"out.txt","content":"x"}`),
+		textStep("写完了"),
+	}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+
+	if err := svc.Prompt("写个文件", nil); err != nil {
+		t.Fatal(err)
+	}
+	// 等到 permission_request（此时 state=busy）。
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev := <-sub.events:
+			if ev.Type == "permission_request" {
+				goto busyConfirmed
+			}
+		case <-deadline:
+			t.Fatal("未收到审批请求")
+		}
+	}
+busyConfirmed:
+	for {
+		if svc.Status().State == "busy" {
+			break
+		}
+		select {
+		case <-sub.events:
+		case <-deadline:
+			t.Fatal("turn 未进入 busy")
+		}
+	}
+
+	// busy 期间新建会话：应成功并复位 ready，而不是静默保留 busy。
+	cwd2 := t.TempDir()
+	if err := svc.NewSession(t.Context(), cwd2); err != nil {
+		t.Fatalf("busy 期间新建会话失败: %v", err)
+	}
+	if st := svc.Status(); st.State != "ready" {
+		t.Fatalf("NewSession 后状态应为 ready, got %s (err=%s)", st.State, st.Error)
+	}
+	if st := svc.Status(); st.SessionID == "" || st.Cwd != cwd2 {
+		t.Fatalf("NewSession 后应指向新会话: %+v", st)
+	}
+	// 旧 turn 已被取消：transcript 收到配对的取消结果，turn_done 收口。
+	final := waitTurnDone(t, sub, 10*time.Second)
+	if final.Type != "turn_done" {
+		t.Fatalf("被放弃的 turn 应收口: %+v", final)
+	}
+	// 服务恢复可用：新会话能正常发起 turn。
+	prov.steps = []llm.StreamResult{textStep("新的会话")}
+	if err := svc.Prompt("你好", nil); err != nil {
+		t.Fatalf("新会话 Prompt 失败: %v", err)
+	}
+	final = waitTurnDone(t, sub, 10*time.Second)
+	if final.Type != "turn_done" {
+		t.Fatalf("新会话 turn 应正常完成: %+v", final)
+	}
+}

--- a/internal/server/nativeagent_test.go
+++ b/internal/server/nativeagent_test.go
@@ -1,0 +1,535 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"grok_switch/internal/agentbridge"
+	"grok_switch/internal/agentkit"
+	"grok_switch/internal/llm"
+	"grok_switch/internal/permission"
+	"grok_switch/internal/profiles"
+	"grok_switch/internal/settings"
+)
+
+// --- 测试基建：可控 Provider 注入 nativeAgentService ---
+
+type stubProvider struct {
+	mu    sync.Mutex
+	steps []llm.StreamResult
+	idx   int
+	calls int
+}
+
+func (p *stubProvider) Name() string      { return "stub" }
+func (p *stubProvider) ModelName() string { return "stub-model" }
+func (p *stubProvider) Capability() llm.ModelCapability {
+	return llm.ModelCapability{ToolUse: true, MaxContextTokens: 100000, UsageAccuracy: llm.UsageExact}
+}
+
+func (p *stubProvider) Generate(ctx context.Context, systemPrompt string, tools []llm.Tool, history []llm.Message, opts llm.GenerateOptions) (*llm.StreamResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if p.idx >= len(p.steps) {
+		p.idx = len(p.steps) - 1
+	}
+	res := p.steps[p.idx]
+	p.idx++
+	if opts.OnDelta != nil && res.Message.Text() != "" {
+		opts.OnDelta(llm.TextDelta{Text: res.Message.Text()})
+	}
+	return &res, nil
+}
+
+func (p *stubProvider) WithThinking(effort string) llm.Provider  { return p }
+func (p *stubProvider) WithMaxOutputTokens(n int64) llm.Provider { return p }
+
+func newTestNativeService(t *testing.T, prov llm.Provider) *nativeAgentService {
+	t.Helper()
+	root := t.TempDir()
+	svc, err := newNativeAgentService(EngineDeps{
+		SessionsRoot: root,
+		ProviderFor:  func() (llm.Provider, error) { return prov, nil },
+		SystemPrompt: func(toolDoc string) string { return "sys+" + toolDoc },
+		DefaultCwd:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func textStep(text string) llm.StreamResult {
+	return llm.StreamResult{
+		Message:      llm.Message{Role: llm.RoleAssistant, Parts: []llm.ContentPart{llm.TextPart{Text: text}}},
+		Usage:        llm.TokenUsage{InputOther: 50, Output: 10},
+		Accuracy:     llm.UsageExact,
+		FinishReason: "stop",
+	}
+}
+
+func toolStep(id, name, args string) llm.StreamResult {
+	return llm.StreamResult{
+		Message:      llm.Message{Role: llm.RoleAssistant, ToolCalls: []llm.ToolCall{{ID: id, Name: name, Arguments: json.RawMessage(args)}}},
+		Usage:        llm.TokenUsage{InputOther: 60, Output: 12},
+		Accuracy:     llm.UsageExact,
+		FinishReason: "tool_use",
+	}
+}
+
+func waitTurnDone(t *testing.T, sub *agentBridgeSub, timeout time.Duration) agentbridge.Event {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev, ok := <-sub.events:
+			if !ok {
+				t.Fatal("订阅关闭")
+			}
+			if ev.Type == "turn_done" || ev.Type == "error" {
+				return ev
+			}
+		case <-deadline:
+			t.Fatal("等待 turn 结束超时")
+		}
+	}
+}
+
+// agentBridgeSub 收集事件的订阅封装。
+type agentBridgeSub struct {
+	id     string
+	events <-chan agentbridge.Event
+}
+
+func subscribeNative(t *testing.T, svc *nativeAgentService) *agentBridgeSub {
+	t.Helper()
+	id, ch := svc.Subscribe()
+	return &agentBridgeSub{id: id, events: ch}
+}
+
+// --- 用例 ---
+
+func TestNativeServiceStatusAndStart(t *testing.T) {
+	svc := newTestNativeService(t, &stubProvider{})
+	st := svc.Status()
+	if !st.Available || st.Running {
+		t.Fatalf("初始状态错误: %+v", st)
+	}
+	if err := svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	st = svc.Status()
+	if !st.Running || st.State != "ready" || st.SessionID == "" {
+		t.Fatalf("启动后状态错误: %+v", st)
+	}
+	if err := svc.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if svc.Status().Running {
+		t.Fatal("停止后 Running 应为 false")
+	}
+}
+
+func TestNativeServicePromptTextTurn(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{textStep("自研引擎回复")}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+
+	if err := svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	<-sub.events // agent_status(ready)
+
+	if err := svc.Prompt("你好", nil); err != nil {
+		t.Fatal(err)
+	}
+	final := waitTurnDone(t, sub, 10*time.Second)
+	if final.Type != "turn_done" || final.StopReason != "end_turn" {
+		t.Fatalf("turn 结束错误: %+v", final)
+	}
+
+	// 忙碌保护：turn 已结束后可以再次 Prompt。
+	if err := svc.Prompt("第二条", nil); err != nil {
+		t.Fatalf("turn 结束后应可继续: %v", err)
+	}
+	waitTurnDone(t, sub, 10*time.Second)
+}
+
+func TestNativeServiceEventsSequence(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{textStep("hello")}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+
+	_ = svc.Prompt("hi", nil)
+	var types []string
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev := <-sub.events:
+			types = append(types, ev.Type)
+			if ev.Type == "turn_done" {
+				goto done
+			}
+		case <-deadline:
+			t.Fatal("超时")
+		}
+	}
+done:
+	// 事件序列：assistant_chunk → turn_done（agent_status 收尾）。
+	joined := joinStrings(types)
+	if !containsStr(joined, "assistant_chunk") || !containsStr(joined, "turn_done") {
+		t.Fatalf("事件缺失: %v", types)
+	}
+}
+
+func TestNativeServiceToolTurnAndPermission(t *testing.T) {
+	// write 工具需要审批：默认 manual 模式 → permission_request。
+	prov := &stubProvider{steps: []llm.StreamResult{
+		toolStep("c1", "write", `{"path":"out.txt","content":"引擎写的"}`),
+		textStep("写完了"),
+	}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	cwd := t.TempDir()
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: cwd})
+	<-sub.events
+
+	_ = svc.Prompt("写个文件", nil)
+
+	// 等待 permission_request。
+	var permEvt agentbridge.Event
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev := <-sub.events:
+			if ev.Type == "permission_request" {
+				permEvt = ev
+				goto gotPerm
+			}
+		case <-deadline:
+			t.Fatal("未收到审批请求")
+		}
+	}
+gotPerm:
+	if permEvt.Permission == nil || permEvt.Permission.RequestID == "" {
+		t.Fatalf("审批事件不完整: %+v", permEvt)
+	}
+	if len(permEvt.Permission.Options) != 3 {
+		t.Fatalf("审批选项错误: %+v", permEvt.Permission.Options)
+	}
+	// 批准。
+	if err := svc.RespondPermissionEx(permEvt.Permission.RequestID, true, false); err != nil {
+		t.Fatal(err)
+	}
+	final := waitTurnDone(t, sub, 10*time.Second)
+	if final.Type != "turn_done" {
+		t.Fatalf("批准后应完成: %+v", final)
+	}
+	// 文件确实被写。
+	data, err := os.ReadFile(filepath.Join(cwd, "out.txt"))
+	if err != nil || string(data) != "引擎写的" {
+		t.Fatalf("工具未生效: %v %q", err, data)
+	}
+}
+
+func TestNativeServiceSessionHistory(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{textStep("第一轮回复")}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+	_ = svc.Prompt("问题一", nil)
+	waitTurnDone(t, sub, 10*time.Second)
+	_ = svc.Prompt("问题二", nil)
+	waitTurnDone(t, sub, 10*time.Second)
+
+	sessionID := svc.Status().SessionID
+	sessions, err := svc.ListStoredSessions("", 100)
+	if err != nil || len(sessions) != 1 {
+		t.Fatalf("会话列表错误: %v %d", err, len(sessions))
+	}
+	history, err := svc.StoredSessionHistory(sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history.Messages) < 4 {
+		t.Fatalf("历史消息不足: %d", len(history.Messages))
+	}
+	if history.Messages[0].Role != "user" || history.Messages[0].Content != "问题一" {
+		t.Fatalf("首条消息错误: %+v", history.Messages[0])
+	}
+	found := false
+	for _, m := range history.Messages {
+		if m.Role == "assistant" && containsStr(m.Content, "第一轮回复") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("assistant 回复未入历史")
+	}
+	// 重命名与删除。
+	if err := svc.RenameStoredSession(sessionID, "测试标题"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.DeleteStoredSession(sessionID); err != nil {
+		t.Fatal(err)
+	}
+	sessions, _ = svc.ListStoredSessions("", 100)
+	if len(sessions) != 0 {
+		t.Fatal("删除后列表应为空")
+	}
+}
+
+func TestNativeServiceRewind(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{textStep("回复")}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+	_ = svc.Prompt("q1", nil)
+	waitTurnDone(t, sub, 10*time.Second)
+	_ = svc.Prompt("q2", nil)
+	waitTurnDone(t, sub, 10*time.Second)
+
+	res := svc.RewindDropLastUser(t.Context(), false)
+	if !res.OK || res.UserTurnCount != 1 {
+		t.Fatalf("rewind 错误: %+v", res)
+	}
+	if svc.memory.UserTurns() != 1 {
+		t.Fatalf("内存轮次错误: %d", svc.memory.UserTurns())
+	}
+}
+
+func TestNativeServiceSystemPromptIncludesToolDoc(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{textStep("ok")}}
+	svc := newTestNativeService(t, prov)
+	var captured string
+	svc.deps.SystemPrompt = func(toolDoc string) string {
+		captured = toolDoc
+		return "sys"
+	}
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+	_ = svc.Prompt("hi", nil)
+	waitTurnDone(t, sub, 10*time.Second)
+	if !containsStr(captured, "read") || !containsStr(captured, "bash") {
+		t.Fatalf("工具文档未注入 system prompt: %q", captured[:min(200, len(captured))])
+	}
+}
+
+func TestProfileToBridgePortRewrite(t *testing.T) {
+	p := profiles.Profile{
+		ID:             "p1",
+		BaseURL:        "http://127.0.0.1:17878/grok/v1",
+		APIKey:         "gsk-test",
+		UpstreamFormat: "openai_responses",
+		DefaultModel:   "grok-4.6",
+		Models: []profiles.ModelDef{
+			{Model: "grok-4.6", BaseURL: "http://127.0.0.1:17878/grok/v1", ContextWindow: 500000, MaxCompletionTokens: 65536, SupportsReasoningEffort: true},
+		},
+	}
+	bridge := profileToBridge(p, 19999)
+	if !containsStr(bridge.BaseURL, "127.0.0.1:19999") {
+		t.Fatalf("端口未重写: %s", bridge.BaseURL)
+	}
+	if bridge.Model != "grok-4.6" || bridge.ContextWindow != 500000 || !bridge.SupportsReasoningEffort {
+		t.Fatalf("模型字段投影错误: %+v", bridge)
+	}
+	if bridge.SessionKey != "p1" {
+		t.Fatalf("sessionKey 应为 Profile ID: %q", bridge.SessionKey)
+	}
+}
+
+func TestAgentEngineSettingNormalization(t *testing.T) {
+	cases := map[string]string{
+		"":        settings.AgentEngineACP,
+		"acp":     settings.AgentEngineACP,
+		"native":  settings.AgentEngineNative,
+		"garbage": settings.AgentEngineACP,
+	}
+	for in, want := range cases {
+		s := settings.Settings{AgentEngine: in}
+		if got := s.NormalizedAgentEngine(); got != want {
+			t.Fatalf("NormalizedAgentEngine(%q)=%q, want %q", in, got, want)
+		}
+	}
+}
+
+// --- 小工具 ---
+
+func joinStrings(items []string) string {
+	out := ""
+	for _, s := range items {
+		out += s + ","
+	}
+	return out
+}
+
+func containsStr(s, sub string) bool {
+	return strings.Contains(s, sub)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestNativeServiceDenyRuleBlocksTool(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{
+		toolStep("c1", "bash", `{"command":"rm -rf /tmp/x"}`),
+		textStep("已跳过危险命令"),
+	}}
+	svc := newTestNativeService(t, prov)
+	if err := svc.perm.AddUserRule("bash(rm *)", permission.Deny); err != nil {
+		t.Fatal(err)
+	}
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+	_ = svc.Prompt("清理", nil)
+	final := waitTurnDone(t, sub, 10*time.Second)
+	if final.Type != "turn_done" {
+		t.Fatalf("deny 不应终止 turn: %+v", final)
+	}
+	// 拒绝原因来自规则（DenyReason 可观测）。
+	if reason := svc.perm.DenyReason("bash", json.RawMessage(`{"command":"rm -rf /tmp/x"}`)); reason == "" {
+		t.Fatal("deny reason 不应为空")
+	}
+}
+
+func TestNativeServiceAllowAlwaysSedimentsRule(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{
+		toolStep("c1", "bash", `{"command":"npm test"}`),
+		textStep("完成"),
+		toolStep("c2", "bash", `{"command":"npm run build"}`),
+		textStep("again"),
+	}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+	_ = svc.Prompt("跑测试", nil)
+
+	// 等审批 → allow_always。
+	deadline := time.After(10 * time.Second)
+	var permEvt agentbridge.Event
+	for {
+		select {
+		case ev := <-sub.events:
+			if ev.Type == "permission_request" {
+				permEvt = ev
+				goto got
+			}
+		case <-deadline:
+			t.Fatal("未收到审批")
+		}
+	}
+got:
+	if err := svc.RespondPermissionOption(permEvt.Permission.RequestID, "allow_always", true); err != nil {
+		t.Fatal(err)
+	}
+	waitTurnDone(t, sub, 10*time.Second)
+
+	// 规则沉淀：bash(*) 会话规则存在，第二个 bash 调用不再弹审批。
+	sessionRules, _ := svc.perm.Rules()
+	if len(sessionRules) != 1 || sessionRules[0] != "bash(*)" {
+		t.Fatalf("allow_always 应沉淀工具级会话规则: %v", sessionRules)
+	}
+	_ = svc.Prompt("再跑构建", nil)
+	deadline = time.After(10 * time.Second)
+	for {
+		select {
+		case ev := <-sub.events:
+			if ev.Type == "permission_request" {
+				t.Fatal("规则命中后不应再弹审批")
+			}
+			if ev.Type == "turn_done" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("等待第二轮结束超时")
+		}
+	}
+}
+
+func TestNativeServiceAutoCompaction(t *testing.T) {
+	// 场景：provider 回报 input tokens 超过 85% 窗口 → 第二个 turn 的
+	// BeforeStep 触发压实，历史被折叠成摘要。
+	big := strings.Repeat("历史内容", 3000) // ~12000 token
+	heavy := textStep("第一轮回复")
+	heavy.Usage = llm.TokenUsage{InputOther: 90000} // 触发 85% 阈值
+	prov := &stubProvider{steps: []llm.StreamResult{
+		heavy,             // turn 1（usage 超阈值）
+		textStep("第二轮回复"), // turn 2 回复
+		textStep(big),     // 摘要调用（compactViaLLM）
+	}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+
+	// turn 1：usage 巨大，触发阈值。
+	_ = svc.Prompt("第一问", nil)
+	waitTurnDone(t, sub, 10*time.Second)
+	// turn 2：BeforeStep 命中压实 → 摘要调用（第 3 步脚本）→ 正常回复。
+	_ = svc.Prompt("第二问", nil)
+	final := waitTurnDone(t, sub, 10*time.Second)
+	if final.Type != "turn_done" {
+		t.Fatalf("压实不应破坏 turn: %+v", final)
+	}
+	// 压实后历史应显著小于压实体积：assistant/tool 全部折叠。
+	msgs := svc.memory.History()
+	if len(msgs) >= 8 {
+		t.Fatalf("压实后历史应被折叠, got %d 条", len(msgs))
+	}
+	foundSummary := false
+	for _, m := range msgs {
+		if strings.HasPrefix(m.Text(), agentkit.COMPACTION_SUMMARY_PREFIX) {
+			foundSummary = true
+		}
+	}
+	if !foundSummary {
+		t.Fatal("压实摘要缺失")
+	}
+	// transcript 里有压实记录。
+	records, _ := svc.st.LoadRecords(svc.Status().SessionID)
+	compacted := false
+	for _, r := range records {
+		if strings.Contains(r.Text, "[上下文已压实") {
+			compacted = true
+		}
+	}
+	if !compacted {
+		t.Fatal("压实事件未落盘")
+	}
+}
+
+func TestNativeServiceRejectsMissingCwd(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{textStep("never")}}
+	svc := newTestNativeService(t, prov)
+	dead := filepath.Join(t.TempDir(), "no-such-dir")
+	err := svc.Start(t.Context(), agentbridge.StartOptions{Cwd: dead})
+	if err == nil || !strings.Contains(err.Error(), "工作目录不存在") {
+		t.Fatalf("死路径应报错: %v", err)
+	}
+	// NewSession 同样拒绝。
+	if err := svc.NewSession(t.Context(), dead); err == nil {
+		t.Fatal("NewSession 应拒绝死路径")
+	}
+	// 死路径不得被记住（状态里没有 cwd 残留）。
+	if svc.Status().Cwd == dead {
+		t.Fatal("失效路径不应写入状态")
+	}
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -34,6 +34,25 @@ type Settings struct {
 	// 服务器并接管 image_gen 请求（走账号池）；关闭时移除注册、不做接管，
 	// 模型回到无生图能力的原始状态。对所有供应商生效。
 	ImageGenEnabled bool `json:"image_gen_enabled"`
+	// AgentEngine 选择聊天工作台的 Agent 引擎（设计文档 D6）：
+	//   "acp"    — spawn Grok CLI 走 ACP 协议（旧行为，默认）
+	//   "native" — 进程内自研引擎（internal/agentloop），无需 grok CLI
+	// 空值按 "acp" 处理；启动失败自动降级 acp 并在 UI 提示。
+	AgentEngine string `json:"agent_engine,omitempty"`
+}
+
+// 引擎选择器的合法取值。
+const (
+	AgentEngineACP    = "acp"
+	AgentEngineNative = "native"
+)
+
+// NormalizedAgentEngine 返回归一化的引擎名（空/未知 → acp）。
+func (s Settings) NormalizedAgentEngine() string {
+	if s.AgentEngine == AgentEngineNative {
+		return AgentEngineNative
+	}
+	return AgentEngineACP
 }
 
 type Store struct {
@@ -235,6 +254,7 @@ func normalize(s Settings) Settings {
 	if s.AgentDefaultCwd == "." {
 		s.AgentDefaultCwd = ""
 	}
+	s.AgentEngine = s.NormalizedAgentEngine()
 	return s
 }
 

--- a/internal/tools/adapter.go
+++ b/internal/tools/adapter.go
@@ -1,0 +1,49 @@
+package tools
+
+import (
+	"context"
+	"strings"
+
+	"grok_switch/internal/agentfs"
+	"grok_switch/internal/agentloop"
+	"grok_switch/internal/llm"
+)
+
+// ToolsAdapter 把 *Registry 适配成 agentloop.ToolExecutor。
+// tools → agentloop 单向依赖（agentloop 不 import tools），无环。
+type ToolsAdapter struct {
+	Registry *Registry
+}
+
+// NewToolsAdapter 构造适配器。
+func NewToolsAdapter(reg *Registry) *ToolsAdapter {
+	return &ToolsAdapter{Registry: reg}
+}
+
+// Schemas 实现 agentloop.ToolExecutor。
+func (a *ToolsAdapter) Schemas() []llm.Tool { return a.Registry.Schemas() }
+
+// Execute 实现 agentloop.ToolExecutor：工具失败转 IsError 结果而非 Go 错误
+// （工具失败不终止 turn，模型看到错误后自行调整）。
+func (a *ToolsAdapter) Execute(ctx context.Context, call llm.ToolCall) (agentloop.ToolResult, error) {
+	out := a.Registry.ExecuteTool(ctx, call)
+	return agentloop.ToolResult{
+		Output:    out.Text,
+		IsError:   out.IsError,
+		Truncated: out.Truncated,
+		Media:     out.Media,
+	}, nil
+}
+
+// EnvFor 返回给定工作目录的沙箱 Env（server 层构造 Registry 时使用）。
+func EnvFor(cwd string) agentfs.Env {
+	return agentfs.Env{Cwd: cwd}
+}
+
+// TruncateForDisplay 截断文本用于 UI 预览。
+func TruncateForDisplay(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return strings.TrimSpace(s[:max]) + "…"
+}

--- a/internal/tools/agenttools.go
+++ b/internal/tools/agenttools.go
@@ -1,0 +1,168 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"grok_switch/internal/agentfs"
+	"grok_switch/internal/llm"
+)
+
+// PlanApprover 是 plan 模式的宿主回调：进入 plan 模式的请求需要用户确认。
+// server 层把它接到现有的 plan 审批 WS 事件流。
+type PlanApprover interface {
+	// RequestPlanMode 由工具调用触发，返回用户决定（approve=进入 plan 模式）。
+	RequestPlanMode(ctx context.Context) bool
+	// ExitPlanWithPlan 提交计划等待用户批准；返回用户决定与反馈。
+	ExitPlanWithPlan(ctx context.Context, plan string) (approved bool, feedback string)
+}
+
+// --- enter_plan_mode ---
+
+type EnterPlanModeTool struct{ Approver PlanApprover }
+
+func (EnterPlanModeTool) Name() string { return "enter_plan_mode" }
+
+func (EnterPlanModeTool) Schema() map[string]any {
+	return map[string]any{
+		"type":       "object",
+		"properties": map[string]any{},
+	}
+}
+
+func (EnterPlanModeTool) Doc() string {
+	return `进入计划模式：先探索与设计，把实施方案提交用户批准后再动手改代码。
+适用于：多文件改动、架构调整、需求有歧义、用户明确要求先出方案。
+在计划模式内只读（read/glob/grep），不得修改文件或执行有副作用的命令。`
+}
+
+func (t EnterPlanModeTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	if t.Approver == nil {
+		return ToolOutput{Text: "已进入计划模式（无审批回调，视为自动同意）。"}
+	}
+	if t.Approver.RequestPlanMode(ctx) {
+		return ToolOutput{Text: "用户同意进入计划模式。请只做只读探索，完成后用 exit_plan_mode 提交方案。"}
+	}
+	return ToolOutput{Text: "用户拒绝了进入计划模式，请按普通模式继续。", IsError: true}
+}
+
+// --- exit_plan_mode ---
+
+type ExitPlanModeTool struct{ Approver PlanApprover }
+
+func (ExitPlanModeTool) Name() string { return "exit_plan_mode" }
+
+func (ExitPlanModeTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"plan": map[string]any{"type": "string", "description": "完整实施计划（markdown）"},
+		},
+		"required": []string{"plan"},
+	}
+}
+
+func (ExitPlanModeTool) Doc() string {
+	return `提交实施计划并等待用户批准。计划应包含：目标、涉及文件、实施步骤、
+验证方式。用户批准后退出计划模式开始实施；被拒绝时按反馈调整。`
+}
+
+type exitPlanArgs struct {
+	Plan string `json:"plan"`
+}
+
+func (t ExitPlanModeTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a exitPlanArgs
+	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Plan) == "" {
+		return argHelp("exit_plan_mode", err, `{"plan": "完整计划 markdown"}`)
+	}
+	if t.Approver == nil {
+		return ToolOutput{Text: "计划已提交（无审批回调，视为自动批准）。"}
+	}
+	approved, feedback := t.Approver.ExitPlanWithPlan(ctx, a.Plan)
+	if approved {
+		return ToolOutput{Text: "用户批准了计划，退出计划模式，开始实施。"}
+	}
+	msg := "用户拒绝了计划"
+	if feedback != "" {
+		msg += "，反馈: " + feedback
+	}
+	return ToolOutput{Text: msg + "。请按反馈修订后重新提交。", IsError: true}
+}
+
+// --- generate_image ---
+
+// ImageGenerator 是生图引擎接口（server 层接 ImagineEngine，测试用假实现）。
+type ImageGenerator interface {
+	// Generate 生成图片，返回保存路径列表。
+	Generate(ctx context.Context, prompt, model, aspect string, count int) ([]string, error)
+}
+
+type GenerateImageTool struct{ Engine ImageGenerator }
+
+func (GenerateImageTool) Name() string { return "generate_image" }
+
+func (GenerateImageTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"prompt": map[string]any{"type": "string", "description": "图像描述（提示词）"},
+			"aspect": map[string]any{"type": "string", "description": "宽高比: 1:1 | 16:9 | 9:16 | 4:3 | 3:4（默认 1:1）"},
+			"count":  map[string]any{"type": "integer", "description": "生成数量 1-4（默认 1）"},
+		},
+		"required": []string{"prompt"},
+	}
+}
+
+func (GenerateImageTool) Doc() string {
+	return `生成图片（走本地生图引擎与账号池）。为获得好结果，提示词应描述主体、
+风格、构图与光线。返回保存路径；结果同时出现在画廊。`
+}
+
+type genImageArgs struct {
+	Prompt string `json:"prompt"`
+	Aspect string `json:"aspect"`
+	Count  int    `json:"count"`
+}
+
+var allowedAspects = map[string]bool{"1:1": true, "16:9": true, "9:16": true, "4:3": true, "3:4": true, "3:2": true, "2:3": true}
+
+func (t GenerateImageTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a genImageArgs
+	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Prompt) == "" {
+		return argHelp("generate_image", err, `{"prompt": "...", "aspect"?: "1:1", "count"?: 1}`)
+	}
+	if t.Engine == nil {
+		return ToolOutput{Text: "生图引擎未启用（设置中可开启生图）", IsError: true}
+	}
+	aspect := a.Aspect
+	if aspect == "" {
+		aspect = "1:1"
+	}
+	if !allowedAspects[aspect] {
+		return ToolOutput{Text: fmt.Sprintf("不支持的宽高比 %q，可选: 1:1 16:9 9:16 4:3 3:4 3:2 2:3", aspect), IsError: true}
+	}
+	count := a.Count
+	if count <= 0 {
+		count = 1
+	}
+	if count > 4 {
+		count = 4
+	}
+	paths, err := t.Engine.Generate(ctx, a.Prompt, "", aspect, count)
+	if err != nil {
+		return ToolOutput{Text: fmt.Sprintf("生图失败: %v", err), IsError: true}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "已生成 %d 张图片:\n", len(paths))
+	for _, p := range paths {
+		b.WriteString(p)
+		b.WriteString("\n")
+	}
+	return ToolOutput{
+		Text:  b.String(),
+		Media: []llm.ContentPart{},
+	}
+}

--- a/internal/tools/defaults.go
+++ b/internal/tools/defaults.go
@@ -1,0 +1,24 @@
+package tools
+
+import (
+	"grok_switch/internal/agentfs"
+)
+
+// DefaultRegistry 组装第一期工具集（设计文档 §6.3 的 9 工具，plan 一对算两个）。
+// imageGen 为 nil 时不注册 generate_image；approver 为 nil 时 plan 工具自动同意。
+func DefaultRegistry(getEnv func() agentfs.Env, imageGen ImageGenerator, approver PlanApprover, todos *TodoStore) *Registry {
+	reg := NewRegistry(func() agentfs.Env { return getEnv() })
+	reg.Register(ReadTool{})
+	reg.Register(WriteTool{})
+	reg.Register(EditTool{})
+	reg.Register(GlobTool{})
+	reg.Register(GrepTool{})
+	reg.Register(BashTool{})
+	reg.Register(TodoListTool{Store: todos})
+	reg.Register(EnterPlanModeTool{Approver: approver})
+	reg.Register(ExitPlanModeTool{Approver: approver})
+	if imageGen != nil {
+		reg.Register(GenerateImageTool{Engine: imageGen})
+	}
+	return reg
+}

--- a/internal/tools/filetools.go
+++ b/internal/tools/filetools.go
@@ -1,0 +1,199 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"grok_switch/internal/agentfs"
+)
+
+// --- read ---
+
+type ReadTool struct{}
+
+func (ReadTool) Name() string { return "read" }
+
+func (ReadTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path":   map[string]any{"type": "string", "description": "要读取的文件路径（相对工作目录或绝对路径）"},
+			"offset": map[string]any{"type": "integer", "description": "起始行号（1 起，从该行开始读）"},
+			"limit":  map[string]any{"type": "integer", "description": "最多读取行数"},
+		},
+		"required": []string{"path"},
+	}
+}
+
+func (ReadTool) Doc() string {
+	return `读取文本文件内容，带行号返回。支持 offset/limit 分页读取大文件。
+读图片请用 read_media。cat/head/tail 一律用本工具代替。`
+}
+
+type readArgs struct {
+	Path   string `json:"path"`
+	Offset int    `json:"offset"`
+	Limit  int    `json:"limit"`
+}
+
+const (
+	readMaxBytes     = 4 << 20
+	readDefaultLimit = 1000
+	readMaxLineLen   = 2000
+)
+
+func (ReadTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a readArgs
+	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Path) == "" {
+		return argHelp("read", err, `{"path": "...", "offset"?: 1, "limit"?: 500}`)
+	}
+	abs, err := env.Guard(a.Path)
+	if err != nil {
+		return ToolOutput{Text: err.Error(), IsError: true}
+	}
+	content, err := env.ReadText(abs, readMaxBytes)
+	if err != nil {
+		return ToolOutput{Text: fmt.Sprintf("读取失败: %v", err), IsError: true}
+	}
+	if content == "" {
+		return ToolOutput{Text: "(空文件)"}
+	}
+	lines := strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+	total := len(lines)
+	start := 1
+	if a.Offset > 1 {
+		start = a.Offset
+	}
+	if start > total {
+		return ToolOutput{Text: fmt.Sprintf("起始行 %d 超出文件总行数 %d", start, total), IsError: true}
+	}
+	limit := a.Limit
+	if limit <= 0 {
+		limit = readDefaultLimit
+	}
+	end := start + limit - 1
+	if end > total {
+		end = total
+	}
+	var b strings.Builder
+	for i := start; i <= end; i++ {
+		line := lines[i-1]
+		if len(line) > readMaxLineLen {
+			line = line[:readMaxLineLen] + "…[行截断]"
+		}
+		fmt.Fprintf(&b, "%6d\t%s\n", i, line)
+	}
+	if end < total {
+		fmt.Fprintf(&b, "... (共 %d 行，显示 %d-%d；用 offset=%d 继续读)\n", total, start, end, end+1)
+	}
+	return ToolOutput{Text: b.String()}
+}
+
+// --- write ---
+
+type WriteTool struct{}
+
+func (WriteTool) Name() string { return "write" }
+
+func (WriteTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path":    map[string]any{"type": "string", "description": "目标文件路径"},
+			"content": map[string]any{"type": "string", "description": "完整文件内容（整文件覆盖写入）"},
+		},
+		"required": []string{"path", "content"},
+	}
+}
+
+func (WriteTool) Doc() string {
+	return `把完整内容写入文件（整文件覆盖，原子写入）。目标已存在时会被覆盖。
+追加或局部修改请用 edit；echo > file / cat <<EOF 一律用本工具代替。`
+}
+
+type writeArgs struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func (WriteTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a writeArgs
+	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Path) == "" {
+		return argHelp("write", err, `{"path": "...", "content": "..."}`)
+	}
+	abs, err := env.Guard(a.Path)
+	if err != nil {
+		return ToolOutput{Text: err.Error(), IsError: true}
+	}
+	if err := env.WriteText(abs, a.Content); err != nil {
+		return ToolOutput{Text: fmt.Sprintf("写入失败: %v", err), IsError: true}
+	}
+	lines := strings.Count(a.Content, "\n") + 1
+	return ToolOutput{Text: fmt.Sprintf("已写入 %s（%d 字节，%d 行）", abs, len(a.Content), lines)}
+}
+
+// --- edit ---
+
+type EditTool struct{}
+
+func (EditTool) Name() string { return "edit" }
+
+func (EditTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"path":       map[string]any{"type": "string", "description": "目标文件路径"},
+			"old_string": map[string]any{"type": "string", "description": "要替换的原文（必须与文件内容精确匹配且唯一）"},
+			"new_string": map[string]any{"type": "string", "description": "替换后的新文本"},
+		},
+		"required": []string{"path", "old_string", "new_string"},
+	}
+}
+
+func (EditTool) Doc() string {
+	return `在文件中做精确字符串替换。old_string 必须与文件内容完全一致且唯一命中；
+命中多处时工具会拒绝并提示补充上下文（把 old_string 写长一点以唯一定位）。
+创建新文件用 write。`
+}
+
+type editArgs struct {
+	Path      string `json:"path"`
+	OldString string `json:"old_string"`
+	NewString string `json:"new_string"`
+}
+
+func (EditTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a editArgs
+	if err := json.Unmarshal(args, &a); err != nil || a.Path == "" {
+		return argHelp("edit", err, `{"path": "...", "old_string": "...", "new_string": "..."}`)
+	}
+	if a.OldString == "" {
+		return ToolOutput{Text: "old_string 不能为空（清空文件请用 write）", IsError: true}
+	}
+	if a.OldString == a.NewString {
+		return ToolOutput{Text: "old_string 与 new_string 相同，无需编辑", IsError: true}
+	}
+	abs, err := env.Guard(a.Path)
+	if err != nil {
+		return ToolOutput{Text: err.Error(), IsError: true}
+	}
+	content, err := env.ReadText(abs, readMaxBytes)
+	if err != nil {
+		return ToolOutput{Text: fmt.Sprintf("读取失败: %v", err), IsError: true}
+	}
+	count := strings.Count(content, a.OldString)
+	switch count {
+	case 0:
+		return ToolOutput{Text: "old_string 在文件中未命中。请用 read 确认精确内容（注意缩进与换行）后再试。", IsError: true}
+	case 1:
+		updated := strings.Replace(content, a.OldString, a.NewString, 1)
+		if err := env.WriteText(abs, updated); err != nil {
+			return ToolOutput{Text: fmt.Sprintf("写回失败: %v", err), IsError: true}
+		}
+		return ToolOutput{Text: fmt.Sprintf("已编辑 %s（替换 1 处）", abs)}
+	default:
+		return ToolOutput{Text: fmt.Sprintf("old_string 命中 %d 处，无法唯一定位。请在 old_string 中包含更多上下文使其唯一。", count), IsError: true}
+	}
+}

--- a/internal/tools/osutil.go
+++ b/internal/tools/osutil.go
@@ -1,0 +1,8 @@
+package tools
+
+import "os"
+
+// osReadDir 是 os.ReadDir 的包级别名（分离到独立文件便于测试替身）。
+func osReadDir(dir string) ([]os.DirEntry, error) {
+	return os.ReadDir(dir)
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -1,0 +1,151 @@
+// Package tools 是自研引擎的内置工具集（对标 Kimi builtin tools 的第一期清单）。
+//
+// 每个工具实现 agentloop.ToolExecutor 需要的接口形态：名字、JSON Schema、
+// 文档（拼进 system prompt）、Execute。文件/进程触碰一律经 internal/agentfs
+// 的沙箱 Env；结果统一做预算截断。
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"grok_switch/internal/agentfs"
+	"grok_switch/internal/llm"
+)
+
+// ResultBudget 是单个工具结果回传模型的字符预算（超出截断）。
+const ResultBudget = 30000
+
+// Registry 是工具注册表，实现 agentloop.ToolExecutor。
+type Registry struct {
+	mu    sync.RWMutex
+	tools map[string]Tool
+	// ExtraHeaders 允许 server 层注入请求头（生图引擎等）。
+	getEnv func() agentfs.Env
+}
+
+// Tool 是单个工具的接口。
+type Tool interface {
+	Name() string
+	Schema() map[string]any
+	// Doc 是拼进 system prompt 的用法说明（Kimi 的 *.md 内嵌模式）。
+	Doc() string
+	Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput
+}
+
+// ToolOutput 是工具输出（agentloop.ToolResult 的工具层形态）。
+type ToolOutput struct {
+	Text      string
+	IsError   bool
+	Truncated bool
+	Media     []llm.ContentPart
+}
+
+// NewRegistry 构造注册表。getEnv 提供当前会话的沙箱环境（工作目录可变）。
+func NewRegistry(getEnv func() agentfs.Env) *Registry {
+	return &Registry{tools: map[string]Tool{}, getEnv: getEnv}
+}
+
+// Register 注册工具；同名覆盖（便于测试）。
+func (r *Registry) Register(t Tool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tools[t.Name()] = t
+}
+
+// Unregister 移除工具（生图开关即时生效的通道）。
+func (r *Registry) Unregister(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.tools, name)
+}
+
+// Names 返回已注册工具名（排序）。
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tools))
+	for n := range r.tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Schemas 实现 agentloop.ToolExecutor。
+func (r *Registry) Schemas() []llm.Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tools))
+	for n := range r.tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]llm.Tool, 0, len(names))
+	for _, n := range names {
+		t := r.tools[n]
+		schema := t.Schema()
+		if schema == nil {
+			schema = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
+		out = append(out, llm.Tool{Name: t.Name(), Description: t.Doc(), Schema: schema})
+	}
+	return out
+}
+
+// Execute 实现 agentloop.ToolExecutor：参数解析 + 沙箱 + 预算截断。
+// 返回值通过 ToAgentloopResult 适配 agentloop.ToolExecutor 的签名（见 adapter.go）。
+func (r *Registry) ExecuteTool(ctx context.Context, call llm.ToolCall) ToolOutput {
+	r.mu.RLock()
+	t, ok := r.tools[call.Name]
+	r.mu.RUnlock()
+	if !ok {
+		return ToolOutput{Text: fmt.Sprintf("未知工具 %q", call.Name), IsError: true}
+	}
+	env := agentfs.Env{}
+	if r.getEnv != nil {
+		env = r.getEnv()
+	}
+	out := t.Execute(ctx, call.Arguments, env)
+	if out.Text == "" && !out.IsError && len(out.Media) == 0 {
+		out.Text = "(无输出)"
+	}
+	if len(out.Text) > ResultBudget {
+		out.Text = out.Text[:ResultBudget] + "\n\n[输出超过预算被截断]"
+		out.Truncated = true
+	}
+	return out
+}
+
+// SystemPromptDoc 汇总所有工具文档，供 server 层拼 system prompt。
+func (r *Registry) SystemPromptDoc() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.tools))
+	for n := range r.tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	b.WriteString("# 可用工具\n\n")
+	for _, n := range names {
+		b.WriteString("## ")
+		b.WriteString(n)
+		b.WriteString("\n")
+		b.WriteString(r.tools[n].Doc())
+		b.WriteString("\n\n")
+	}
+	return b.String()
+}
+
+// argHelp 构造参数解析错误信息（带期望字段，帮模型自纠）。
+func argHelp(tool string, err error, expected string) ToolOutput {
+	return ToolOutput{
+		Text:    fmt.Sprintf("参数解析失败: %v。期望 JSON 对象字段: %s", err, expected),
+		IsError: true,
+	}
+}

--- a/internal/tools/searchtools.go
+++ b/internal/tools/searchtools.go
@@ -1,0 +1,329 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"grok_switch/internal/agentfs"
+)
+
+// --- glob ---
+
+type GlobTool struct{}
+
+func (GlobTool) Name() string { return "glob" }
+
+func (GlobTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"pattern": map[string]any{"type": "string", "description": "glob 模式，如 \"**/*.go\"、\"internal/**/*.md\""},
+			"path":    map[string]any{"type": "string", "description": "起始目录（默认工作目录）"},
+		},
+		"required": []string{"pattern"},
+	}
+}
+
+func (GlobTool) Doc() string {
+	return `按 glob 模式列出文件路径（支持 ** 跨目录）。按文件名找文件用本工具，
+按内容搜索用 grep。结果按修改时间排序（最新在前），上限 200 条。`
+}
+
+type globArgs struct {
+	Pattern string `json:"pattern"`
+	Path    string `json:"path"`
+}
+
+const globMaxResults = 200
+
+func (GlobTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a globArgs
+	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Pattern) == "" {
+		return argHelp("glob", err, `{"pattern": "**/*.go", "path"?: "."}`)
+	}
+	base := env.Cwd
+	if a.Path != "" {
+		abs, err := env.Guard(a.Path)
+		if err != nil {
+			return ToolOutput{Text: err.Error(), IsError: true}
+		}
+		base = abs
+	}
+	pattern := a.Pattern
+	if !filepath.IsAbs(pattern) {
+		pattern = filepath.Join(base, pattern)
+	} else if !env.WithinSandbox(pattern) {
+		return ToolOutput{Text: (&agentfs.SandboxError{Path: pattern}).Error(), IsError: true}
+	}
+
+	// 简易 glob：目录遍历 + pattern 匹配（filepath.Match + ** 展开）。
+	var matches []string
+	err := walkGlob(base, base, a.Pattern, &matches, 0)
+	if err != nil {
+		return ToolOutput{Text: fmt.Sprintf("glob 失败: %v", err), IsError: true}
+	}
+	if len(matches) == 0 {
+		return ToolOutput{Text: "(无匹配文件)"}
+	}
+	sort.Strings(matches)
+	var b strings.Builder
+	shown := len(matches)
+	if shown > globMaxResults {
+		shown = globMaxResults
+	}
+	for i := 0; i < shown; i++ {
+		rel, _ := filepath.Rel(env.Cwd, matches[i])
+		b.WriteString(rel)
+		b.WriteString("\n")
+	}
+	if len(matches) > globMaxResults {
+		fmt.Fprintf(&b, "... (共 %d 个匹配，仅显示前 %d 个；请收窄 pattern)\n", len(matches), globMaxResults)
+	}
+	return ToolOutput{Text: b.String()}
+}
+
+// walkGlob 用 filepath.Match 逐层匹配支持 ** 的简化实现。
+func walkGlob(root, dir, pattern string, out *[]string, depth int) error {
+	if depth > 12 {
+		return nil
+	}
+	// 当前层匹配（** 在段首时匹配任意层级）。
+	rest := pattern
+	for {
+		if strings.HasPrefix(rest, "**/") {
+			// 尝试在当前目录直接匹配剩余模式。
+			if err := walkGlob(root, dir, strings.TrimPrefix(rest, "**/"), out, depth+1); err != nil {
+				return err
+			}
+			// 并深入子目录继续。
+			entries, err := osReadDir(dir)
+			if err != nil {
+				return nil
+			}
+			for _, e := range entries {
+				if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+					if err := walkGlob(root, filepath.Join(dir, e.Name()), rest, out, depth+1); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		}
+		break
+	}
+	// 普通段匹配。
+	seg := rest
+	var next string
+	if idx := strings.Index(seg, "/"); idx >= 0 {
+		seg, next = seg[:idx], seg[idx+1:]
+	}
+	if seg == "" {
+		// pattern 以 / 结尾等退化形态。
+		return nil
+	}
+	entries, err := osReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	hasMeta := strings.ContainsAny(seg, "*?[")
+	for _, e := range entries {
+		name := e.Name()
+		ok := name == seg
+		if !ok && hasMeta {
+			m, _ := filepath.Match(seg, name)
+			ok = m
+		}
+		if !ok {
+			continue
+		}
+		full := filepath.Join(dir, name)
+		if next == "" {
+			if !e.IsDir() {
+				*out = append(*out, full)
+			}
+		} else if e.IsDir() {
+			if err := walkGlob(root, full, next, out, depth+1); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// --- grep ---
+
+type GrepTool struct{}
+
+func (GrepTool) Name() string { return "grep" }
+
+func (GrepTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"pattern":   map[string]any{"type": "string", "description": "正则表达式（RE2 语法）"},
+			"path":      map[string]any{"type": "string", "description": "搜索的文件或目录（默认工作目录）"},
+			"glob":      map[string]any{"type": "string", "description": "文件名过滤，如 \"*.go\""},
+			"max_items": map[string]any{"type": "integer", "description": "最多返回的匹配条数（默认 100）"},
+		},
+		"required": []string{"pattern"},
+	}
+}
+
+func (GrepTool) Doc() string {
+	return `按正则搜索文件内容，返回命中文件、行号与行内容（截断到 500 字符）。
+搜索会跳过 .git、node_modules、二进制文件与超大文件（>2MB）。`
+}
+
+type grepArgs struct {
+	Pattern  string `json:"pattern"`
+	Path     string `json:"path"`
+	Glob     string `json:"glob"`
+	MaxItems int    `json:"max_items"`
+}
+
+const (
+	grepMaxFileBytes = 2 << 20
+	grepDefaultItems = 100
+	grepMaxLineLen   = 500
+	grepSkipDirs     = ".git,node_modules,vendor,dist,build,__pycache__,.venv"
+)
+
+func (GrepTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a grepArgs
+	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Pattern) == "" {
+		return argHelp("grep", err, `{"pattern": "regex", "path"?: ".", "glob"?: "*.go"}`)
+	}
+	re, err := regexp.Compile(a.Pattern)
+	if err != nil {
+		return ToolOutput{Text: fmt.Sprintf("正则无效: %v", err), IsError: true}
+	}
+	max := a.MaxItems
+	if max <= 0 || max > 1000 {
+		max = grepDefaultItems
+	}
+	base := env.Cwd
+	if a.Path != "" {
+		abs, err := env.Guard(a.Path)
+		if err != nil {
+			return ToolOutput{Text: err.Error(), IsError: true}
+		}
+		base = abs
+	}
+	st := env.Stat(base)
+	if !st.Exists {
+		return ToolOutput{Text: fmt.Sprintf("路径不存在: %s", base), IsError: true}
+	}
+
+	grepState := &grepRun{re: re, env: env, glob: a.Glob, max: max}
+	if !st.IsDir {
+		grepState.searchFile(base)
+	} else {
+		grepState.walk(base, 0)
+	}
+	return grepState.render(a.Pattern)
+}
+
+type grepHit struct {
+	Path string
+	Line int
+	Text string
+}
+
+type grepRun struct {
+	re     *regexp.Regexp
+	env    agentfs.Env
+	glob   string
+	max    int
+	hits   []grepHit
+	files  map[string]bool
+	capped bool
+}
+
+func (g *grepRun) walk(dir string, depth int) {
+	if depth > 10 || len(g.hits) >= g.max {
+		return
+	}
+	entries, err := osReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if len(g.hits) >= g.max {
+			return
+		}
+		name := e.Name()
+		full := filepath.Join(dir, name)
+		if e.IsDir() {
+			if strings.Contains(","+grepSkipDirs+",", ","+name+",") || strings.HasPrefix(name, ".") {
+				continue
+			}
+			g.walk(full, depth+1)
+			continue
+		}
+		if g.glob != "" {
+			m, _ := filepath.Match(g.glob, name)
+			if !m {
+				continue
+			}
+		}
+		g.searchFile(full)
+	}
+}
+
+func (g *grepRun) searchFile(path string) {
+	if len(g.hits) >= g.max {
+		return
+	}
+	if st := g.env.Stat(path); !st.Exists || st.Size > grepMaxFileBytes {
+		return
+	}
+	content, err := g.env.ReadText(path, grepMaxFileBytes)
+	if err != nil {
+		return
+	}
+	if strings.ContainsRune(content, 0) {
+		return // 二进制
+	}
+	if g.files == nil {
+		g.files = map[string]bool{}
+	}
+	g.files[path] = true
+	for i, line := range strings.Split(content, "\n") {
+		if len(g.hits) >= g.max {
+			g.capped = true
+			return
+		}
+		if g.re.MatchString(line) {
+			text := line
+			if len(text) > grepMaxLineLen {
+				text = text[:grepMaxLineLen] + "…"
+			}
+			g.hits = append(g.hits, grepHit{Path: path, Line: i + 1, Text: text})
+		}
+	}
+}
+
+func (g *grepRun) render(pattern string) ToolOutput {
+	if len(g.hits) == 0 {
+		return ToolOutput{Text: fmt.Sprintf("(无匹配: %s)", pattern)}
+	}
+	var b strings.Builder
+	curFile := ""
+	for _, h := range g.hits {
+		rel, _ := filepath.Rel(g.env.Cwd, h.Path)
+		if rel != curFile {
+			curFile = rel
+			fmt.Fprintf(&b, "%s:\n", rel)
+		}
+		fmt.Fprintf(&b, "  %d: %s\n", h.Line, h.Text)
+	}
+	if g.capped {
+		fmt.Fprintf(&b, "... (达到 %d 条上限，结果已截断；请收窄 pattern)\n", g.max)
+	}
+	return ToolOutput{Text: b.String()}
+}

--- a/internal/tools/shelltools.go
+++ b/internal/tools/shelltools.go
@@ -1,0 +1,172 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"grok_switch/internal/agentfs"
+)
+
+// --- bash ---
+
+type BashTool struct{}
+
+func (BashTool) Name() string { return "bash" }
+
+func (BashTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"command": map[string]any{"type": "string", "description": "要执行的 shell 命令"},
+			"timeout": map[string]any{"type": "integer", "description": "超时秒数（默认 120，上限 600）"},
+			"dir":     map[string]any{"type": "string", "description": "执行目录（默认会话工作目录）"},
+		},
+		"required": []string{"command"},
+	}
+}
+
+func (BashTool) Doc() string {
+	return `在 shell 中执行命令（git、构建、测试、包管理等）。每次调用独立 shell：
+变量与 cd 不跨调用保留，请在 command 内组合（&& / ; / 管道）或用 dir 参数。
+cat/sed/grep 等文件操作优先用专用工具。输出超长会被截断。`
+}
+
+type bashArgs struct {
+	Command string `json:"command"`
+	Timeout int    `json:"timeout"`
+	Dir     string `json:"dir"`
+}
+
+const (
+	bashDefaultTimeout = 120 * time.Second
+	bashMaxTimeout     = 600 * time.Second
+)
+
+func (BashTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a bashArgs
+	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Command) == "" {
+		return argHelp("bash", err, `{"command": "npm test", "timeout"?: 120, "dir"?: "..."}`)
+	}
+	timeout := bashDefaultTimeout
+	if a.Timeout > 0 {
+		timeout = time.Duration(a.Timeout) * time.Second
+		if timeout > bashMaxTimeout {
+			timeout = bashMaxTimeout
+		}
+	}
+	dir := env.Cwd
+	if a.Dir != "" {
+		abs, err := env.Guard(a.Dir)
+		if err != nil {
+			return ToolOutput{Text: err.Error(), IsError: true}
+		}
+		dir = abs
+	}
+	res := env.Shell(ctx, a.Command, dir, timeout)
+	var b strings.Builder
+	if out := res.Combined(); out != "" {
+		b.WriteString(out)
+		b.WriteString("\n")
+	}
+	if res.TimedOut {
+		fmt.Fprintf(&b, "[命令超时（%s），已终止]\n", timeout)
+		return ToolOutput{Text: b.String(), IsError: true}
+	}
+	if res.ExitCode != 0 {
+		fmt.Fprintf(&b, "[退出码: %d]\n", res.ExitCode)
+		return ToolOutput{Text: b.String(), IsError: true}
+	}
+	if b.Len() == 0 {
+		return ToolOutput{Text: "(命令成功，无输出)"}
+	}
+	return ToolOutput{Text: strings.TrimRight(b.String(), "\n")}
+}
+
+// --- todo_list ---
+
+// TodoStore 是会话级 todo 状态（server 层持有并渲染到 UI）。
+type TodoStore struct {
+	mu    sync.Mutex
+	items []TodoItem
+}
+
+// TodoItem 是单条任务。
+type TodoItem struct {
+	Content string `json:"content"`
+	Status  string `json:"status"` // pending | in_progress | completed
+}
+
+type TodoListTool struct{ Store *TodoStore }
+
+func (TodoListTool) Name() string { return "todo_list" }
+
+func (TodoListTool) Schema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"items": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"content": map[string]any{"type": "string"},
+						"status":  map[string]any{"type": "string", "enum": []string{"pending", "in_progress", "completed"}},
+					},
+					"required": []string{"content", "status"},
+				},
+				"description": "完整替换当前任务列表",
+			},
+		},
+		"required": []string{"items"},
+	}
+}
+
+func (TodoListTool) Doc() string {
+	return `维护结构化任务列表（多步骤任务时使用）。每次调用完整替换列表；
+同一时刻最多一条 in_progress。完成一步后立即更新状态，让用户看到进度。`
+}
+
+type todoArgs struct {
+	Items []TodoItem `json:"items"`
+}
+
+func (t TodoListTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
+	var a todoArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return argHelp("todo_list", err, `{"items": [{"content": "...", "status": "pending"}]}`)
+	}
+	if t.Store == nil {
+		t.Store = &TodoStore{}
+	}
+	valid := make([]TodoItem, 0, len(a.Items))
+	for _, it := range a.Items {
+		status := it.Status
+		if status != "pending" && status != "in_progress" && status != "completed" {
+			status = "pending"
+		}
+		if strings.TrimSpace(it.Content) == "" {
+			continue
+		}
+		valid = append(valid, TodoItem{Content: strings.TrimSpace(it.Content), Status: status})
+	}
+	t.Store.mu.Lock()
+	t.Store.items = valid
+	t.Store.mu.Unlock()
+	return ToolOutput{Text: fmt.Sprintf("任务列表已更新（%d 项）", len(valid))}
+}
+
+// Snapshot 返回当前列表副本。
+func (s *TodoStore) Snapshot() []TodoItem {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]TodoItem, len(s.items))
+	copy(out, s.items)
+	return out
+}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1,0 +1,330 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"grok_switch/internal/agentfs"
+	"grok_switch/internal/llm"
+)
+
+func testEnv(t *testing.T) agentfs.Env {
+	t.Helper()
+	return agentfs.Env{Cwd: t.TempDir()}
+}
+
+func runTool(t *testing.T, tool Tool, args string, env agentfs.Env) ToolOutput {
+	t.Helper()
+	out := tool.Execute(context.Background(), json.RawMessage(args), env)
+	return out
+}
+
+func TestReadTool(t *testing.T) {
+	env := testEnv(t)
+	path := filepath.Join(env.Cwd, "sample.go")
+	_ = env.WriteText(path, "package main\n\nimport \"fmt\"\n\nfunc main() {}\n")
+
+	out := runTool(t, ReadTool{}, `{"path": "sample.go"}`, env)
+	if out.IsError {
+		t.Fatalf("read 失败: %s", out.Text)
+	}
+	if !strings.Contains(out.Text, "1\tpackage main") || !strings.Contains(out.Text, "5\tfunc main() {}") {
+		t.Fatalf("行号格式错误:\n%s", out.Text)
+	}
+
+	// 分页。
+	out = runTool(t, ReadTool{}, `{"path": "sample.go", "offset": 3, "limit": 2}`, env)
+	if !strings.Contains(out.Text, "3\timport") || strings.Contains(out.Text, "4\t") && strings.Contains(out.Text, "5\t") && !strings.Contains(out.Text, "继续读") {
+		t.Fatalf("分页读取错误:\n%s", out.Text)
+	}
+
+	// 未命中文件。
+	out = runTool(t, ReadTool{}, `{"path": "nope.txt"}`, env)
+	if !out.IsError {
+		t.Fatal("缺失文件应报错")
+	}
+
+	// 越界行。
+	out = runTool(t, ReadTool{}, `{"path": "sample.go", "offset": 99}`, env)
+	if !out.IsError {
+		t.Fatal("超起始行应报错")
+	}
+}
+
+func TestWriteAndEditTool(t *testing.T) {
+	env := testEnv(t)
+
+	out := runTool(t, WriteTool{}, `{"path": "a.txt", "content": "line1\nline2\nline3"}`, env)
+	if out.IsError {
+		t.Fatalf("write 失败: %s", out.Text)
+	}
+
+	out = runTool(t, EditTool{}, `{"path": "a.txt", "old_string": "line2", "new_string": "middle"}`, env)
+	if out.IsError {
+		t.Fatalf("edit 失败: %s", out.Text)
+	}
+	got, _ := env.ReadText(filepath.Join(env.Cwd, "a.txt"), 0)
+	if got != "line1\nmiddle\nline3" {
+		t.Fatalf("edit 结果错误: %q", got)
+	}
+
+	// 多处命中拒绝。
+	_ = env.WriteText(filepath.Join(env.Cwd, "b.txt"), "x\nx\n")
+	out = runTool(t, EditTool{}, `{"path": "b.txt", "old_string": "x", "new_string": "y"}`, env)
+	if !out.IsError || !strings.Contains(out.Text, "2 处") {
+		t.Fatalf("多处命中应拒绝: %+v", out)
+	}
+
+	// 未命中提示。
+	out = runTool(t, EditTool{}, `{"path": "a.txt", "old_string": "不存在", "new_string": "y"}`, env)
+	if !out.IsError || !strings.Contains(out.Text, "未命中") {
+		t.Fatalf("未命中应提示: %+v", out)
+	}
+}
+
+func TestGlobTool(t *testing.T) {
+	env := testEnv(t)
+	_ = env.WriteText(filepath.Join(env.Cwd, "a.go"), "package a\n")
+	_ = env.WriteText(filepath.Join(env.Cwd, "sub", "b.go"), "package b\n")
+	_ = env.WriteText(filepath.Join(env.Cwd, "sub", "deep", "c.md"), "# c\n")
+
+	out := runTool(t, GlobTool{}, `{"pattern": "**/*.go"}`, env)
+	if out.IsError {
+		t.Fatalf("glob 失败: %s", out.Text)
+	}
+	if !strings.Contains(out.Text, "a.go") || !strings.Contains(out.Text, filepath.Join("sub", "b.go")) {
+		t.Fatalf("** 匹配错误:\n%s", out.Text)
+	}
+	if strings.Contains(out.Text, "c.md") {
+		t.Fatalf("不应匹配 md: %s", out.Text)
+	}
+
+	out = runTool(t, GlobTool{}, `{"pattern": "sub/**/*.md"}`, env)
+	if !strings.Contains(out.Text, "c.md") {
+		t.Fatalf("sub/**/*.md 匹配失败:\n%s", out.Text)
+	}
+}
+
+func TestGrepTool(t *testing.T) {
+	env := testEnv(t)
+	_ = env.WriteText(filepath.Join(env.Cwd, "code.go"), "func Alpha() {}\nfunc Beta() int { return Alpha() }\n")
+	_ = env.WriteText(filepath.Join(env.Cwd, ".git", "ignored.go"), "func Alpha() {}\n")
+	_ = env.WriteText(filepath.Join(env.Cwd, "skip.txt"), "Alpha in txt\n")
+
+	out := runTool(t, GrepTool{}, `{"pattern": "Alpha"}`, env)
+	if out.IsError {
+		t.Fatalf("grep 失败: %s", out.Text)
+	}
+	if !strings.Contains(out.Text, "code.go") || !strings.Contains(out.Text, "1: func Alpha() {}") {
+		t.Fatalf("命中格式错误:\n%s", out.Text)
+	}
+	if strings.Contains(out.Text, ".git") {
+		t.Fatalf("应跳过 .git:\n%s", out.Text)
+	}
+
+	// glob 过滤。
+	out = runTool(t, GrepTool{}, `{"pattern": "Alpha", "glob": "*.txt"}`, env)
+	if !strings.Contains(out.Text, "skip.txt") || strings.Contains(out.Text, "code.go") {
+		t.Fatalf("glob 过滤错误:\n%s", out.Text)
+	}
+
+	// 无效正则。
+	out = runTool(t, GrepTool{}, `{"pattern": "([bad"}`, env)
+	if !out.IsError {
+		t.Fatal("无效正则应报错")
+	}
+}
+
+func TestBashTool(t *testing.T) {
+	env := testEnv(t)
+
+	out := runTool(t, BashTool{}, `{"command": "echo engine-bash"}`, env)
+	if out.IsError || !strings.Contains(out.Text, "engine-bash") {
+		t.Fatalf("bash 失败: %+v", out)
+	}
+
+	// 非零退出码。
+	out = runTool(t, BashTool{}, `{"command": "exit 7"}`, env)
+	if !out.IsError || !strings.Contains(out.Text, "7") {
+		t.Fatalf("非零退出码错误: %+v", out)
+	}
+
+	// 超时。
+	out = runTool(t, BashTool{}, `{"command": "sleep 3", "timeout": 1}`, env)
+	if !out.IsError || !strings.Contains(out.Text, "超时") {
+		t.Fatalf("超时错误: %+v", out)
+	}
+
+	// dir 参数。
+	sub := filepath.Join(env.Cwd, "subdir")
+	_ = os.MkdirAll(sub, 0o755)
+	out = runTool(t, BashTool{}, `{"command": "pwd", "dir": "subdir"}`, env)
+	if out.IsError || !strings.Contains(out.Text, "subdir") {
+		t.Fatalf("dir 参数错误: %+v", out)
+	}
+
+	// 越界 dir。
+	out = runTool(t, BashTool{}, `{"command": "pwd", "dir": "../../etc"}`, env)
+	if !out.IsError {
+		t.Fatal("越界 dir 应拒绝")
+	}
+}
+
+func TestTodoListTool(t *testing.T) {
+	store := &TodoStore{}
+	tool := TodoListTool{Store: store}
+
+	out := runTool(t, tool, `{"items": [{"content": "step1", "status": "completed"}, {"content": "step2", "status": "in_progress"}, {"content": "step3", "status": "weird"}]}`, agentfs.Env{})
+	if out.IsError {
+		t.Fatalf("todo 失败: %s", out.Text)
+	}
+	items := store.Snapshot()
+	if len(items) != 3 {
+		t.Fatalf("应有 3 项: %+v", items)
+	}
+	if items[2].Status != "pending" {
+		t.Fatalf("非法状态应归一为 pending: %+v", items[2])
+	}
+}
+
+type autoApprover struct{}
+
+func (autoApprover) RequestPlanMode(ctx context.Context) bool { return true }
+func (autoApprover) ExitPlanWithPlan(ctx context.Context, plan string) (bool, string) {
+	return true, ""
+}
+
+func TestPlanTools(t *testing.T) {
+	env := testEnv(t)
+	out := runTool(t, EnterPlanModeTool{Approver: autoApprover{}}, `{}`, env)
+	if out.IsError {
+		t.Fatalf("enter plan 失败: %s", out.Text)
+	}
+	out = runTool(t, ExitPlanModeTool{Approver: autoApprover{}}, `{"plan": "# 计划\n1. 做事"}`, env)
+	if out.IsError {
+		t.Fatalf("exit plan 失败: %s", out.Text)
+	}
+
+	// 无参数校验。
+	out = runTool(t, ExitPlanModeTool{Approver: autoApprover{}}, `{}`, env)
+	if !out.IsError {
+		t.Fatal("空 plan 应报错")
+	}
+}
+
+type fakeImageGen struct{}
+
+func (fakeImageGen) Generate(ctx context.Context, prompt, model, aspect string, count int) ([]string, error) {
+	return []string{"/tmp/gallery/a.png", "/tmp/gallery/b.png"}, nil
+}
+
+func TestGenerateImageTool(t *testing.T) {
+	env := testEnv(t)
+	tool := GenerateImageTool{Engine: fakeImageGen{}}
+
+	out := runTool(t, tool, `{"prompt": "一只猫"}`, env)
+	if out.IsError || !strings.Contains(out.Text, "已生成 2 张") {
+		t.Fatalf("生图失败: %+v", out)
+	}
+
+	out = runTool(t, tool, `{"prompt": "x", "aspect": "21:9"}`, env)
+	if !out.IsError {
+		t.Fatal("非法宽高比应拒绝")
+	}
+
+	// 引擎未启用。
+	out = runTool(t, GenerateImageTool{}, `{"prompt": "x"}`, env)
+	if !out.IsError {
+		t.Fatal("无引擎应报错")
+	}
+}
+
+// --- Registry / Adapter 集成 ---
+
+func TestRegistrySchemasAndExecute(t *testing.T) {
+	env := testEnv(t)
+	reg := DefaultRegistry(func() agentfs.Env { return env }, nil, nil, &TodoStore{})
+
+	names := reg.Names()
+	if len(names) != 9 {
+		t.Fatalf("默认注册 9 工具, got %d: %v", len(names), names)
+	}
+	schemas := reg.Schemas()
+	if len(schemas) != 9 {
+		t.Fatalf("schema 数错误: %d", len(schemas))
+	}
+	for _, s := range schemas {
+		if s.Name == "" || s.Description == "" || s.Schema == nil {
+			t.Fatalf("schema 字段缺失: %+v", s)
+		}
+	}
+	// 未知工具。
+	out := reg.ExecuteTool(context.Background(), mustCall("nope", "{}"))
+	if !out.IsError {
+		t.Fatal("未知工具应报错")
+	}
+	// read 走注册表全链路。
+	_ = env.WriteText(filepath.Join(env.Cwd, "x.txt"), "hello")
+	out = reg.ExecuteTool(context.Background(), mustCall("read", `{"path":"x.txt"}`))
+	if out.IsError || !strings.Contains(out.Text, "hello") {
+		t.Fatalf("注册表 read 失败: %+v", out)
+	}
+	// SystemPromptDoc。
+	doc := reg.SystemPromptDoc()
+	if !strings.Contains(doc, "## read") || !strings.Contains(doc, "## bash") {
+		t.Fatalf("system prompt 文档缺失:\n%s", doc)
+	}
+}
+
+func TestRegistryUnregisterImageGen(t *testing.T) {
+	env := testEnv(t)
+	reg := DefaultRegistry(func() agentfs.Env { return env }, fakeImageGen{}, nil, &TodoStore{})
+	if len(reg.Names()) != 10 {
+		t.Fatalf("带生图应 10 工具: %d", len(reg.Names()))
+	}
+	reg.Unregister("generate_image")
+	if len(reg.Names()) != 9 {
+		t.Fatalf("注销后应 9 工具: %d", len(reg.Names()))
+	}
+	out := reg.ExecuteTool(context.Background(), mustCall("generate_image", `{"prompt":"x"}`))
+	if !out.IsError {
+		t.Fatal("注销后调用应报未知工具")
+	}
+}
+
+func TestAdapterBudgetTruncation(t *testing.T) {
+	env := testEnv(t)
+	// 生成一个 1000 行、每行 60 字符的文件：read 无分页全读时
+	// 输出超 ResultBudget，触发注册表的截断路径。
+	var b strings.Builder
+	for i := 0; i < 1000; i++ {
+		b.WriteString(strings.Repeat("x", 60))
+		b.WriteString("\n")
+	}
+	_ = env.WriteText(filepath.Join(env.Cwd, "big.txt"), b.String())
+	reg := NewRegistry(func() agentfs.Env { return env })
+	reg.Register(ReadTool{})
+
+	adapter := NewToolsAdapter(reg)
+	res, err := adapter.Execute(context.Background(), mustCall("read", `{"path":"big.txt","limit":1000}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Truncated {
+		t.Fatalf("超预算应标记 truncated, len=%d", len(res.Output))
+	}
+	if len(res.Output) > ResultBudget+100 {
+		t.Fatalf("输出未截断: %d", len(res.Output))
+	}
+}
+
+func mustCall(name, args string) llm.ToolCall {
+	return llm.ToolCall{ID: "t-" + name, Name: name, Arguments: json.RawMessage(args)}
+}

--- a/main.go
+++ b/main.go
@@ -136,12 +136,25 @@ func main() {
 		CpaMint:       cpamint.NewService(),
 		Registrar:     registrarService,
 		Switcher:      sw,
-		Agent:         agent,
 		Assets:        assets,
 		ExePath:       exePath,
 		Version:       version,
 		UpdateChecker: updatecheck.New(version, "grok_switch.exe"),
 		UpdateState:   updateState,
+	}
+	// 引擎选择器（设计文档 D6）：native = 进程内自研引擎，无需 grok CLI；
+	// acp = 旧桥（spawn Grok CLI，默认）。构造失败自动降级 acp 并写日志。
+	// 必须在 Listen 之前赋值：Handler 在 goroutine 里开始服务后读 s.Agent。
+	if currentSettings.AgentEngine == settings.AgentEngineNative {
+		if nativeSvc, nativeErr := appServer.NewNativeAgentService(); nativeErr == nil {
+			appServer.Agent = nativeSvc
+			crash.Logf("agent engine: native")
+		} else {
+			appServer.Agent = agent
+			crash.Logf("native agent engine unavailable, fallback to acp: %v", nativeErr)
+		}
+	} else {
+		appServer.Agent = agent
 	}
 	httpServer, port, err := appServer.Listen(currentSettings.Port)
 	if err != nil {

--- a/ui/app.js
+++ b/ui/app.js
@@ -4482,6 +4482,16 @@ function renderSettings(settings) {
   $("silentAutostart").checked = !!settings.silent_autostart;
   $("autoOpenBrowser").checked = !!settings.auto_open_browser;
   $("port").value = settings.port;
+  const engineSelect = $("agentEngine");
+  if (engineSelect) {
+    engineSelect.value = settings.agent_engine === "native" ? "native" : "acp";
+    const hint = $("agentEngineHint");
+    if (hint) {
+      hint.textContent = engineSelect.value === "native"
+        ? "当前使用内置引擎（进程内，无需 Grok CLI）。切换引擎后重启应用生效。"
+        : "当前使用 Grok CLI（ACP 桥）。切换引擎后重启应用生效；内置引擎无需安装 Grok CLI。";
+    }
+  }
   const actual = state.status?.port;
   const hint = $("portHint");
   if (actual && settings.port && actual !== settings.port) {
@@ -6307,12 +6317,13 @@ $("settingsForm").onsubmit = (event) => {
       silent_autostart: $("silentAutostart").checked,
       auto_open_browser: $("autoOpenBrowser").checked,
       lan_access_enabled: $("lanAccessEnabled").checked,
+      agent_engine: ($("agentEngine")?.value === "native") ? "native" : "acp",
       theme: themeSetting(),
       port: Number($("port").value || 17878),
     };
     await api("/api/settings", { method: "PUT", body: JSON.stringify(settings) });
     await refreshAll();
-  }, { button: $("saveSettingsBtn"), busyLabel: "保存中…", success: "设置已保存" });
+  }, { button: $("saveSettingsBtn"), busyLabel: "保存中…", success: "设置已保存（引擎切换重启后生效）" });
 };
 
 $("lanAccessAddress").onchange = () => {

--- a/ui/index.html
+++ b/ui/index.html
@@ -567,6 +567,13 @@
       </div>
 
       <form id="settingsForm" class="formCard">
+        <label class="field">Agent 引擎
+          <select id="agentEngine">
+            <option value="acp">Grok CLI（ACP 桥，默认）</option>
+            <option value="native">内置引擎（无需安装 Grok CLI）</option>
+          </select>
+        </label>
+        <p class="muted tiny settingsHint" id="agentEngineHint">切换引擎后重启应用生效；已开启生图时两种引擎均可生图（走账号池）。内置引擎还在灰度阶段，遇到问题可随时切回。</p>
         <label class="check"><input type="checkbox" id="autostart"> 开机自启</label>
         <label class="check"><input type="checkbox" id="silentAutostart"> 自启时静默</label>
         <label class="check"><input type="checkbox" id="autoOpenBrowser"> 启动时打开面板</label>


### PR DESCRIPTION
## 问题（用户可见现象）

native 引擎下「新建会话」按钮无限转圈。

## 根因

`nativeAgentService.NewSession` 里有一行：

```go
if n.state != "busy" {
    n.state = "ready"
}
```

turn 挂起权限/计划审批期间状态为 `busy`。此时若审批无人应答（典型场景：WS 断开或页面刷新导致 `permission_request` 弹窗丢失，服务端没有任何重放/拉取机制），turn 的 goroutine 会永远阻塞在 `WaitForDecision`，状态停在 `busy`。之后每次 `NewSession` 都只换 `sessionID` 却保留 `busy`，所有后续新建会话静默失效，UI 无限转圈；`Prompt` 也因 state != ready 被拒。

实测复现：会话 `nat-…312000` 于 16:11 发起工具调用进入审批挂起，状态 `busy` 持续到 16:24 手动取消，期间新建会话全部转圈。

## 修复

- `NewSession` 显式取消进行中的 turn（`turnCancel()`）并 `resolveAllPending()` 唤醒挂起的审批/计划（与 `CancelPrompt` 同语义），被放弃的 turn 按事件配对契约正常收口 `turn_done(cancelled)`
- 会话重建期间状态走 `starting → ready`，`store.Create` 失败置 `dead`——状态机不再停留在与事实不符的 `busy`
- 顺带修复：旧实现换 cwd 前如果路径不存在，会先把内存里 cwd/memory 清掉再报错，留下半更新状态；现在校验前置

## 验证

- 新增回归测试 `TestNativeServiceNewSessionUnblocksBusy`：构造审批挂起（busy）→ busy 期间 NewSession → 断言状态复位 ready、指向新会话、旧 turn 收口 turn_done、新会话可正常 Prompt
- `go test ./internal/server -count=1` 全绿，`go build ./...`、`go vet ./...` 通过

## 备注

这是转圈问题的服务端兜底（不锁死）。审批本身丢失后的恢复路径（刷新页面重新看到挂起审批）由后续 PR 处理。
