### PR TITLE
fix: 权限审批丢失后无恢复路径，turn 永久挂起且用户看不到审批入口

### DIFF
--- a/internal/server/agent.go
+++ b/internal/server/agent.go
@@ -58,6 +58,29 @@ func (s *Server) handleAgentStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, s.Agent.Status())
 }
 
+// handleAgentPending 返回仍然挂起的审批/计划请求。
+// permission_request 走 WS 单次广播，页面刷新或 WS 断开期间发出的事件
+// 无法再收到；此接口让前端重连后主动拉取，恢复审批入口（.turn 仍挂在
+// WaitForDecision 上，不响应就会一直占着 busy）。
+func (s *Server) handleAgentPending(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	if s.Agent == nil {
+		writeError(w, errors.New("Agent 服务未初始化"), http.StatusServiceUnavailable)
+		return
+	}
+	pender, ok := s.Agent.(interface {
+		PendingRequests() []agentbridge.Event
+	})
+	if !ok {
+		writeJSON(w, []agentbridge.Event{})
+		return
+	}
+	writeJSON(w, pender.PendingRequests())
+}
+
 func (s *Server) handleAgentStart(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		methodNotAllowed(w)

--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -73,6 +73,10 @@ type nativeAgentService struct {
 	planMu      sync.Mutex
 	pendingPlan map[string]chan agentbridge.PlanDecision
 	planSeq     int64
+	// 挂起审批的原始事件（按发生顺序）：WS 断开/页面刷新会丢掉一次性广播，
+	// 订阅与查询接口据此重放，用户重新打开页面可继续审批。
+	pendingPermEvents map[string]agentbridge.Event
+	pendingPermOrder  []string
 
 	// 订阅者。
 	subMu   sync.Mutex
@@ -95,13 +99,14 @@ func newNativeAgentService(deps EngineDeps) (*nativeAgentService, error) {
 		return nil, err
 	}
 	return &nativeAgentService{
-		deps:        deps,
-		st:          st,
-		perm:        perm,
-		state:       "idle",
-		pendingPerm: map[string]*pendingPermReq{},
-		pendingPlan: map[string]chan agentbridge.PlanDecision{},
-		subs:        map[int]chan agentbridge.Event{},
+		deps:              deps,
+		st:                st,
+		perm:              perm,
+		state:             "idle",
+		pendingPerm:       map[string]*pendingPermReq{},
+		pendingPermEvents: map[string]agentbridge.Event{},
+		pendingPlan:       map[string]chan agentbridge.PlanDecision{},
+		subs:              map[int]chan agentbridge.Event{},
 	}, nil
 }
 
@@ -119,6 +124,14 @@ func (n *nativeAgentService) Subscribe() (string, <-chan agentbridge.Event) {
 	ch <- agentbridge.Event{
 		Type: "agent_status", SessionID: status.SessionID, Status: status.State,
 		Model: status.Model, Error: status.Error, SessionAutoApprove: &status.SessionAutoApprove,
+	}
+	// 重放仍然挂起的审批：广播是 fire-and-forget，页面刷新/WS 断开期间
+	// 发出的 permission_request 不会再来第二次；没有重放，用户重新打开
+	// 页面只能眼睁睁看着 turn 卡在 busy。
+	for _, requestID := range n.pendingPermOrder {
+		if ev, ok := n.pendingPermEvents[requestID]; ok {
+			ch <- ev
+		}
 	}
 	return fmt.Sprintf("sub-%d", id), ch
 }
@@ -462,6 +475,28 @@ func (n *nativeAgentService) CancelPrompt() error {
 	return nil
 }
 
+// PendingRequests 返回仍然挂起的审批/计划事件（按发生顺序），供
+// GET /api/agent/pending 在 WS 重连后拉取重放。事件是登记时的快照。
+func (n *nativeAgentService) PendingRequests() []agentbridge.Event {
+	n.permMu.Lock()
+	events := make([]agentbridge.Event, 0, len(n.pendingPermOrder)+len(n.pendingPlan))
+	for _, requestID := range n.pendingPermOrder {
+		if ev, ok := n.pendingPermEvents[requestID]; ok {
+			events = append(events, ev)
+		}
+	}
+	n.permMu.Unlock()
+	n.planMu.Lock()
+	for requestID := range n.pendingPlan {
+		events = append(events, agentbridge.Event{
+			Type: "plan_request", SessionID: n.sessionID,
+			Plan: &agentbridge.PlanEvent{RequestID: requestID, Waiting: true},
+		})
+	}
+	n.planMu.Unlock()
+	return events
+}
+
 // --- 审批（权限/计划） ---
 
 // nativePermGate 实现 agentloop.PermissionGate：manual 模式下写类工具需要审批。
@@ -511,15 +546,8 @@ func (g *nativePermGate) WaitForDecision(ctx context.Context, call llm.ToolCall)
 	req := &pendingPermReq{ch: make(chan agentloop.PermResult, 1), tool: call.Name}
 	g.svc.permMu.Lock()
 	g.svc.pendingPerm[requestID] = req
-	g.svc.permMu.Unlock()
-	defer func() {
-		g.svc.permMu.Lock()
-		delete(g.svc.pendingPerm, requestID)
-		g.svc.permMu.Unlock()
-	}()
-
-	g.svc.broadcast(agentbridge.Event{
-		Type: "permission_request", SessionID: g.svc.Status().SessionID,
+	permEvt := agentbridge.Event{
+		Type: "permission_request", SessionID: g.svc.sessionID,
 		Permission: &agentbridge.PermissionEvent{
 			RequestID: requestID,
 			Summary:   fmt.Sprintf("工具 %s 请求执行", call.Name),
@@ -529,7 +557,26 @@ func (g *nativePermGate) WaitForDecision(ctx context.Context, call llm.ToolCall)
 			},
 			Options: nativePermissionOptions,
 		},
-	})
+	}
+	// 记录挂起事件供重放：WS 是 fire-and-forget 广播，断线/刷新即丢；
+	// 没有这条记录，用户重新打开页面就再也看不到这次审批。
+	g.svc.pendingPermEvents[requestID] = permEvt
+	g.svc.pendingPermOrder = append(g.svc.pendingPermOrder, requestID)
+	g.svc.permMu.Unlock()
+	defer func() {
+		g.svc.permMu.Lock()
+		delete(g.svc.pendingPerm, requestID)
+		delete(g.svc.pendingPermEvents, requestID)
+		for i, id := range g.svc.pendingPermOrder {
+			if id == requestID {
+				g.svc.pendingPermOrder = append(g.svc.pendingPermOrder[:i], g.svc.pendingPermOrder[i+1:]...)
+				break
+			}
+		}
+		g.svc.permMu.Unlock()
+	}()
+
+	g.svc.broadcast(permEvt)
 
 	select {
 	case res := <-req.ch:
@@ -545,6 +592,8 @@ func (n *nativeAgentService) resolveAllPending() {
 		req.ch <- agentloop.PermResult{Decision: agentloop.DecDeny, Reason: "用户取消了任务。"}
 	}
 	n.pendingPerm = map[string]*pendingPermReq{}
+	n.pendingPermEvents = map[string]agentbridge.Event{}
+	n.pendingPermOrder = nil
 	n.permMu.Unlock()
 	n.planMu.Lock()
 	for _, ch := range n.pendingPlan {

--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -279,31 +279,44 @@ func (n *nativeAgentService) Stop() error {
 }
 
 func (n *nativeAgentService) NewSession(ctx context.Context, cwd string) error {
+	// 取消进行中的 turn：新建会话意味着用户明确放弃当前任务，若 busy 时
+	// 不复位状态，一次卡死的 turn（如权限审批无人应答）会把服务永久锁在
+	// busy，后续所有 NewSession 都被吞掉，UI 表现为无限转圈。
 	n.mu.Lock()
 	if n.turnCancel != nil {
 		n.turnCancel()
 		n.turnCancel = nil
 	}
+	// 卡死 turn 的挂起审批/计划一并唤醒（CancelPrompt 同款语义），
+	// 否则被取消的 turn goroutine 收口时可能把状态写回 ready 之外。
+	n.mu.Unlock()
+	n.resolveAllPending()
 	if cwd == "" {
 		cwd = n.deps.DefaultCwd
 	}
 	if info, statErr := os.Stat(cwd); statErr != nil || !info.IsDir() {
-		n.mu.Unlock()
 		return fmt.Errorf("工作目录不存在: %s", cwd)
 	}
+	n.mu.Lock()
 	n.cwd = cwd
 	n.memory = agentkit.NewCtxMemory()
 	n.errText = ""
+	n.sessionID = ""
+	n.state = "starting"
 	n.mu.Unlock()
+	n.broadcastStatus()
 	meta, err := n.st.Create(agentkit.SessionMeta{Cwd: cwd})
 	if err != nil {
+		n.mu.Lock()
+		n.state = "dead"
+		n.errText = err.Error()
+		n.mu.Unlock()
+		n.broadcastStatus()
 		return err
 	}
 	n.mu.Lock()
 	n.sessionID = meta.ID
-	if n.state != "busy" {
-		n.state = "ready"
-	}
+	n.state = "ready"
 	n.mu.Unlock()
 	n.broadcastStatus()
 	return nil

--- a/internal/server/nativeagent_test.go
+++ b/internal/server/nativeagent_test.go
@@ -533,3 +533,72 @@ func TestNativeServiceRejectsMissingCwd(t *testing.T) {
 		t.Fatal("失效路径不应写入状态")
 	}
 }
+
+// 回归：permission_request 只走 WS 单次广播，页面刷新/WS 断开期间发出的
+// 事件无法再收到，turn 卡在 WaitForDecision 而用户看不到任何审批入口。
+// 修复后：Subscribe 时重放挂起审批 + GET /api/agent/pending 可主动拉取。
+func TestNativeServicePendingPermissionReplay(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{
+		toolStep("c1", "write", `{"path":"out.txt","content":"x"}`),
+		textStep("写完了"),
+	}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc) // 第一个订阅者：会收到原始广播
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+
+	if err := svc.Prompt("写个文件", nil); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.After(10 * time.Second)
+	var permEvt agentbridge.Event
+	for {
+		select {
+		case ev := <-sub.events:
+			if ev.Type == "permission_request" {
+				permEvt = ev
+				goto gotPerm
+			}
+		case <-deadline:
+			t.Fatal("未收到审批请求")
+		}
+	}
+gotPerm:
+	// 1) 订阅重放：新订阅者（模拟刷新后的页面）应立刻收到挂起审批。
+	sub2 := subscribeNative(t, svc)
+	replayed := false
+	replayDeadline := time.After(5 * time.Second)
+	for !replayed {
+		select {
+		case ev := <-sub2.events:
+			if ev.Type == "permission_request" && ev.Permission != nil &&
+				ev.Permission.RequestID == permEvt.Permission.RequestID {
+				replayed = true
+			}
+		case <-replayDeadline:
+			t.Fatal("Subscribe 未重放挂起审批")
+		}
+	}
+	// 2) REST 拉取：PendingRequests 应返回同一条。
+	pending := svc.PendingRequests()
+	if len(pending) != 1 || pending[0].Type != "permission_request" ||
+		pending[0].Permission == nil || pending[0].Permission.RequestID != permEvt.Permission.RequestID {
+		t.Fatalf("PendingRequests 返回错误: %+v", pending)
+	}
+	// 审批后重放与拉取都应清空。
+	if err := svc.RespondPermissionEx(permEvt.Permission.RequestID, true, false); err != nil {
+		t.Fatal(err)
+	}
+	waitTurnDone(t, sub, 10*time.Second)
+	if got := svc.PendingRequests(); len(got) != 0 {
+		t.Fatalf("审批完成后仍有挂起: %+v", got)
+	}
+	sub3 := subscribeNative(t, svc)
+	select {
+	case ev := <-sub3.events:
+		if ev.Type == "permission_request" {
+			t.Fatalf("审批完成后不应重放: %+v", ev)
+		}
+	case <-time.After(500 * time.Millisecond):
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -257,6 +257,7 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/skills", s.handleSkills)
 	mux.HandleFunc("/api/skills/delete", s.handleSkillsDelete)
 	mux.HandleFunc("/api/agent/status", s.handleAgentStatus)
+	mux.HandleFunc("/api/agent/pending", s.handleAgentPending)
 	mux.HandleFunc("/api/agent/start", s.handleAgentStart)
 	mux.HandleFunc("/api/agent/stop", s.handleAgentStop)
 	mux.HandleFunc("/api/agent/cancel", s.handleAgentCancel)

--- a/ui/app.js
+++ b/ui/app.js
@@ -2034,7 +2034,13 @@ function connectAgentSocket() {
   const protocol = location.protocol === "https:" ? "wss:" : "ws:";
   const socket = new WebSocket(`${protocol}//${location.host}/api/agent/ws`);
   agentSocket = socket;
-  socket.onopen = () => clearTimeout(agentReconnectTimer);
+  socket.onopen = () => {
+    clearTimeout(agentReconnectTimer);
+    // 断线/刷新期间发出的 permission_request 是一次性广播，收不到第二次；
+    // 服务端在 Subscribe 时会重放挂起审批，这里再主动拉取一次兜底
+    // （也覆盖 plan_request 等挂起请求），恢复卡住的审批入口。
+    fetchPendingAgentRequests();
+  };
   socket.onmessage = (message) => {
     try {
       handleAgentEvent(JSON.parse(message.data));
@@ -2049,6 +2055,23 @@ function connectAgentSocket() {
       agentReconnectTimer = setTimeout(connectAgentSocket, 1500);
     }
   };
+}
+
+/** 拉取服务端仍挂起的审批/计划请求（WS 重连后的恢复路径）。 */
+async function fetchPendingAgentRequests() {
+  try {
+    const pending = await api("/api/agent/pending");
+    if (!Array.isArray(pending)) return;
+    for (const event of pending) {
+      if (event?.type === "permission_request" && event.permission) {
+        showAgentPermission(event.permission);
+      } else if (event?.type === "plan_request" && event.plan) {
+        showAgentPlan(event.plan, true);
+      }
+    }
+  } catch {
+    // 服务未就绪或接口不可用（如 acp 桥）：静默跳过。
+  }
 }
 
 // 切换会话后，旧会话的流式事件仍可能在 WS 上晚到（服务端补发/重连回放同理）；


### PR DESCRIPTION
## 问题

`permission_request` 只经 WS **单次广播**（fire-and-forget）。页面刷新、WS 断线重连、或多端在线但只有一端恰好在广播时收到，事件即永久丢失：

- turn 的 goroutine 仍阻塞在 `WaitForDecision`，服务状态停在 `busy`
- 用户端**没有任何入口**能再看到或响应这次审批，只能手动停止任务
- 这也是 #37 中「新建会话无限转圈」的原始触发链路（服务端兜底在该 PR，本 PR 补恢复路径本身）

## 修复

### 服务端（internal/server/nativeagent.go）

- 登记挂起审批的原始事件（`pendingPermEvents` + 顺序表，`permMu` 保护），审批完成 / 任务取消 / resolveAllPending 时同步清理，不泄漏
- `Subscribe()` 向新订阅者**重放**仍挂起的审批：刷新后的页面重连 WS 立即看到弹窗
- 新增 `PendingRequests()`（返回挂起审批 + 计划审批快照，按发生顺序）。通过 `AgentService` 接口内省暴露（`interface { PendingRequests() []agentbridge.Event }`），不破坏 acp 桥等既有实现
- 新增路由 `GET /api/agent/pending`（`handleAgentPending`），不支持的服务返回空数组

### 前端（ui/app.js）

- WS `onopen` 时调用新增的 `fetchPendingAgentRequests()`：拉取 `/api/agent/pending` 并把挂起的 `permission_request` / `plan_request` 渲染进现有审批栏（`showAgentPermission` / `showAgentPlan`，零新 UI）
- 接口不可用（acp 桥等）时静默跳过

## 验证

- 新增回归测试 `TestNativeServicePendingPermissionReplay`：审批挂起 → 新订阅者收到重放（requestID 一致）→ `PendingRequests()` 返回同一条 → 审批后重放与拉取均清空、后续新订阅不再收到
- `go test ./...` 全绿（-count=1），`go build` / `go vet` / `node --check ui/app.js` 通过

## 备注

计划审批（plan_request）目前是内存 chan 且无法恢复原始 plan 正文，本 PR 先把它纳入 pending 列表返回（含 requestID，可响应），正文重放留待 plan 流后续增强。
