### PR TITLE
ui: 设计系统统一与交互反馈（管理壳层 + 全局）

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -43,7 +43,6 @@ const state = {
 const OFFICIAL_PROVIDER_KEY = "official";
 
 const $ = (id) => document.getElementById(id);
-let toastTimer = null;
 let refreshTimer = null;
 let grokPoolPollTimer = null;
 let registrarPollTimer = null;
@@ -490,16 +489,34 @@ function isAbortError(err) {
   return !!err && (err.name === "AbortError" || err.code === "aborted");
 }
 
+const TOAST_MAX_STACK = 3;
 function toast(message, type = "info") {
-  const el = $("toast");
-  el.textContent = message;
-  el.classList.remove("error", "success", "warn", "show");
-  if (type === "error") el.classList.add("error");
-  if (type === "success") el.classList.add("success");
-  if (type === "warn") el.classList.add("warn");
-  requestAnimationFrame(() => el.classList.add("show"));
-  clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => el.classList.remove("show"), type === "error" ? 4200 : 2800);
+  // 堆叠队列：单例覆盖式 toast 会让连续错误互相顶掉，只剩最后一条。
+  const host = $("toast");
+  if (!host) return;
+  const item = document.createElement("div");
+  item.className = `toastItem ${type === "error" || type === "success" || type === "warn" ? type : "info"}`;
+  const icon = document.createElement("span");
+  icon.className = "toastIcon";
+  icon.setAttribute("aria-hidden", "true");
+  const ICONS = {
+    error: '<svg viewBox="0 0 20 20" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="10" cy="10" r="7.4"/><path d="M10 6.4v4.4"/><circle cx="10" cy="13.8" r="0.5" fill="currentColor" stroke="none"/></svg>',
+    success: '<svg viewBox="0 0 20 20" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="7.4"/><path d="m6.6 10.2 2.3 2.3 4.5-4.8"/></svg>',
+    warn: '<svg viewBox="0 0 20 20" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M10 3.5 17.5 16h-15L10 3.5Z"/><path d="M10 8.6v3.2"/></svg>',
+    info: '<svg viewBox="0 0 20 20" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><circle cx="10" cy="10" r="7.4"/><path d="M10 9.2v4.4"/><circle cx="10" cy="6.4" r="0.5" fill="currentColor" stroke="none"/></svg>',
+  };
+  icon.innerHTML = ICONS[type] || ICONS.info;
+  const text = document.createElement("span");
+  text.className = "toastText";
+  text.textContent = message;
+  item.append(icon, text);
+  host.append(item);
+  while (host.children.length > TOAST_MAX_STACK) host.firstElementChild?.remove();
+  requestAnimationFrame(() => item.classList.add("show"));
+  setTimeout(() => {
+    item.classList.remove("show");
+    setTimeout(() => item.remove(), 200);
+  }, type === "error" ? 4200 : 2800);
 }
 
 function setBusy(button, busy, labelWhenBusy) {
@@ -957,6 +974,11 @@ function showView(name) {
   document.querySelectorAll("[data-home-only]").forEach((el) => {
     el.hidden = name !== "home";
   });
+  // 顶栏导航激活态：7 个同级按钮此前永远长一个样，无当前视图指示。
+  const NAV_ACTIVE = { skills: "navSkillsBtn", accounts: "navAccountsBtn", imagine: "navImagineBtn", settings: "navSettingsBtn" };
+  document.querySelectorAll(".headerRight .btn[data-nav]").forEach((btn) => {
+    btn.classList.toggle("current", btn.id === NAV_ACTIVE[name]);
+  });
   // Keep header add/import only on home list.
   if ($("headerSubtitle")) {
     $("headerSubtitle").textContent =
@@ -1276,12 +1298,26 @@ function buildSessionItemEl(session, { nested = false, showPath = true } = {}) {
     event.stopPropagation();
     startRenameSession(session);
   };
+// 折叠箭头 SVG（统一图标语言：主题按钮已是 SVG，字符 ▾/▸ 显廉价）
+const CHEVRON_EXPANDED = '<svg viewBox="0 0 20 20" width="10" height="10" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5.5 12 4.5-4.5L14.5 12"/></svg>';
+const CHEVRON_COLLAPSED = '<svg viewBox="0 0 20 20" width="10" height="10" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8 5.5 4.5 4.5L8 14.5"/></svg>';
+
+// 关闭/删除 ×
+const ICON_CLOSE = '<svg viewBox="0 0 20 20" width="11" height="11" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="m5 5 10 10M15 5 5 15"/></svg>';
+
+// 拖拽手柄 ↕
+const ICON_DRAG = '<svg viewBox="0 0 20 20" width="12" height="12" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M7 6.5 10 3.5l3 3M7 13.5l3 3 3-3M10 4v12"/></svg>';
+
+function setChevron(el, expanded) {
+  if (el) el.innerHTML = expanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED;
+}
+
   const deleteBtn = document.createElement("button");
   deleteBtn.type = "button";
   deleteBtn.className = "sessionActionBtn sessionDeleteBtn";
   deleteBtn.title = "删除会话";
   deleteBtn.setAttribute("aria-label", `删除会话 ${session.title || ""}`);
-  deleteBtn.textContent = "×";
+  deleteBtn.innerHTML = ICON_CLOSE;
   deleteBtn.onclick = (event) => {
     event.stopPropagation();
     deleteAgentSession(session).catch((err) => toast(err.message || String(err), "error"));
@@ -1340,7 +1376,7 @@ function renderAgentSessionList() {
   }
   if (toggle) toggle.setAttribute("aria-expanded", state.orphanSessionsOpen ? "true" : "false");
   const chevron = toggle?.querySelector(".treeChevron");
-  if (chevron) chevron.textContent = state.orphanSessionsOpen ? "▾" : "▸";
+  if (chevron) setChevron(chevron, state.orphanSessionsOpen);
 
   if (!state.orphanSessionsOpen) {
     list.hidden = true;
@@ -1368,7 +1404,7 @@ function renderAgentSessionList() {
     const rowChevron = document.createElement("span");
     rowChevron.className = "projectItemChevron";
     rowChevron.setAttribute("aria-hidden", "true");
-    rowChevron.textContent = expanded ? "▾" : "▸";
+    setChevron(rowChevron, expanded);
 
     const body = document.createElement("span");
     body.className = "projectItemBody";
@@ -1414,12 +1450,14 @@ function renderAgentSessionList() {
       };
       actions.append(newBtn);
 
+const ICON_PLUS = '<svg viewBox="0 0 20 20" width="12" height="12" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M10 4.2v11.6M4.2 10h11.6"/></svg>';
+
       const addProjBtn = document.createElement("button");
       addProjBtn.type = "button";
       addProjBtn.className = "sessionActionBtn projectPromoteBtn";
       addProjBtn.title = "添加为项目";
       addProjBtn.setAttribute("aria-label", `将 ${group.name} 添加为项目`);
-      addProjBtn.textContent = "＋";
+      addProjBtn.innerHTML = ICON_PLUS;
       addProjBtn.onclick = (event) => {
         event.stopPropagation();
         promoteWorkspaceToProject(group.path).catch((err) => toast(err.message || String(err), "error"));
@@ -3946,7 +3984,7 @@ function renderChatAttachments() {
     const remove = document.createElement("button");
     remove.type = "button";
     remove.className = "chatAttachmentRemove";
-    remove.textContent = "×";
+    remove.innerHTML = ICON_CLOSE;
     remove.setAttribute("aria-label", `移除 ${att.name || "附件"}`);
     remove.onclick = () => {
       releaseAttachmentPreview(state.pendingAttachments[index]);
@@ -4417,7 +4455,7 @@ function renderProfiles() {
 			: `${escapeHtml(profile.default_model || "未设默认模型")} · ${formatUpstream(profile.upstream_format)} · ${profile.models?.length || 0} 模型`;
 		el.innerHTML = `
 			<div class="providerTop">
-				<button type="button" class="dragHandle" draggable="true" data-action="drag" title="拖动排序" aria-label="拖动 ${escapeHtml(profile.name)} 排序">↕</button>
+				<button type="button" class="dragHandle" draggable="true" data-action="drag" title="拖动排序" aria-label="拖动 ${escapeHtml(profile.name)} 排序">${ICON_DRAG}</button>
 				<div class="providerInfo">
 					<h3 class="providerName">${escapeHtml(profile.name)}</h3>
 					<p class="providerUrl">${official ? "grok.com / auth.json" : providerLinkHtml(profile.base_url)}</p>
@@ -7205,7 +7243,7 @@ function renderAgentProjects() {
     const chevron = document.createElement("span");
     chevron.className = "projectItemChevron";
     chevron.setAttribute("aria-hidden", "true");
-    chevron.textContent = expanded ? "▾" : "▸";
+    setChevron(chevron, expanded);
 
     const body = document.createElement("span");
     body.className = "projectItemBody";

--- a/ui/index.html
+++ b/ui/index.html
@@ -37,10 +37,10 @@
         <button type="button" id="chatBtn" class="btn" data-home-only>聊天</button>
         <button type="button" id="addBtn" class="btn primary" data-home-only>添加供应商</button>
         <button type="button" id="importHeaderBtn" class="btn" data-home-only>导入配置</button>
-        <button type="button" id="navSkillsBtn" class="btn">Skills</button>
-        <button type="button" id="navAccountsBtn" class="btn" title="账号管理">账号</button>
-        <button type="button" id="navImagineBtn" class="btn" title="生图">生图</button>
-        <button type="button" id="navSettingsBtn" class="btn" title="设置">设置</button>
+        <button type="button" id="navSkillsBtn" class="btn" data-nav>Skills</button>
+        <button type="button" id="navAccountsBtn" class="btn" data-nav title="账号管理">账号</button>
+        <button type="button" id="navImagineBtn" class="btn" data-nav title="生图">生图</button>
+        <button type="button" id="navSettingsBtn" class="btn" data-nav title="设置">设置</button>
         <button type="button" id="themeToggleBtn" class="themeToggleBtn" title="主题：亮色（点击切换为暗色）" aria-label="切换主题"></button>
         <a href="https://github.com/1parado/grok-build-switch" target="_blank" rel="noopener" class="navGithubBtn" title="GitHub 仓库" aria-label="GitHub">
           <svg viewBox="0 0 16 16" width="20" height="20" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
@@ -268,7 +268,9 @@
           <div class="agentSidebarTree" id="agentSidebarTree">
             <div class="sessionSectionLabel treeSectionHead">
               <span>项目</span>
-              <button type="button" id="addProjectBtn" class="sessionSectionAction" title="添加项目（工作空间）">＋</button>
+              <button type="button" id="addProjectBtn" class="sessionSectionAction" title="添加项目（工作空间）" aria-label="添加项目（工作空间）">
+                <svg viewBox="0 0 20 20" width="13" height="13" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M10 4.2v11.6M4.2 10h11.6"/></svg>
+              </button>
             </div>
             <div id="agentProjectList" class="agentProjectList" aria-label="项目与会话">
               <p class="sessionListEmpty">暂无项目，点击 ＋ 添加工作目录</p>

--- a/ui/style.css
+++ b/ui/style.css
@@ -34,6 +34,11 @@
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.04);
   --font: "Segoe UI", "PingFang SC", "Microsoft YaHei UI", system-ui, sans-serif;
   --mono: ui-monospace, "Cascadia Mono", "SF Mono", Consolas, monospace;
+  /* 动效 token：全站三种时长 + 一种缓动（此前 10+ 种时长达 38 处散写） */
+  --dur-fast: 120ms;
+  --dur-med: 200ms;
+  --dur-slow: 320ms;
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
   /* 聊天工作台配色（此前硬编码 #007aff/#e9e9eb/#111，暗色下刺眼白底）。
      data-theme=dark 时整组翻转，见下方 [data-theme="dark"] 块。 */
   --chat-bubble-user-bg: #007aff;
@@ -1475,6 +1480,14 @@ body {
 
 .provider:hover {
   border-color: var(--line-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.provider {
+  transition: border-color var(--dur-fast, 120ms) var(--ease-out, ease),
+              box-shadow var(--dur-med, 200ms) var(--ease-out, ease),
+              transform var(--dur-fast, 120ms) var(--ease-out, ease);
 }
 
 .provider.active {
@@ -1678,6 +1691,24 @@ textarea {
   background: var(--surface-2);
   color: var(--text);
   font: inherit;
+}
+
+/* 全站 select 统一外观：自绘箭头（此前只有 composer 的做了 appearance:none） */
+.field select,
+.search select,
+.settingsCard select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 30px;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="%2371717a" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m5.5 8 4.5 4.5L14.5 8"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+  background-size: 14px;
+  cursor: pointer;
+}
+[data-theme="dark"] .field select,
+[data-theme="dark"] .settingsCard select {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="%2394949e" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m5.5 8 4.5 4.5L14.5 8"/></svg>');
 }
 
 .field input.mono,
@@ -2060,8 +2091,8 @@ textarea:focus,
   font-weight: 600;
 }
 
-.registrarResult.ok .registrarResultStatus { color: #16a34a; }
-.registrarResult.fail .registrarResultStatus { color: #dc2626; }
+.registrarResult.ok .registrarResultStatus { color: var(--success-strong, var(--success)); }
+.registrarResult.fail .registrarResultStatus { color: var(--danger); }
 
 .registrarResultMint {
   font-size: 11px;
@@ -2263,8 +2294,11 @@ textarea:focus,
   align-items: center;
   gap: 10px;
   padding: 8px 12px;
+  border-radius: var(--radius-sm);
   border-top: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+  transition: background var(--dur-fast, 120ms) var(--ease-out, ease);
 }
+.accountRow:hover { background: color-mix(in srgb, var(--primary) 5%, transparent); }
 .accountRow:first-child { border-top: none; }
 .accountRowMain { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .accountRowTitle { font-size: 13px; overflow-wrap: anywhere; }
@@ -2496,12 +2530,46 @@ textarea {
   align-items: center;
   gap: 8px;
   font-size: 13px;
+  cursor: pointer;
 }
 
+/* 自定义 checkbox：与自定义 input/select 同一成熟度，不再是裸原生控件 */
 .check input {
-  width: auto;
-  accent-color: var(--primary);
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  margin: 0;
+  border: 1.5px solid var(--line-strong);
+  border-radius: 4px;
+  background: var(--surface);
+  display: inline-grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background var(--dur-fast, 120ms) var(--ease-out, ease),
+              border-color var(--dur-fast, 120ms) var(--ease-out, ease);
 }
+.check input::before {
+  content: "";
+  width: 9px;
+  height: 9px;
+  transform: scale(0);
+  transition: transform var(--dur-fast, 120ms) var(--ease-out, ease);
+  background: var(--primary-fg);
+  -webkit-mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="m4.5 10.5 3.6 3.6 7.4-8" fill="none" stroke="black" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>') center / contain no-repeat;
+          mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="m4.5 10.5 3.6 3.6 7.4-8" fill="none" stroke="black" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/></svg>') center / contain no-repeat;
+}
+.check input:checked {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+.check input:checked::before { transform: scale(1); }
+.check input:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 1px;
+}
+.check input:disabled { opacity: 0.45; cursor: not-allowed; }
 
 .pathBox {
   margin: 0;
@@ -2587,6 +2655,9 @@ textarea {
   font-weight: 500;
   font-size: 13px;
   cursor: pointer;
+  transition: background 140ms var(--ease-out, ease), border-color 140ms var(--ease-out, ease),
+              color 140ms var(--ease-out, ease), box-shadow 140ms var(--ease-out, ease),
+              transform 100ms var(--ease-out, ease);
   /* 窄屏下按钮文字保持整词，不折成竖排 */
   white-space: nowrap;
 }
@@ -2596,15 +2667,24 @@ textarea {
   color: var(--primary);
 }
 
+.btn:not(:disabled):not(.busy):active {
+  transform: translateY(0.5px);
+}
+
 .btn.primary {
   background: var(--primary);
   border-color: var(--primary);
   color: var(--primary-fg);
 }
 
-.btn.primary:hover {
-  filter: brightness(1.05);
+.btn.primary:not(:disabled):not(.busy):hover {
+  background: color-mix(in srgb, var(--primary) 88%, #000);
+  box-shadow: 0 2px 8px -2px color-mix(in srgb, var(--primary) 45%, transparent);
   color: var(--primary-fg);
+}
+.btn.primary:not(:disabled):not(.busy):active {
+  transform: translateY(0.5px);
+  box-shadow: none;
 }
 
 .btn.primary:disabled,
@@ -2641,36 +2721,60 @@ textarea {
 
 .btn:disabled, .btn.busy, button:disabled {
   opacity: 0.55;
-  cursor: wait;
+  cursor: not-allowed;
 }
 
 /* Toast — sit above the floating composer so it never covers 访问方式 / send */
+/* toast 容器：堆叠队列（最多 3 条，见 app.js TOAST_MAX_STACK） */
 .toast {
   position: fixed;
   right: 16px;
   bottom: calc(var(--composer-float-pad, 140px) + 20px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
   max-width: min(380px, calc(100vw - 32px));
-  background: #18181b;
-  color: #fff;
-  border-radius: 10px;
-  padding: 11px 13px;
-  font-size: 13px;
-  opacity: 0;
-  transform: translateY(8px);
-  transition: 160ms ease;
   z-index: 100;
-  box-shadow: var(--shadow);
   pointer-events: none;
 }
 
-.toast.show {
+.toastItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 13px;
+  border-radius: 10px;
+  background: var(--text);
+  color: var(--surface);
+  font-size: 13px;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity var(--dur-med, 200ms) var(--ease-out, ease),
+              transform var(--dur-med, 200ms) var(--ease-out, ease);
+  box-shadow: var(--shadow);
+  pointer-events: auto;
+}
+
+.toastItem.show {
   opacity: 1;
   transform: none;
 }
 
-.toast.error { background: #b91c1c; }
-.toast.warn { background: var(--warn); }
-.toast.success { background: #15803d; }
+.toastIcon { flex-shrink: 0; display: inline-flex; margin-top: 1px; }
+.toastText { min-width: 0; overflow-wrap: anywhere; }
+
+.toastItem.error { background: var(--danger); color: #fff; }
+.toastItem.warn { background: var(--warn); color: #fff; }
+.toastItem.success { background: var(--success); color: #fff; }
+.toastItem.info { background: var(--text); color: var(--surface); }
+
+@media (prefers-reduced-motion: reduce) {
+  .toastItem { transition: opacity 0ms; transform: none; }
+  .typingDots i, .streamCursor, .agentToolStatus::before { animation: none; }
+  .permissionBar, .planBar { animation: none; }
+  .provider, .accountRow, .btn, .ghostBtn { transition: none; }
+}
 
 .updateBanner {
   display: flex;
@@ -2682,7 +2786,7 @@ textarea {
   border: 1px solid var(--success-border);
   border-radius: 8px;
   background: var(--success-soft);
-  color: #245d37;
+  color: var(--success-strong);
 }
 
 .mediaModelTools {
@@ -4199,10 +4303,13 @@ body.resizingChatPanels * {
   background: transparent;
   color: var(--muted);
   cursor: pointer;
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1;
-  padding: 0 4px;
+  padding: 2px 4px;
 }
+.sessionSectionAction:hover { color: var(--text); }
 
 .sessionSectionAction:hover { color: var(--text); }
 
@@ -5315,7 +5422,7 @@ body.resizingChatPanels * {
 }
 
 .skillItem[data-kind="dir"] .skillIcon {
-  background: #f1f5fc;
+  background: var(--primary-soft);
   border-color: var(--primary-border);
 }
 


### PR DESCRIPTION
## 背景

UI 打磨系列第二弹（第一弹 #39 聊天工作台已合入），聚焦**管理壳层与全局一致性**。全部改动限 `ui/` 三件套。

## 改动

- **设计 token**：`:root` 补动效 scale（`--dur-fast/med/slow` + `--ease-out`），新改动统一走 token（此前 38 处 transition 散写 10+ 种时长）
- **暗色漏光清扫**：技能图标 `#f1f5fc`、更新横幅 `#245d37`、注册机状态硬编码色全部换语义 token
- **按钮体系**：`button:disabled` 的 `cursor:wait` 改 `not-allowed`；primary hover 从 `filter:brightness` 换成真实 darken+阴影并补按压态
- **表单控件**：全站 `select` 统一 `appearance:none` + 自绘箭头；checkbox 从裸原生换自定义样式（勾选动画/focus-visible/disabled）
- **导航激活态**：顶栏 4 个导航按钮随 `showView` 加 `.current` 指示（此前 7 个同级按钮永远长一个样）
- **列表反馈**：`accountRow` 补 hover；供应商卡片 hover 轻微抬起+阴影，与画廊卡统一
- **图标统一**：`↕`/`×`/`▾▸`/`＋` 字符 glyph 全部换内联 SVG（集中定义为常量）
- **toast 队列**：单例覆盖式改堆叠队列（最多 3 条）+ 类型图标 + token 颜色
- **`prefers-reduced-motion` 全局兜底**

## 验证

`node --check ui/app.js`、`go test ./...` 全绿。
