### PR TITLE
fix: 图标 SVG 常量误落函数体内导致 ReferenceError

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -1350,6 +1350,21 @@ function setOrphanWorkspaceExpanded(key, open) {
   state.expandedOrphanWorkspaces = { ...state.expandedOrphanWorkspaces, [key]: !!open };
 }
 
+// 统一图标语言：主题按钮已是 SVG，字符 ▾/▸/×/↕/＋ 显廉价。
+// 注意：这些常量必须位于顶层作用域——renderAgentSessionList /
+// renderProfiles / renderAgentProjects / renderChatAttachments 都会引用。
+const CHEVRON_EXPANDED = '<svg viewBox="0 0 20 20" width="10" height="10" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5.5 12 4.5-4.5L14.5 12"/></svg>';
+const CHEVRON_COLLAPSED = '<svg viewBox="0 0 20 20" width="10" height="10" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8 5.5 4.5 4.5L8 14.5"/></svg>';
+
+const ICON_CLOSE = '<svg viewBox="0 0 20 20" width="11" height="11" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="m5 5 10 10M15 5 5 15"/></svg>';
+
+const ICON_DRAG = '<svg viewBox="0 0 20 20" width="12" height="12" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M7 6.5 10 3.5l3 3M7 13.5l3 3 3-3M10 4v12"/></svg>';
+const ICON_PLUS = '<svg viewBox="0 0 20 20" width="12" height="12" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M10 4.2v11.6M4.2 10h11.6"/></svg>';
+
+function setChevron(el, expanded) {
+  if (el) el.innerHTML = expanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED;
+}
+
 function renderSidebarTree() {
   renderAgentProjects();
   renderAgentSessionList();
@@ -1387,20 +1402,6 @@ function buildSessionItemEl(session, { nested = false, showPath = true } = {}) {
     event.stopPropagation();
     startRenameSession(session);
   };
-// 折叠箭头 SVG（统一图标语言：主题按钮已是 SVG，字符 ▾/▸ 显廉价）
-const CHEVRON_EXPANDED = '<svg viewBox="0 0 20 20" width="10" height="10" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5.5 12 4.5-4.5L14.5 12"/></svg>';
-const CHEVRON_COLLAPSED = '<svg viewBox="0 0 20 20" width="10" height="10" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8 5.5 4.5 4.5L8 14.5"/></svg>';
-
-// 关闭/删除 ×
-const ICON_CLOSE = '<svg viewBox="0 0 20 20" width="11" height="11" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="m5 5 10 10M15 5 5 15"/></svg>';
-
-// 拖拽手柄 ↕
-const ICON_DRAG = '<svg viewBox="0 0 20 20" width="12" height="12" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M7 6.5 10 3.5l3 3M7 13.5l3 3 3-3M10 4v12"/></svg>';
-
-function setChevron(el, expanded) {
-  if (el) el.innerHTML = expanded ? CHEVRON_EXPANDED : CHEVRON_COLLAPSED;
-}
-
   const deleteBtn = document.createElement("button");
   deleteBtn.type = "button";
   deleteBtn.className = "sessionActionBtn sessionDeleteBtn";
@@ -1538,8 +1539,6 @@ function renderAgentSessionList() {
         });
       };
       actions.append(newBtn);
-
-const ICON_PLUS = '<svg viewBox="0 0 20 20" width="12" height="12" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M10 4.2v11.6M4.2 10h11.6"/></svg>';
 
       const addProjBtn = document.createElement("button");
       addProjBtn.type = "button";


### PR DESCRIPTION
## 问题

用户界面出现两条红色 toast：`setChevron is not defined`、`ICON_DRAG is not defined`。

根因：#40 引入的 `CHEVRON_EXPANDED / CHEVRON_COLLAPSED / ICON_CLOSE / ICON_DRAG / setChevron` 被错误地插进了 `buildSessionItemEl()` 函数体内部。它们成了块级声明，只在会话列表项构建期间存在；而 `renderAgentSessionList / renderProfiles / renderAgentProjects / renderChatAttachments` 都在各自时机引用它们，一执行就抛 ReferenceError。

`node --check` 之前没拦住：语法完全合法，只是作用域错位。

## 修复

- 6 个图标常量与 `setChevron` 提升到顶层作用域（放在 `renderSidebarTree` 之前）
- `ICON_PLUS` 同样嵌在 `renderAgentSessionList` 的中间块里，一并提升
- 用大括号深度扫描验证：6 个定义全部位于顶层（depth=0），全部引用点可达

## 验证

- `node --check ui/app.js` ✅
- `go build ./...` + `go test ./...` ✅