### PR TITLE
refactor: 系统提示词回归环境事实，行为指令退役

### DIFF
--- a/internal/server/env_preview_test.go
+++ b/internal/server/env_preview_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTopLevelPreviewShape(t *testing.T) {
+	cwd := t.TempDir()
+	_ = os.WriteFile(filepath.Join(cwd, "a.txt"), []byte("x"), 0o644)
+	_ = os.Mkdir(filepath.Join(cwd, "proj"), 0o755)
+	_ = os.WriteFile(filepath.Join(cwd, ".DS_Store"), []byte("junk"), 0o644)
+
+	out := topLevelPreview(cwd)
+	if !strings.Contains(out, "a.txt") || !strings.Contains(out, "proj/") {
+		t.Fatalf("预览缺条目: %q", out)
+	}
+	if strings.Contains(out, ".DS_Store") {
+		t.Fatalf(".DS_Store 应被过滤: %q", out)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(out), "a.txt") {
+		t.Fatalf("条目应为排序后的纯名字列表: %q", out)
+	}
+}
+
+func TestTopLevelPreviewTruncates(t *testing.T) {
+	cwd := t.TempDir()
+	for i := 0; i < 60; i++ {
+		_ = os.WriteFile(filepath.Join(cwd, fmt.Sprintf("f%02d.txt", i)), []byte("x"), 0o644)
+	}
+	out := topLevelPreview(cwd)
+	if got := strings.Count(out, "\n"); got != 41 { // 40 条 + 1 行省略提示
+		t.Fatalf("应 40 条 + 省略行，得到 %d 行: %q", got, out)
+	}
+	if !strings.Contains(out, "60") {
+		t.Fatalf("省略行应含总数: %q", out)
+	}
+}
+
+func TestBuildEnvSection(t *testing.T) {
+	cwd := t.TempDir()
+	_ = os.Mkdir(filepath.Join(cwd, "src"), 0o755)
+	out := buildEnvSection(cwd)
+	for _, want := range []string{"# 环境", "工作目录: " + cwd, "平台:", "src/"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("环境块缺 %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -31,8 +31,8 @@ type EngineDeps struct {
 	// ProviderFor 返回当前会话应使用的 Provider（按当前生效 Profile 构造）。
 	// 返回 error 时 Prompt 报"引擎未配置"。
 	ProviderFor func() (llm.Provider, error)
-	// SystemPrompt 组装系统提示词（含工具文档）。
-	SystemPrompt func(toolDoc string) string
+	// SystemPrompt 组装系统提示词（每 turn 以当前会话的环境块调用）。
+	SystemPrompt func(env string) string
 	// ImageGen 为 nil 时不注册 generate_image。
 	ImageGen tools.ImageGenerator
 	// DefaultCwd 兜底工作目录。
@@ -404,7 +404,7 @@ func (n *nativeAgentService) Prompt(text string, attachments []agentbridge.Attac
 		res, runErr := agentloop.RunTurn(turnCtx, agentloop.RunTurnInput{
 			TurnID:       turnID,
 			Provider:     provider,
-			SystemPrompt: n.deps.SystemPrompt(registry.SystemPromptDoc()),
+			SystemPrompt: n.deps.SystemPrompt(buildEnvSection(n.cwd)),
 			Memory:       mem,
 			Tools:        &tools.ToolsAdapter{Registry: registry},
 			PermGate:     &nativePermGate{svc: n, registry: registry},

--- a/internal/server/nativeagent_setup.go
+++ b/internal/server/nativeagent_setup.go
@@ -6,6 +6,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
+	"runtime"
 	"strings"
 
 	"grok_switch/internal/agentbridge"
@@ -157,35 +159,72 @@ func (s *Server) agentDefaultCwd() string {
 }
 
 // nativeSystemPrompt 组装原生引擎系统提示词。
-// 骨架借鑑 Kimi 内置工具文档的组织方式（§6.3）；文案用中文，
-// 与本工具用户群一致。toolDoc 由注册表汇总（含每个工具的用法契约）。
-func nativeSystemPrompt(toolDoc string) string {
+// 系统提示词只携带模型无法从对话推断的环境事实（工作目录、目录概貌、
+// 平台）；服务方式已由后训练写入权重，不再重复。环境块按会话现算：
+// cwd 是每会话状态，不能在服务构造时定死。
+func nativeSystemPrompt(env string) string {
 	var b strings.Builder
-	b.WriteString(`你是 grok_switch 内置的软件工程 Agent，运行在用户的本机，直接操作他们的项目。
-
-# 工作方式
-
-- 先理解再动手：改动前读相关代码，确认最近的结构与约定；不确定时先问。
-- 从事实出发：以代码为准，不要凭文档或猜测断言。
-- 改动聚焦：只做当前任务要求的事，不顺手重构。
-- 验证闭环：改完代码后运行构建/测试验证；无法验证时明确说明。
-
-# 工具使用
-
-- 能用专用工具就不要用 bash：读文件用 read、改文件用 edit/write、找文件用 glob、搜内容用 grep。
-- 多个独立的只读操作放在同一轮并行发起。
-- 长命令（构建、测试、安装依赖）设置合理的 timeout。
-- 危险操作（删除、覆盖用户数据、全局安装）先说明再执行。
-
-# 输出
-
-- 用用户使用的语言回复。
-- 解释改了什么、为什么这么改；引用代码给出路径与行号。
-- 遇到阻塞如实说明，不要编造结果。
-
+	b.WriteString(`运行在用户的本机，直接读写用户的真实文件系统、执行真实命令。
+相对路径基于工作目录解析；沙箱外的路径会被拒绝。
 `)
-	b.WriteString(toolDoc)
+	b.WriteString(env)
 	return b.String()
+}
+
+// buildEnvSection 环境块：cwd、平台、目录顶层条目。每次 turn 重算，
+// 模型由此获得方位感，无需靠 glob 自查身份。
+func buildEnvSection(cwd string) string {
+	var b strings.Builder
+	b.WriteString("\n# 环境\n\n")
+	b.WriteString("- 工作目录: " + cwd + "\n")
+	b.WriteString("- 平台: " + runtime.GOOS + "/" + runtime.GOARCH + " shell: " + osShell() + "\n")
+	if entries := topLevelPreview(cwd); entries != "" {
+		b.WriteString("- 目录顶层:\n" + entries)
+	}
+	return b.String()
+}
+
+// osShell 报告用户默认 shell（读 SHELL；空则不猜）。
+func osShell() string {
+	return os.Getenv("SHELL")
+}
+
+// topLevelPreview 列出工作目录顶层条目（目录带尾斜杠，最多 40 条，
+// 附加总条目数）。只一层，不递归——Downloads 这类大目录的递归列表
+// 会撑爆上下文且全是噪声。
+func topLevelPreview(cwd string) string {
+	dirEntries, err := os.ReadDir(cwd)
+	if err != nil {
+		return ""
+	}
+	names := make([]string, 0, len(dirEntries))
+	for _, e := range dirEntries {
+		// macOS 会往各处塞 .DS_Store；对模型理解目录结构没有价值。
+		if e.Name() == ".DS_Store" {
+			continue
+		}
+		name := e.Name()
+		if e.IsDir() {
+			name += "/"
+		}
+		names = append(names, name)
+	}
+	const maxEntries = 40
+	shown := names
+	truncated := false
+	if len(names) > maxEntries {
+		shown = names[:maxEntries]
+		truncated = true
+	}
+	var b strings.Builder
+	for _, name := range shown {
+		b.WriteString("  " + name + "\n")
+	}
+	suffix := ""
+	if truncated {
+		suffix = fmt.Sprintf("  …（共 %d 项，已省略）\n", len(names))
+	}
+	return b.String() + suffix
 }
 
 // 编译期引用（保持 import 最小化：agentbridge 用于 Status 语义对齐）。

--- a/internal/server/nativeagent_test.go
+++ b/internal/server/nativeagent_test.go
@@ -57,7 +57,7 @@ func newTestNativeService(t *testing.T, prov llm.Provider) *nativeAgentService {
 	svc, err := newNativeAgentService(EngineDeps{
 		SessionsRoot: root,
 		ProviderFor:  func() (llm.Provider, error) { return prov, nil },
-		SystemPrompt: func(toolDoc string) string { return "sys+" + toolDoc },
+		SystemPrompt: func(env string) string { return "sys+" + env },
 		DefaultCwd:   t.TempDir(),
 	})
 	if err != nil {
@@ -309,21 +309,24 @@ func TestNativeServiceRewind(t *testing.T) {
 	}
 }
 
-func TestNativeServiceSystemPromptIncludesToolDoc(t *testing.T) {
+func TestNativeServiceSystemPromptIncludesEnvSection(t *testing.T) {
 	prov := &stubProvider{steps: []llm.StreamResult{textStep("ok")}}
 	svc := newTestNativeService(t, prov)
 	var captured string
-	svc.deps.SystemPrompt = func(toolDoc string) string {
-		captured = toolDoc
+	svc.deps.SystemPrompt = func(env string) string {
+		captured = env
 		return "sys"
 	}
+	cwd := t.TempDir()
+	_ = os.WriteFile(filepath.Join(cwd, "alpha.txt"), []byte("x"), 0o644)
+	_ = os.Mkdir(filepath.Join(cwd, "subdir"), 0o755)
 	sub := subscribeNative(t, svc)
-	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: cwd})
 	<-sub.events
 	_ = svc.Prompt("hi", nil)
 	waitTurnDone(t, sub, 10*time.Second)
-	if !containsStr(captured, "read") || !containsStr(captured, "bash") {
-		t.Fatalf("工具文档未注入 system prompt: %q", captured[:min(200, len(captured))])
+	if !containsStr(captured, "工作目录: "+cwd) || !containsStr(captured, "alpha.txt") || !containsStr(captured, "subdir/") {
+		t.Fatalf("环境块未注入 system prompt: %q", captured)
 	}
 }
 

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 
 	"grok_switch/internal/agentfs"
@@ -119,27 +118,6 @@ func (r *Registry) ExecuteTool(ctx context.Context, call llm.ToolCall) ToolOutpu
 		out.Truncated = true
 	}
 	return out
-}
-
-// SystemPromptDoc 汇总所有工具文档，供 server 层拼 system prompt。
-func (r *Registry) SystemPromptDoc() string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	names := make([]string, 0, len(r.tools))
-	for n := range r.tools {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	var b strings.Builder
-	b.WriteString("# 可用工具\n\n")
-	for _, n := range names {
-		b.WriteString("## ")
-		b.WriteString(n)
-		b.WriteString("\n")
-		b.WriteString(r.tools[n].Doc())
-		b.WriteString("\n\n")
-	}
-	return b.String()
 }
 
 // argHelp 构造参数解析错误信息（带期望字段，帮模型自纠）。

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -273,11 +273,6 @@ func TestRegistrySchemasAndExecute(t *testing.T) {
 	if out.IsError || !strings.Contains(out.Text, "hello") {
 		t.Fatalf("注册表 read 失败: %+v", out)
 	}
-	// SystemPromptDoc。
-	doc := reg.SystemPromptDoc()
-	if !strings.Contains(doc, "## read") || !strings.Contains(doc, "## bash") {
-		t.Fatalf("system prompt 文档缺失:\n%s", doc)
-	}
 }
 
 func TestRegistryUnregisterImageGen(t *testing.T) {


### PR DESCRIPTION
## 依据

「hi」触发 8 次工具调用的转录分析（nat-1788179708595216000）：模型靠 `glob **/*` 自查身份、被 Downloads 大目录列表带跑人设。根因：系统提示词只讲行为规范，不给环境事实。

原则（[Anthropic: Effective context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)）：后训练已把「如何服务用户」写进权重；系统提示词的工作是告诉模型世界长什么样——只携带模型无法从对话推断的环境状态。判据：删掉不变差的句子不该存在。

## 变更

**系统提示词瘦身**（nativeagent_setup.go）
- 移除：身份定义（「你是…Agent」）、#工作方式 四条、#工具使用 四条、#输出 三条——全部是后训练内容或已有机制兜底（危险操作审批已由 permission 引擎机械化执行）
- 移除「能用专用工具就不要用 bash」类内容：归 tool description 管辖
- 保留并新增环境块（每 turn 以当前 cwd 现算）：
  - 工作目录（相对路径解析基准 + 沙箱边界）
  - 平台 / shell
  - 目录顶层条目：一层不递归、40 条上限、过滤 .DS_Store、超限附总数

**消除工具文档双重呈现**（registry.go）
- 退役 `SystemPromptDoc()`：每个工具的 Doc 此前同时进 schema Description 和 system prompt 汇总，上下文里出现两次，纯 token 翻倍；只保留 schema 一条路

**签名调整**
- `EngineDeps.SystemPrompt: func(toolDoc string)` → `func(env string)`；环境块依赖每会话 cwd，必须在 turn 时组装而非服务构造时定死

## 测试

- `TestNativeServiceSystemPromptIncludesToolDoc` 改写为 `TestNativeServiceSystemPromptIncludesEnvSection`（断言 cwd/文件/目录出现在环境块）
- 新增 `TestTopLevelPreviewShape/Truncates`、`TestBuildEnvSection`
- `go build ./...` + `go test ./...` 全绿
