### PR TITLE
fix: 会话推理强度从未传入 turn，思考过程因此不显示

### DIFF
--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -341,6 +341,7 @@ func (n *nativeAgentService) Prompt(text string, attachments []agentbridge.Attac
 	if n.model == "" {
 		n.model = provider.ModelName()
 	}
+	effort := n.effort
 	// turn 独立 ctx（与 Start/Stop 的生命周期解耦）。
 	turnCtx, cancel := context.WithCancel(context.Background())
 	n.turnCancel = cancel
@@ -412,6 +413,7 @@ func (n *nativeAgentService) Prompt(text string, attachments []agentbridge.Attac
 			MaxSteps:     100,
 			MaxRetries:   3,
 			Hooks:        hooks,
+			Effort:       effort,
 		})
 		// turn 收尾。
 		n.mu.Lock()

--- a/internal/server/nativeagent_test.go
+++ b/internal/server/nativeagent_test.go
@@ -21,10 +21,11 @@ import (
 // --- 测试基建：可控 Provider 注入 nativeAgentService ---
 
 type stubProvider struct {
-	mu    sync.Mutex
-	steps []llm.StreamResult
-	idx   int
-	calls int
+	mu         sync.Mutex
+	steps      []llm.StreamResult
+	idx        int
+	calls      int
+	lastEffort string
 }
 
 func (p *stubProvider) Name() string      { return "stub" }
@@ -37,6 +38,7 @@ func (p *stubProvider) Generate(ctx context.Context, systemPrompt string, tools 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.calls++
+	p.lastEffort = opts.Effort
 	if p.idx >= len(p.steps) {
 		p.idx = len(p.steps) - 1
 	}
@@ -306,6 +308,22 @@ func TestNativeServiceRewind(t *testing.T) {
 	}
 	if svc.memory.UserTurns() != 1 {
 		t.Fatalf("内存轮次错误: %d", svc.memory.UserTurns())
+	}
+}
+
+func TestNativeServiceEffortWiring(t *testing.T) {
+	prov := &stubProvider{steps: []llm.StreamResult{textStep("ok")}}
+	svc := newTestNativeService(t, prov)
+	sub := subscribeNative(t, svc)
+	_ = svc.Start(t.Context(), agentbridge.StartOptions{Cwd: t.TempDir()})
+	<-sub.events
+	_ = svc.SetSessionConfig(t.Context(), "", "high")
+	_ = svc.Prompt("hi", nil)
+	waitTurnDone(t, sub, 10*time.Second)
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	if prov.lastEffort != "high" {
+		t.Fatalf("Generate 未收到会话推理强度: got %q want \"high\"", prov.lastEffort)
 	}
 }
 


### PR DESCRIPTION
## 问题

界面推理强度选了「高」，模型却不显示思考过程。

## 排查（全链路）

| 环节 | 状态 |
|---|---|
| UI 每条 user_message 带 strength | ✅（app.js 三处 send） |
| 服务端 SetSessionConfig 存入 n.effort | ✅ |
| Prompt → RunTurnInput.Effort | ❌ **漏传**（端口字段已预留，赋值缺失） |
| Generate opts.Effort 为空 → validateEffort 返回 "" | 请求不带 reasoning 参数 |
| 上游返回 reasoning summary → thought_chunk → UI 渲染 | 永远不触发 |

## 修复

Prompt 组装 turn 输入时快照 n.effort 并传入 `RunTurnInput.Effort`。

## 回归

`TestNativeServiceEffortWiring`：SetSessionConfig("", "high") 后，Generate 必须收到 opts.Effort == "high"。

`go test ./...` 全绿。
