### PR TITLE
fix: 「自动」推理档从未生效，Profile 默认档未注入 Provider

### DIFF
--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -24,8 +24,12 @@ type ProfileBridge struct {
 	// ModelDef 投影（能力表来源）。
 	SupportsReasoningEffort bool
 	ReasoningEfforts        []string
-	ContextWindow           int64
-	MaxCompletionTokens     int64
+	// DefaultEffort 是 Profile 级默认推理强度（default_reasoning_effort）。
+	// 用户在 UI 选「自动」时前端不发 strength，Provider 用它兜底；
+	// 空表示 Profile 未配置默认档，请求不带 reasoning 参数。
+	DefaultEffort       string
+	ContextWindow       int64
+	MaxCompletionTokens int64
 }
 
 // NewProviderForProfile 是 Profile→Provider 的唯一工厂。
@@ -52,14 +56,14 @@ func NewProviderForProfile(p ProfileBridge) (Provider, error) {
 	}
 	switch format {
 	case "responses":
-		return newResponsesProviderFull(target, p.Model, p.SessionKey, cap, "/responses", p.WirePathOverride)
+		return newResponsesProviderFull(target, p.Model, p.SessionKey, cap, "/responses", p.WirePathOverride, p.DefaultEffort)
 	default:
-		return newChatCompletionsProviderFull(target, p.Model, cap, "/chat/completions", p.WirePathOverride)
+		return newChatCompletionsProviderFull(target, p.Model, cap, "/chat/completions", p.WirePathOverride, p.DefaultEffort)
 	}
 }
 
 // newResponsesProviderFull 构造带路径覆盖的 Responses 适配器（工厂内部使用）。
-func newResponsesProviderFull(target UpstreamTarget, model, sessionKey string, cap ModelCapability, defaultPath, override string) (Provider, error) {
+func newResponsesProviderFull(target UpstreamTarget, model, sessionKey string, cap ModelCapability, defaultPath, override, defaultEffort string) (Provider, error) {
 	p, err := NewResponsesProvider(target, model, sessionKey, cap)
 	if err != nil {
 		return nil, err
@@ -69,11 +73,12 @@ func newResponsesProviderFull(target UpstreamTarget, model, sessionKey string, c
 	} else {
 		p.wirePath = defaultPath
 	}
+	p.effort = defaultEffort
 	return p, nil
 }
 
 // newChatCompletionsProviderFull 构造带路径覆盖的 chat/completions 适配器。
-func newChatCompletionsProviderFull(target UpstreamTarget, model string, cap ModelCapability, defaultPath, override string) (Provider, error) {
+func newChatCompletionsProviderFull(target UpstreamTarget, model string, cap ModelCapability, defaultPath, override, defaultEffort string) (Provider, error) {
 	p, err := NewChatCompletionsProvider(target, model, cap)
 	if err != nil {
 		return nil, err
@@ -83,6 +88,7 @@ func newChatCompletionsProviderFull(target UpstreamTarget, model string, cap Mod
 	} else {
 		p.wirePath = defaultPath
 	}
+	p.effort = defaultEffort
 	return p, nil
 }
 

--- a/internal/llm/factory_effort_test.go
+++ b/internal/llm/factory_effort_test.go
@@ -1,0 +1,34 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProviderForProfileDefaultEffort(t *testing.T) {
+	p, err := NewProviderForProfile(ProfileBridge{
+		BaseURL:                 "http://127.0.0.1:19999/grok/v1",
+		Model:                   "grok-4.6",
+		SupportsReasoningEffort: true,
+		ReasoningEfforts:        []string{"low", "medium", "high"},
+		DefaultEffort:           "high",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rp, ok := p.(*ResponsesProvider)
+	if !ok {
+		t.Fatalf("期望 ResponsesProvider，得到 %T", p)
+	}
+	if rp.effort != "high" {
+		t.Fatalf("Provider 默认档未注入: %q", rp.effort)
+	}
+	// per-call 覆盖优先于默认档（模拟 run_turn 显式传 low 的场景）。
+	body, err := rp.buildRequest("sys", nil, nil, GenerateOptions{Effort: "low"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) == "" || !strings.Contains(string(body), `"effort":"low"`) {
+		t.Fatalf("per-call Effort 应覆盖默认档: %s", body[:200])
+	}
+}

--- a/internal/server/nativeagent_setup.go
+++ b/internal/server/nativeagent_setup.go
@@ -85,6 +85,7 @@ func profileToBridge(p profiles.Profile, actualPort int) llm.ProfileBridge {
 		SessionKey:              p.ID,
 		SupportsReasoningEffort: supportsEffort,
 		ReasoningEfforts:        efforts,
+		DefaultEffort:           p.DefaultReasoningEffort,
 		ContextWindow:           contextWindow,
 		MaxCompletionTokens:     maxCompletion,
 	}


### PR DESCRIPTION
## 问题（第二轮）

#45 接通了显式档位后实测仍无思考块。

## 排查

「自动」档是默认选中项，其语义链路是断的：

1. UI 把 `auto` 剥成空串发送（三处 send 均如此）→ `SetSessionConfig` 不更新
2. `RunTurn.Effort = ""` → `effectiveEffort` 回落到 Provider 自身 `effort` 字段
3. **工厂从 Profile 构造 Provider 时从未设置 effort（零值 ""）** ← 断点
4. `validateEffort("")` → 请求不带 `reasoning` → 上游不返回 summary

结果：Profile 配置的 `default_reasoning_effort: "high"` 从未进入任何请求；只有用户手动选低/中/高才有思考，选「自动」（默认）反而永远没有。

## 修复

- `ProfileBridge` 增加 `DefaultEffort`（Profile 级 `default_reasoning_effort` 的投影）
- 工厂构造 Responses / ChatCompletions Provider 时注入为默认档
- 显式档位（run_turn per-call Effort）仍优先于默认档——语义为「UI 自动档用配置默认，手动档覆盖」

## 回归

`TestProviderForProfileDefaultEffort`：断言 Provider 构造后默认档为注入值、per-call 覆盖生效。

`go test ./...` 全绿。
