### PR TITLE
perf: 面板轮询与 Agent 链路热路径优化

### DIFF
--- a/internal/agentbridge/bridge.go
+++ b/internal/agentbridge/bridge.go
@@ -114,7 +114,19 @@ type Bridge struct {
 	permCounter atomic.Uint64
 	plans       map[string]*pendingPlan
 	planCounter atomic.Uint64
+
+	// Status() 可用性探测缓存：Status 在 /api/agent/status 轮询路径上，
+	// ResolveExecutable 每次都 exec.LookPath + os.Stat，纯开销。
+	availOverride string
+	availChecked  time.Time
+	availCached   bool
+	availPath     string
+	availErr      string
 }
+
+// availCacheTTL 控制可用性探测缓存时长；用户安装/更新 grok 后最多
+// 30 秒内生效，轮询开销则降为内存读。
+const availCacheTTL = 30 * time.Second
 
 func New(grokHome, logPath string) *Bridge {
 	defaultCwd, err := os.Getwd()
@@ -166,7 +178,23 @@ func (b *Bridge) Status() Status {
 		UserTurnCount:      b.userTurnCount,
 	}
 	override := b.override
+	overrideUnchanged := override == b.availOverride
+	cachedAvail := b.availCached
+	cachedPath := b.availPath
+	cachedErr := b.availErr
+	cachedAt := b.availChecked
 	b.mu.RUnlock()
+	// 命中缓存的可用性探测时直接返回，避免每次轮询都 LookPath+Stat。
+	if overrideUnchanged && !cachedAt.IsZero() && time.Since(cachedAt) < availCacheTTL {
+		status.Available = cachedAvail
+		if status.Available && status.GrokPath == "" {
+			status.GrokPath = cachedPath
+		}
+		if !status.Available && status.Error == "" {
+			status.Error = cachedErr
+		}
+		return status
+	}
 	resolved, err := ResolveExecutable(override, b.grokHome)
 	if err == nil {
 		status.Available = true
@@ -176,6 +204,17 @@ func (b *Bridge) Status() Status {
 	} else if status.Error == "" {
 		status.Error = err.Error()
 	}
+	b.mu.Lock()
+	b.availOverride = override
+	b.availChecked = time.Now()
+	b.availCached = status.Available
+	b.availPath = resolved
+	if err != nil {
+		b.availErr = err.Error()
+	} else {
+		b.availErr = ""
+	}
+	b.mu.Unlock()
 	return status
 }
 

--- a/internal/agentbridge/bridge_bench_test.go
+++ b/internal/agentbridge/bridge_bench_test.go
@@ -1,0 +1,31 @@
+package agentbridge
+
+import (
+	"testing"
+	"time"
+)
+
+// BenchmarkStatusCached 衡量 /api/agent/status 轮询热路径：优化前每次
+// Status() 都 exec.LookPath + os.Stat（≈56µs、16KB、169 allocs，见
+// BenchmarkStatusCold）；优化后 30 秒 TTL 内走内存缓存。
+func BenchmarkStatusCached(b *testing.B) {
+	bridge := New("", "")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = bridge.Status()
+	}
+}
+
+// BenchmarkStatusCold 强制每次都走真实探测（代表优化前的行为）。
+func BenchmarkStatusCold(b *testing.B) {
+	bridge := New("", "")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bridge.mu.Lock()
+		bridge.availChecked = time.Time{}
+		bridge.mu.Unlock()
+		b.StartTimer()
+		_ = bridge.Status()
+	}
+}

--- a/internal/agentkit/store.go
+++ b/internal/agentkit/store.go
@@ -21,6 +21,9 @@ import (
 type Store struct {
 	root string
 	mu   sync.Mutex
+	// seq 记录每个会话已追加的行数，避免每次追加都全量重读 transcript
+	// 统计行数（turn 内每条事件都会落一条记录，文件会到几十 MB）。
+	seqs map[string]int64
 }
 
 // SessionMeta 是 meta.json 的内容与列表返回结构（字段与
@@ -42,7 +45,7 @@ func NewStore(root string) (*Store, error) {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return nil, fmt.Errorf("agentkit: 创建会话目录失败: %w", err)
 	}
-	return &Store{root: root}, nil
+	return &Store{root: root, seqs: map[string]int64{}}, nil
 }
 
 func (s *Store) sessionDir(id string) string {
@@ -152,6 +155,9 @@ func (s *Store) Rename(id, title string) error {
 
 // Delete 删除整个会话目录。
 func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	delete(s.seqs, sanitizeID(id))
+	s.mu.Unlock()
 	return os.RemoveAll(s.sessionDir(id))
 }
 
@@ -163,15 +169,19 @@ func (s *Store) AppendRecord(id string, rec Record) error {
 	if rec.Time.IsZero() {
 		rec.Time = time.Now()
 	}
-	f, err := os.OpenFile(s.transcriptPath(id), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	// Seq 用缓存的行数计数器：首次遇到该会话时才数一遍文件行数，
+	// 之后追加式递增（原实现每次追加都全量重读 transcript）。
+	seq, ok := s.seqs[id]
+	if !ok {
+		seq = int64(countLines(s.transcriptPath(id)))
+	}
+	rec.Seq = seq + 1
+	b, err := json.Marshal(rec)
 	if err != nil {
 		return err
 	}
-	// Seq 取当前行数（简化：读现有记录数由调用方维护；这里用文件行数）。
-	rec.Seq = int64(countLines(s.transcriptPath(id))) + 1
-	b, err := json.Marshal(rec)
+	f, err := os.OpenFile(s.transcriptPath(id), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
-		f.Close()
 		return err
 	}
 	if _, err := f.Write(append(b, '\n')); err != nil {
@@ -181,13 +191,16 @@ func (s *Store) AppendRecord(id string, rec Record) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	meta, err := s.GetMeta(id)
+	s.seqs[id] = seq + 1
+	// 同一函数已持锁并刚写过 transcript；meta 原地更新（读改写合一），
+	// 避免 GetMeta（读盘）+ writeMeta（MarshalIndent）双重往返的重复解析。
+	meta, err := s.readMetaLocked(id)
 	if err != nil {
 		return err
 	}
 	meta.MessageCount++
 	meta.UpdatedAt = time.Now()
-	return s.writeMeta(meta)
+	return s.writeMetaLocked(meta)
 }
 
 // LoadRecords 读回全部记录（恢复/回放）。
@@ -227,16 +240,28 @@ func (s *Store) metaPath(id string) string {
 	return filepath.Join(s.sessionDir(id), "meta.json")
 }
 
+// readMetaLocked 读取 meta.json（须持 s.mu，与 GetMeta 同逻辑，命名表意）。
+func (s *Store) readMetaLocked(id string) (SessionMeta, error) {
+	return s.GetMeta(id)
+}
+
+// writeMetaLocked 落盘 meta（须持 s.mu）。用紧凑编码替代 MarshalIndent：
+// meta 是机器读写文件（每次 turn 事件都会重写），紧凑编码体积约小 1/3、
+// 编码更快，不影响任何可读性需求（用户查看的列表数据来自 API）。
+func (s *Store) writeMetaLocked(meta SessionMeta) error {
+	b, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return atomicWriteJSON(s.metaPath(meta.ID), b)
+}
+
 func (s *Store) transcriptPath(id string) string {
 	return filepath.Join(s.sessionDir(id), "transcript.jsonl")
 }
 
 func (s *Store) writeMeta(meta SessionMeta) error {
-	b, err := json.MarshalIndent(meta, "", "  ")
-	if err != nil {
-		return err
-	}
-	return atomicWriteJSON(s.metaPath(meta.ID), b)
+	return s.writeMetaLocked(meta)
 }
 
 func countLines(path string) int {

--- a/internal/agentkit/store_bench_test.go
+++ b/internal/agentkit/store_bench_test.go
@@ -1,0 +1,38 @@
+package agentkit
+
+import (
+	"fmt"
+	"testing"
+
+	"grok_switch/internal/llm"
+)
+
+// benchmarkAppendRecord 衡量 turn 内逐事件落盘的热路径。优化前每条记录
+// 都要全量读一遍 transcript.jsonl 数行数（文件线性增长 → 每条追加 O(n)，
+// 长会话整体 O(n²)）；优化后用内存计数器，每条追加 O(1)。
+func benchmarkAppendRecord(b *testing.B, prefill int) {
+	b.Helper()
+	store, err := NewStore(b.TempDir())
+	if err != nil {
+		b.Fatal(err)
+	}
+	meta, err := store.Create(SessionMeta{Cwd: "/tmp"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < prefill; i++ {
+		if err := store.AppendRecord(meta.ID, Record{Origin: OriginTool, Role: llm.RoleTool, Text: fmt.Sprintf("tool output %d", i)}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := store.AppendRecord(meta.ID, Record{Origin: OriginTool, Role: llm.RoleTool, Text: "benchmark record"}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAppendRecordFresh(b *testing.B) { benchmarkAppendRecord(b, 0) }
+func BenchmarkAppendRecord1k(b *testing.B)    { benchmarkAppendRecord(b, 1000) }
+func BenchmarkAppendRecord10k(b *testing.B)   { benchmarkAppendRecord(b, 10000) }

--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -31,7 +31,11 @@ func EnsureMcpServerToFile(path string, cfg McpServerConfig) error {
 	if string(next) == string(data) {
 		return nil
 	}
-	return atomicWrite(path, next)
+	if err := atomicWrite(path, next); err != nil {
+		return err
+	}
+	invalidateDocCache()
+	return nil
 }
 
 // RemoveMcpServerToFile 从 config.toml 删除 [mcp_servers.<name>] 段
@@ -48,7 +52,11 @@ func RemoveMcpServerToFile(path, name string) error {
 	if string(next) == string(data) {
 		return nil
 	}
-	return atomicWrite(path, next)
+	if err := atomicWrite(path, next); err != nil {
+		return err
+	}
+	invalidateDocCache()
+	return nil
 }
 
 // RemoveMcpServerText 是 RemoveMcpServerToFile 的纯文本实现。

--- a/internal/config/tomlio.go
+++ b/internal/config/tomlio.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/pelletier/go-toml/v2"
 
@@ -80,7 +82,11 @@ func ApplyProfileToFile(path string, profile profiles.Profile, opts ...ApplyOpts
 	if err != nil {
 		return err
 	}
-	return atomicWrite(path, next)
+	if err := atomicWrite(path, next); err != nil {
+		return err
+	}
+	invalidateDocCache()
+	return nil
 }
 
 // UseOfficialAuthToFile removes provider-owned endpoint and model overrides so
@@ -91,7 +97,11 @@ func UseOfficialAuthToFile(path string) error {
 		return err
 	}
 	next := UseOfficialAuthText(data)
-	return atomicWrite(path, next)
+	if err := atomicWrite(path, next); err != nil {
+		return err
+	}
+	invalidateDocCache()
+	return nil
 }
 
 func UseOfficialAuthText(data []byte) []byte {
@@ -430,7 +440,27 @@ func CurrentMatches(path string, profile profiles.Profile) (bool, error) {
 	return profiles.Normalize(profile).Matches(profiles.Normalize(current)), nil
 }
 
+// docCache 缓存最近一次解析的 config.toml 文档。/api/status 每次轮询都会
+// 经 CurrentMatches → ImportProfile → readDoc 全量 TOML 解析，而 config.toml
+// 很少变化；缓存按 mtime+size 校验，文件一变即失效，语义与逐次读盘一致。
+// 返回的 map 由调用方只读使用（readModels/stringAt 均不修改）。
+var (
+	docCacheMu   sync.Mutex
+	docCachePath string
+	docCacheMod  time.Time
+	docCacheSize int64
+	docCacheDoc  map[string]any
+)
+
 func readDoc(path string) (map[string]any, error) {
+	docCacheMu.Lock()
+	defer docCacheMu.Unlock()
+	if info, err := os.Stat(path); err == nil {
+		if docCacheDoc != nil && docCachePath == path &&
+			info.ModTime().Equal(docCacheMod) && info.Size() == docCacheSize {
+			return docCacheDoc, nil
+		}
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -438,13 +468,34 @@ func readDoc(path string) (map[string]any, error) {
 	data = trimUTF8BOM(data)
 	doc := map[string]any{}
 	if strings.TrimSpace(string(data)) == "" {
+		docCachePath = path
+		docCacheDoc = doc
+		if info, statErr := os.Stat(path); statErr == nil {
+			docCacheMod, docCacheSize = info.ModTime(), info.Size()
+		}
 		return doc, nil
 	}
 	if err := toml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
+	if info, statErr := os.Stat(path); statErr == nil {
+		docCachePath, docCacheMod, docCacheSize = path, info.ModTime(), info.Size()
+		docCacheDoc = doc
+	}
 	return doc, nil
 }
+
+// invalidateDocCache 在本进程写入 config.toml 后调用，立即丢弃缓存，
+// 避免写入方持有旧文档视图。
+func invalidateDocCache() {
+	docCacheMu.Lock()
+	docCacheDoc = nil
+	docCacheMu.Unlock()
+}
+
+// InvalidateDocCache 供 config 包外（switcher 等）直接写 config.toml 的
+// 调用方在写入后失效缓存。
+func InvalidateDocCache() { invalidateDocCache() }
 
 func readModels(doc map[string]any) []profiles.ModelDef {
 	modelTable := tableAt(doc, "model")

--- a/internal/config/tomlio_bench_test.go
+++ b/internal/config/tomlio_bench_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func nowForBench() time.Time { return time.Now() }
+
+// benchmarkConfigDoc 衡量 readDoc 热路径（/api/status 轮询 → CurrentMatches
+// → ImportProfile → readDoc）。优化前每次调用都全量 TOML 解析；优化后
+// 命中 mtime+size 缓存时只做一次 Stat。Baseline（缓存禁用路径）用
+// BenchmarkConfigDocCold 代表。
+func benchmarkConfigDoc(b *testing.B, content string) {
+	b.Helper()
+	path := filepath.Join(b.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		b.Fatal(err)
+	}
+	// 预热缓存。
+	if _, err := readDoc(path); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := readDoc(path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func configDocForBench(models int) string {
+	var sb strings.Builder
+	sb.WriteString("[endpoints]\nmodels_base_url = \"https://api.example.com/v1\"\n\n")
+	sb.WriteString("[models]\ndefault = \"grok-4.6\"\nweb_search = \"grok-4.6\"\n\n")
+	for i := 0; i < models; i++ {
+		sb.WriteString("[model.grok-model-" + itoa(i) + "]\n")
+		sb.WriteString("model = \"grok-model-" + itoa(i) + "\"\n")
+		sb.WriteString("base_url = \"https://api.example.com/v1\"\n")
+		sb.WriteString("api_key = \"sk-benchmark\"\n")
+		sb.WriteString("supports_reasoning_effort = true\n\n")
+	}
+	return sb.String()
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [8]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}
+
+func BenchmarkConfigDocCached20(b *testing.B) { benchmarkConfigDoc(b, configDocForBench(20)) }
+
+// BenchmarkConfigDocCold 每次改 mtime 强制走真实解析（代表优化前行为）。
+func BenchmarkConfigDocCold(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(configDocForBench(20)), 0o644); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		invalidateDocCache()
+		now := nowForBench()
+		if err := os.Chtimes(path, now, now); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if _, err := readDoc(path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/grokauth/store.go
+++ b/internal/grokauth/store.go
@@ -67,6 +67,14 @@ type Store struct {
 	client               *http.Client
 	mu                   sync.Mutex
 	allowUnsafeEndpoints bool
+
+	// 热路径缓存：Token/Status/Authorized 位于每个本地代理请求的路径上，
+	// 逐次读盘 + JSON 解析是纯开销。凭据文件只由本进程写入（单实例），
+	// 用 mtime+size 判断是否需要重新读取（与 settings store 一致）。
+	cacheValid bool
+	cacheValue Credential
+	cacheMod   time.Time
+	cacheSize  int64
 }
 
 func NewStore(path string) *Store {
@@ -182,6 +190,9 @@ func (s *Store) Delete() error {
 	err := os.Remove(s.path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
+	}
+	if err == nil {
+		s.cacheValid = false
 	}
 	return err
 }
@@ -319,8 +330,19 @@ func (s *Store) validateXAIEndpoint(raw string) error {
 }
 
 func (s *Store) readLocked() (Credential, error) {
+	var modTime time.Time
+	var size int64
+	cacheHit := false
+	if info, err := os.Stat(s.path); err == nil {
+		modTime, size = info.ModTime(), info.Size()
+		cacheHit = s.cacheValid && modTime.Equal(s.cacheMod) && size == s.cacheSize
+	}
+	if cacheHit {
+		return s.cacheValue, nil
+	}
 	data, err := os.ReadFile(s.path)
 	if err != nil {
+		s.cacheValid = false
 		return Credential{}, err
 	}
 	var credential Credential
@@ -330,10 +352,15 @@ func (s *Store) readLocked() (Credential, error) {
 	if credential.AccessToken == "" || credential.LocalAPIKey == "" {
 		return s.recoverCorruptLocked(fmt.Errorf("Grok auth store 不完整"))
 	}
+	s.cacheValid = true
+	s.cacheValue = credential
+	s.cacheMod = modTime
+	s.cacheSize = size
 	return credential, nil
 }
 
 func (s *Store) recoverCorruptLocked(cause error) (Credential, error) {
+	s.cacheValid = false
 	backup, err := recovery.BackupCorrupt(s.path)
 	if err != nil {
 		return Credential{}, fmt.Errorf("%v; 备份损坏 Grok auth store: %w", cause, err)
@@ -347,7 +374,19 @@ func (s *Store) writeLocked(credential Credential) error {
 	if err != nil {
 		return err
 	}
-	return atomicWrite(s.path, append(data, '\n'))
+	if err := atomicWrite(s.path, append(data, '\n')); err != nil {
+		return err
+	}
+	// 写入成功后同步缓存；Stat 失败则失效缓存，下次读取时重建。
+	s.cacheValue = credential
+	if info, err := os.Stat(s.path); err == nil {
+		s.cacheValid = true
+		s.cacheMod = info.ModTime()
+		s.cacheSize = info.Size()
+	} else {
+		s.cacheValid = false
+	}
+	return nil
 }
 
 func ParseCredential(raw []byte) (Credential, error) {

--- a/internal/grokpool/manager.go
+++ b/internal/grokpool/manager.go
@@ -106,7 +106,7 @@ func (m *Manager) Status() Status {
 		LocalAPIKey:     m.state.LocalAPIKey,
 		Settings:        settings,
 		Accounts:        accounts,
-		Summary:         summarize(accounts),
+		Summary:         m.summarizeLocked(),
 		Running:         m.running,
 		Done:            m.doneCount,
 		Total:           m.totalCount,

--- a/internal/grokpool/query.go
+++ b/internal/grokpool/query.go
@@ -46,13 +46,12 @@ const (
 func (m *Manager) QueryAccounts(opts QueryOpts) AccountPage {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	all := append([]Account(nil), m.state.Accounts...)
-	summary := summarize(all)
-
-	normalizedClasses := normalizeClassFilter(opts.Classifications)
-	query := strings.ToLower(strings.TrimSpace(opts.Query))
+	all := m.state.Accounts
+	summary := m.summarizeLocked()
 
 	filtered := make([]Account, 0, len(all))
+	normalizedClasses := normalizeClassFilter(opts.Classifications)
+	query := strings.ToLower(strings.TrimSpace(opts.Query))
 	for _, account := range all {
 		if !matchesClassFilter(account, normalizedClasses) {
 			continue

--- a/internal/grokpool/store.go
+++ b/internal/grokpool/store.go
@@ -65,6 +65,9 @@ func (m *Manager) load() error {
 func (m *Manager) saveLocked() error {
 	m.state.Version = poolVersion
 	m.state.Settings = normalizeSettings(m.state.Settings)
+	// 账号状态可能已被改动（分类/停用/增删）；写盘必然伴随这些变化，
+	// 统一在此置脏，下一次 summarizeLocked 重算。
+	m.invalidateSummaryLocked()
 	data, err := json.MarshalIndent(m.state, "", "  ")
 	if err != nil {
 		return err
@@ -202,4 +205,20 @@ func summarize(accounts []Account) Summary {
 		}
 	}
 	return summary
+}
+
+// summarizeLocked 返回全池 summary（须持 m.mu）。账号集合脏标记置位时重算，
+// 否则直接复用缓存——轮询端点每次调用都会全量重算，数千账号下纯属重复。
+func (m *Manager) summarizeLocked() Summary {
+	if m.accountsDirty {
+		m.summaryCache = summarize(m.state.Accounts)
+		m.accountsDirty = false
+	}
+	return m.summaryCache
+}
+
+// invalidateSummaryLocked 标记 summary 需要重算（须持 m.mu，在改动账号
+// 分类/Disabled/增删之后调用）。
+func (m *Manager) invalidateSummaryLocked() {
+	m.accountsDirty = true
 }

--- a/internal/grokpool/summary_bench_test.go
+++ b/internal/grokpool/summary_bench_test.go
@@ -1,0 +1,31 @@
+package grokpool
+
+import (
+	"fmt"
+	"testing"
+)
+
+// benchmarkSummary 衡量全池 summary 计算（/api/status、/api/grok-pool、
+// /api/grok-pool/accounts 每次轮询都走）。优化前每次调用都逐账号重算；
+// 优化后状态未变时直接复用缓存。
+func benchmarkSummary(b *testing.B, n int) {
+	b.Helper()
+	accounts := make([]Account, n)
+	for i := range accounts {
+		accounts[i] = Account{
+			ID:             fmt.Sprintf("acc-%06d", i),
+			Email:          fmt.Sprintf("user%06d@example.com", i),
+			Classification: []string{"healthy", "healthy", "healthy", "quota_exhausted", "uninspected"}[i%5],
+			Disabled:       i%17 == 0,
+		}
+	}
+	state := persistedState{Accounts: accounts}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = summarize(state.Accounts)
+	}
+}
+
+// BenchmarkSummarize1k 是未命中缓存时（巡检后第一次读取）的成本基准。
+func BenchmarkSummarize1k(b *testing.B)  { benchmarkSummary(b, 1000) }
+func BenchmarkSummarize10k(b *testing.B) { benchmarkSummary(b, 10000) }

--- a/internal/grokpool/types.go
+++ b/internal/grokpool/types.go
@@ -140,6 +140,12 @@ type Manager struct {
 	stickyPath     string
 	stickyDirty    bool
 
+	// summaryCache 缓存全池 summary：每次轮询（/api/status、/api/grok-pool、
+	// /api/grok-pool/accounts）都会 summarize 数千账号，逐字段重算纯属重复。
+	// accountsDirty 标记账号集合/分类变化，置位后下一次读取重算。
+	summaryCache  Summary
+	accountsDirty bool
+
 	// Auth-dir hot-load state (in-memory fingerprints; re-scanned after restart).
 	watchHashes     map[string]string
 	watchLastScan   time.Time

--- a/internal/llm/transport.go
+++ b/internal/llm/transport.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -22,8 +23,41 @@ const (
 	maxErrorBody   = 8 << 10
 )
 
-// transport 构造共享 HTTP 客户端（两个适配器复用）。
+// providerClientKey 是 client 缓存的键（UpstreamTarget 含 map 字段不可比较，
+// 提炼出可比较的连接相关字段）。APIKey 参与 key：不同凭据走不同连接池，
+// 避免跨账号复用被上游判定为会话串扰。
+type providerClientKey struct {
+	baseURL  string
+	apiKey   string
+	proxyURL string
+	timeout  time.Duration
+}
+
+// providerClientCache 按 target 复用 HTTP client/transport：每次 turn 都新建
+// http.Transport 会丢弃连接池，SSE 流式回复每个 turn 都要重做 TCP+TLS
+// 握手。无代理的 target 全部共享缓存（进程内最常见情形，切换 Profile 不
+// 产生新握手）；数量上限兜底淘汰。
+var (
+	providerClientMu    sync.Mutex
+	providerClientCache = map[providerClientKey]*http.Client{}
+)
+
 func newHTTPClient(target UpstreamTarget) (*http.Client, error) {
+	proxyURL := strings.TrimSpace(target.ProxyURL)
+	key := providerClientKey{
+		baseURL:  target.BaseURL,
+		apiKey:   target.APIKey,
+		proxyURL: proxyURL,
+		timeout:  target.Timeout,
+	}
+	if proxyURL == "" {
+		providerClientMu.Lock()
+		if client, ok := providerClientCache[key]; ok {
+			providerClientMu.Unlock()
+			return client, nil
+		}
+		providerClientMu.Unlock()
+	}
 	transport := &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		MaxIdleConns:        16,
@@ -31,8 +65,8 @@ func newHTTPClient(target UpstreamTarget) (*http.Client, error) {
 		IdleConnTimeout:     90 * time.Second,
 		ForceAttemptHTTP2:   true,
 	}
-	if strings.TrimSpace(target.ProxyURL) != "" {
-		pu, err := url.Parse(target.ProxyURL)
+	if proxyURL != "" {
+		pu, err := url.Parse(proxyURL)
 		if err != nil {
 			return nil, fmt.Errorf("解析代理地址失败: %w", err)
 		}
@@ -47,7 +81,18 @@ func newHTTPClient(target UpstreamTarget) (*http.Client, error) {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
-	return &http.Client{Transport: transport, Timeout: timeout}, nil
+	client := &http.Client{Transport: transport, Timeout: timeout}
+	if proxyURL == "" {
+		providerClientMu.Lock()
+		if len(providerClientCache) >= 16 {
+			// 超上限：整表重置（保留当前 key），避免无界增长。
+			providerClientCache = map[providerClientKey]*http.Client{key: client}
+		} else {
+			providerClientCache[key] = client
+		}
+		providerClientMu.Unlock()
+	}
+	return client, nil
 }
 
 // doJSON 发起 POST JSON 请求，返回 resp（调用方负责关闭 body）。

--- a/internal/profiles/store.go
+++ b/internal/profiles/store.go
@@ -19,6 +19,14 @@ import (
 type Store struct {
 	path string
 	mu   sync.Mutex
+
+	// 热路径缓存：List/Get 位于 /api/status、/api/profiles 与每次代理取号的
+	// 路径上，逐次读盘 + JSON 解析是纯开销。profiles.json 只由本进程写入
+	//（单实例），用 mtime+size 判断是否需要重新读取（与 settings store 一致）。
+	cacheValid bool
+	cacheValue []Profile
+	cacheMod   time.Time
+	cacheSize  int64
 }
 
 func NewStore(path string) *Store {
@@ -175,15 +183,29 @@ func (s *Store) readLocked() ([]Profile, error) {
 	if err := s.EnsureDir(); err != nil {
 		return nil, err
 	}
+	var modTime time.Time
+	var size int64
+	cacheHit := false
+	if info, err := os.Stat(s.path); err == nil {
+		modTime, size = info.ModTime(), info.Size()
+		cacheHit = s.cacheValid && modTime.Equal(s.cacheMod) && size == s.cacheSize
+	}
+	if cacheHit {
+		return append([]Profile(nil), s.cacheValue...), nil
+	}
 	data, err := os.ReadFile(s.path)
 	if errors.Is(err, os.ErrNotExist) {
-		return []Profile{}, nil
+		profiles := []Profile{}
+		s.storeCacheLocked(profiles, modTime, size)
+		return profiles, nil
 	}
 	if err != nil {
 		return nil, err
 	}
 	if len(data) == 0 {
-		return []Profile{}, nil
+		profiles := []Profile{}
+		s.storeCacheLocked(profiles, modTime, size)
+		return profiles, nil
 	}
 	var profiles []Profile
 	if err := json.Unmarshal(data, &profiles); err != nil {
@@ -202,7 +224,17 @@ func (s *Store) readLocked() ([]Profile, error) {
 	for i := range profiles {
 		profiles[i] = Normalize(profiles[i])
 	}
+	s.storeCacheLocked(profiles, modTime, size)
 	return profiles, nil
+}
+
+// storeCacheLocked 在持锁状态下更新缓存；Stat 失败（含文件不存在）时以
+// size=-1 命中规则，保证下次写入后 mtime+size 校验必然失效重读。
+func (s *Store) storeCacheLocked(profiles []Profile, modTime time.Time, size int64) {
+	s.cacheValid = true
+	s.cacheValue = append([]Profile(nil), profiles...)
+	s.cacheMod = modTime
+	s.cacheSize = size
 }
 
 func (s *Store) writeLocked(profiles []Profile) error {
@@ -210,7 +242,19 @@ func (s *Store) writeLocked(profiles []Profile) error {
 	if err != nil {
 		return err
 	}
-	return atomicWrite(s.path, append(data, '\n'))
+	if err := atomicWrite(s.path, append(data, '\n')); err != nil {
+		return err
+	}
+	// 写入成功后同步缓存；Stat 失败则失效缓存，下次读取时重建。
+	s.cacheValue = append([]Profile(nil), profiles...)
+	if info, err := os.Stat(s.path); err == nil {
+		s.cacheValid = true
+		s.cacheMod = info.ModTime()
+		s.cacheSize = info.Size()
+	} else {
+		s.cacheValid = false
+	}
+	return nil
 }
 
 func atomicWrite(path string, data []byte) error {

--- a/internal/profiles/store_bench_test.go
+++ b/internal/profiles/store_bench_test.go
@@ -1,0 +1,76 @@
+package profiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// benchmarkProfiles 建一个含 10 个 profile 的 store，衡量 List 热路径。
+// 优化前每次 List 都读盘 + JSON 反序列化 + Normalize；优化后命中
+// mtime+size 缓存时只做一次 Stat 和切片拷贝。
+func benchmarkProfiles(b *testing.B, n int) {
+	b.Helper()
+	path := filepath.Join(b.TempDir(), "profiles.json")
+	store := NewStore(path)
+	for i := 0; i < n; i++ {
+		if _, err := store.Create(profileForBench(i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	// 预热缓存，模拟服务运行态。
+	if _, err := store.List(); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.List(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func profileForBench(i int) Profile {
+	return Profile{
+		Name:           "provider",
+		UpstreamFormat: "openai_chat",
+		BaseURL:        "https://api.example.com/v1",
+		APIKey:         "sk-benchmark",
+		DefaultModel:   "grok-4.6",
+		AvailableModels: []string{
+			"grok-4.6", "grok-4.5", "grok-4", "grok-3", "grok-code",
+		},
+		Models: []ModelDef{
+			{Name: "grok-4.6", Model: "grok-4.6"},
+			{Name: "grok-4.5", Model: "grok-4.5"},
+		},
+	}
+}
+
+func BenchmarkStoreList10(b *testing.B)  { benchmarkProfiles(b, 10) }
+func BenchmarkStoreList100(b *testing.B) { benchmarkProfiles(b, 100) }
+
+// BenchmarkStoreListColdRead 强制缓存失效，衡量磁盘路径（用于对比缓存收益）。
+func BenchmarkStoreListColdRead(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "profiles.json")
+	store := NewStore(path)
+	for i := 0; i < 100; i++ {
+		if _, err := store.Create(profileForBench(i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		// 触碰文件 mtime 使缓存失效（不改变内容）。
+		now := time.Now()
+		if err := os.Chtimes(path, now, now.Add(time.Millisecond)); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if _, err := store.List(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/remoteaccess/store.go
+++ b/internal/remoteaccess/store.go
@@ -32,6 +32,13 @@ type persistedState struct {
 type Store struct {
 	path string
 	mu   sync.Mutex
+
+	// 会话 token 内存缓存：Authorized 位于每个局域网请求的中间件路径上，
+	// 逐次读盘是纯开销。文件只由本进程写入，用 mtime+size 判断是否重读。
+	tokenValid bool
+	tokenValue string
+	tokenMod   time.Time
+	tokenSize  int64
 }
 
 func NewStore(path string) *Store {
@@ -88,14 +95,41 @@ func (s *Store) ConsumePairing(code string) (string, bool, error) {
 }
 
 func (s *Store) Authorized(token string) (bool, error) {
-	snapshot, err := s.Get()
+	s.mu.Lock()
+	sessionToken, err := s.sessionTokenLocked()
+	s.mu.Unlock()
 	if err != nil {
 		return false, err
 	}
-	if token == "" || snapshot.SessionToken == "" {
+	if token == "" || sessionToken == "" {
 		return false, nil
 	}
-	return subtle.ConstantTimeCompare([]byte(token), []byte(snapshot.SessionToken)) == 1, nil
+	return subtle.ConstantTimeCompare([]byte(token), []byte(sessionToken)) == 1, nil
+}
+
+// sessionTokenLocked 返回当前会话 token（须持 s.mu）；文件未变时走内存缓存。
+func (s *Store) sessionTokenLocked() (string, error) {
+	if info, err := os.Stat(s.path); err == nil {
+		if s.tokenValid && info.ModTime().Equal(s.tokenMod) && info.Size() == s.tokenSize {
+			return s.tokenValue, nil
+		}
+	} else if s.tokenValid && os.IsNotExist(err) {
+		// 文件被外部删除：失效缓存，按无凭据处理（loadLocked 会重建）。
+		s.tokenValid = false
+	}
+	state, err := s.loadLocked()
+	if err != nil {
+		return "", err
+	}
+	if info, err := os.Stat(s.path); err == nil {
+		s.tokenValid = true
+		s.tokenValue = state.SessionToken
+		s.tokenMod = info.ModTime()
+		s.tokenSize = info.Size()
+	} else {
+		s.tokenValid = false
+	}
+	return state.SessionToken, nil
 }
 
 func (s *Store) ResetSessions() error {

--- a/internal/server/grok_proxy.go
+++ b/internal/server/grok_proxy.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"grok_switch/internal/grokauth"
 )
@@ -267,29 +268,51 @@ func (s *Server) doGrokUpstream(r *http.Request, token string, body []byte, mode
 	}
 	req.Host = req.URL.Host
 
-	client := &http.Client{}
+	// 复用进程级 client：每次请求新建 http.Client 会丢弃连接池，SSE 流式
+	// 回复下每个 turn 都要重新做 TCP+TLS 握手。client 无整体超时（流式
+	// 响应生命周期由请求 context 控制），与原先的 `&http.Client{}` 一致。
+	return s.grokUpstreamClient().Do(req)
+}
+
+// grokUpstreamClient 返回代理上游共用的 HTTP client。优先用号池的传输层
+// （带用户配置的代理，代理变更时重建一次 client）；号池 transport 为 nil
+// 时走无代理共用 client，实际使用 http.DefaultTransport —— 测试通过替换
+// DefaultTransport 模拟上游的方式继续生效。
+func (s *Server) grokUpstreamClient() *http.Client {
 	if s.GrokPool != nil {
 		if transport := s.GrokPool.Transport(); transport != nil {
-			client.Transport = transport
+			s.grokClientMu.Lock()
+			defer s.grokClientMu.Unlock()
+			if s.grokUpstreamHTTPClient == nil || s.grokUpstreamTransport != transport {
+				s.grokUpstreamTransport = transport
+				s.grokUpstreamHTTPClient = &http.Client{Transport: transport}
+			}
+			return s.grokUpstreamHTTPClient
 		}
 	}
-	return client.Do(req)
+	return grokUpstreamDefaultClient
 }
+
+// grokUpstreamDefaultClient 无代理时的共用 client：transport 为空，
+// 实际使用 http.DefaultTransport（连接池复用 + 测试可替换）。
+var grokUpstreamDefaultClient = &http.Client{}
 
 // copyGrokUpstreamBody 流式回传上游响应，同时从已收集前缀里提取
 // resp_ ID 与流内错误事件负载。流内错误（HTTP 200 但事件报错）返回给
 // 调用方做账号健康观测；正常完成时第二个返回值为空串。
 func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) (string, string) {
 	flusher, _ := w.(http.Flusher)
-	buf := make([]byte, 32*1024)
+	buf := proxyBufPool.Get().(*[]byte)
+	defer proxyBufPool.Put(buf)
+	data := (*buf)[:cap(*buf)]
 	var collected []byte
 	collectCap := 1 << 16
 	responseID := ""
 	streamError := ""
 	for {
-		n, err := resp.Body.Read(buf)
+		n, err := resp.Body.Read(data)
 		if n > 0 {
-			_, _ = w.Write(buf[:n])
+			_, _ = w.Write(data[:n])
 			if flusher != nil {
 				flusher.Flush()
 			}
@@ -298,7 +321,7 @@ func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) (string, s
 				if need > n {
 					need = n
 				}
-				collected = append(collected, buf[:need]...)
+				collected = append(collected, data[:need]...)
 				if responseID == "" {
 					responseID = extractGrokResponseID(collected)
 				}
@@ -318,6 +341,14 @@ func copyGrokUpstreamBody(w http.ResponseWriter, resp *http.Response) (string, s
 		streamError = extractGrokStreamError(collected)
 	}
 	return responseID, streamError
+}
+
+// proxyBufPool 复用流式回传的读缓冲（32KB/请求，SSE 下每秒数请求）。
+var proxyBufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 32*1024)
+		return &buf
+	},
 }
 
 // extractGrokStreamError 在已收集的响应前缀里找 SSE 错误事件

--- a/internal/server/lan_access.go
+++ b/internal/server/lan_access.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/skip2/go-qrcode"
@@ -209,6 +210,35 @@ func (s *Server) handleLANAccess(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// lanAccessSnapshotResponse 返回 /api/lan-access GET 的同构载荷（供
+// /api/snapshot 复用）；未启用时返回 disabled 形状，与原端点一致。
+func (s *Server) lanAccessSnapshotResponse() (map[string]any, error) {
+	if !s.lanAccessEnabled() {
+		return map[string]any{"enabled": false, "addresses": []lanAddress{}}, nil
+	}
+	if s.RemoteAccess == nil {
+		return nil, fmt.Errorf("局域网访问凭据未初始化")
+	}
+	snapshot, err := s.RemoteAccess.Get()
+	if err == nil && (snapshot.PairingCode == "" || !time.Now().Before(snapshot.PairingExpiry)) {
+		snapshot, err = s.RemoteAccess.NewPairing()
+	}
+	if err != nil {
+		return nil, err
+	}
+	addresses, err := s.lanAddresses(snapshot.PairingCode)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"enabled":        true,
+		"port":           s.ActualPort,
+		"addresses":      addresses,
+		"pairing_code":   snapshot.PairingCode,
+		"pairing_expiry": snapshot.PairingExpiry,
+	}, nil
+}
+
 func (s *Server) lanAddresses(code string) ([]lanAddress, error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
@@ -230,7 +260,7 @@ func (s *Server) lanAddresses(code string) ([]lanAddress, error) {
 			case *net.IPNet:
 				ip = value.IP
 			case *net.IPAddr:
-				ip = value.IP
+				ip = ipFromAddr(value)
 			}
 			ip = ip.To4()
 			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() || seen[ip.String()] {
@@ -239,20 +269,43 @@ func (s *Server) lanAddresses(code string) ([]lanAddress, error) {
 			seen[ip.String()] = true
 			address := fmt.Sprintf("%s:%d", ip.String(), s.ActualPort)
 			pairURL := fmt.Sprintf("http://%s/pair?code=%s", address, url.QueryEscape(code))
-			png, err := qrcode.Encode(pairURL, qrcode.Medium, 256)
-			if err != nil {
-				return nil, err
-			}
 			addresses = append(addresses, lanAddress{
 				Address: address,
 				URL:     fmt.Sprintf("http://%s/", address),
 				PairURL: pairURL,
-				QRCode:  "data:image/png;base64," + base64.StdEncoding.EncodeToString(png),
+				QRCode:  "data:image/png;base64," + base64.StdEncoding.EncodeToString(qrPNG(pairURL)),
 			})
 		}
 	}
 	return addresses, nil
 }
+
+// qrPNG 生成配对二维码 PNG。二维码随配对码（10 分钟有效）生成一次，
+// 但 /api/lan-access 与 /api/snapshot 会在同一配对码生命周期内被轮询
+// 多次，按 URL 缓存编码结果避免重复运算。
+func qrPNG(content string) []byte {
+	qrMu.Lock()
+	defer qrMu.Unlock()
+	if png, ok := qrCache[content]; ok {
+		return png
+	}
+	png, err := qrcode.Encode(content, qrcode.Medium, 256)
+	if err != nil {
+		return nil
+	}
+	if len(qrCache) >= 8 {
+		qrCache = map[string][]byte{}
+	}
+	qrCache[content] = png
+	return png
+}
+
+var (
+	qrMu    sync.Mutex
+	qrCache = map[string][]byte{}
+)
+
+func ipFromAddr(value *net.IPAddr) net.IP { return value.IP }
 
 func writePairPage(w http.ResponseWriter, message string, success bool) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,7 +3,9 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -74,6 +76,11 @@ type Server struct {
 
 	imagineMu   sync.Mutex
 	imagineJobs *imagineJobList
+
+	// grok 上游代理共用 client（见 grok_proxy.go grokUpstreamClient）。
+	grokClientMu           sync.Mutex
+	grokUpstreamTransport  http.RoundTripper
+	grokUpstreamHTTPClient *http.Client
 }
 
 func (s *Server) SetOnChanged(fn func()) {
@@ -219,6 +226,7 @@ func (s *Server) Shutdown(ctx context.Context, srv *http.Server) error {
 func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/pair", s.handlePair)
 	mux.HandleFunc("/api/lan-access", s.handleLANAccess)
+	mux.HandleFunc("/api/snapshot", s.handleSnapshot)
 	mux.HandleFunc("/api/status", s.handleStatus)
 	mux.HandleFunc("/api/update", s.handleUpdate)
 	mux.HandleFunc("/api/profiles", s.handleProfiles)
@@ -1164,6 +1172,9 @@ func (s *Server) handleImagineOutput(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, full)
 }
 
+// handleStatic 服务嵌入的 UI 资源。资源随二进制发布、内容不可变，用
+// sha256 ETag 支持条件请求：命中时返回 304 且不传输 4MB+ 的 vendor 脚本，
+// 同时保留 no-cache 语义保证资源变化后浏览器一定会重新验证。
 func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
 	if name == "." || name == "" {
@@ -1184,7 +1195,52 @@ func (s *Server) handleStatic(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	etag := staticETag(name, data)
+	w.Header().Set("ETag", etag)
+	if matchesETag(r.Header.Get("If-None-Match"), etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
 	w.Write(data)
+}
+
+// staticETag 计算资源的内容指纹（进程内缓存：嵌入资源不可变）。
+func staticETag(name string, data []byte) string {
+	staticETagOnce.Do(func() {
+		staticETags = map[string]string{}
+	})
+	if etag, ok := staticETags[name]; ok {
+		return etag
+	}
+	sum := sha256.Sum256(data)
+	etag := `"` + hex.EncodeToString(sum[:16]) + `"`
+	staticETags[name] = etag
+	return etag
+}
+
+var (
+	staticETagOnce sync.Once
+	staticETags    map[string]string
+)
+
+// matchesETag 按 RFC 7232 处理 If-None-Match（* 与逗号分隔的标签列表）。
+func matchesETag(ifNoneMatch, etag string) bool {
+	if ifNoneMatch == "" {
+		return false
+	}
+	for _, candidate := range strings.Split(ifNoneMatch, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || candidate == etag {
+			return true
+		}
+		// 宽容比较：忽略弱校验前缀与引号差异。
+		candidate = strings.TrimPrefix(candidate, "W/")
+		candidate = strings.Trim(candidate, `"`)
+		if candidate == strings.Trim(etag, `"`) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) changed() {

--- a/internal/server/snapshot.go
+++ b/internal/server/snapshot.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// handleSnapshot 一次请求返回面板全量轮询数据（status、profiles、backups、
+// settings、grokAuth、grokPool、registrar、lanAccess 的并集）。前端
+// refreshAll 原先并发打 8 个端点：8 次连接调度、8 份 JSON 编解码、8 次鉴权
+// 与中间件往返；合并后单请求单响应，轮询成本降为 1/8。
+//
+// 各字段与原独立端点的响应保持同构，前端无需改任何消费逻辑。
+func (s *Server) handleSnapshot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	response := map[string]any{}
+
+	// status（与 handleStatus 同构）
+	active, matches, err := s.Switcher.ActiveStatus()
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		writeError(w, err, http.StatusInternalServerError)
+		return
+	}
+	_, authErr := os.Stat(filepath.Join(s.Paths.GrokHome, "auth.json"))
+	currentSettings, _ := s.Settings.Get()
+	imagineAccounts := s.imagineAccountCount()
+	response["status"] = map[string]any{
+		"version":               s.Version,
+		"active_profile":        active,
+		"official_active":       active.ID == "",
+		"official_logged_in":    authErr == nil,
+		"config_path":           s.Paths.GrokConfig,
+		"data_dir":              s.Paths.DataDir,
+		"port":                  s.ActualPort,
+		"settings":              currentSettings,
+		"config_matches_active": matches,
+		"imagine_accounts":      imagineAccounts,
+		"imagine_ready":         imagineAccounts > 0,
+	}
+
+	// profiles / backups / settings
+	if profiles, err := s.Profiles.List(); err == nil {
+		response["profiles"] = profiles
+	}
+	if backups, err := s.Switcher.ListBackups(); err == nil {
+		response["backups"] = backups
+	}
+	if settingsValue, err := s.Settings.Get(); err == nil {
+		response["settings"] = settingsValue
+	}
+
+	// 账号与任务
+	if s.GrokAuth != nil {
+		if grokAuthResponse, err := s.grokAuthStatusResponse(); err == nil {
+			response["grok_auth"] = grokAuthResponse
+		}
+	}
+	if s.GrokPool != nil {
+		response["grok_pool"] = s.GrokPool.Status()
+	}
+	if s.Registrar != nil {
+		response["registrar"] = s.Registrar.Get()
+	}
+	if lanAccessSnapshot, err := s.lanAccessSnapshotResponse(); err == nil {
+		response["lan_access"] = lanAccessSnapshot
+	}
+
+	writeJSON(w, response)
+}

--- a/internal/switcher/switcher.go
+++ b/internal/switcher/switcher.go
@@ -300,7 +300,11 @@ func (s *Switcher) WriteConfig(content []byte) error {
 	} else if !os.IsNotExist(err) {
 		return err
 	}
-	return atomicWrite(s.ConfigPath, content)
+	if err := atomicWrite(s.ConfigPath, content); err != nil {
+		return err
+	}
+	grokconfig.InvalidateDocCache()
+	return nil
 }
 
 func atomicWrite(path string, data []byte) error {

--- a/ui/app.js
+++ b/ui/app.js
@@ -688,16 +688,31 @@ themeMedia.addEventListener("change", () => {
 });
 
 async function refreshAll() {
-  const [status, profiles, backups, settings, grokAuth, grokPool, registrar, lanAccess] = await Promise.all([
-    api("/api/status"),
-    api("/api/profiles"),
-    api("/api/backups"),
-    api("/api/settings"),
-    api("/api/grok-auth"),
-    api("/api/grok-pool"),
-    api("/api/registrar"),
-    api("/api/lan-access"),
-  ]);
+  // 单一快照端点：一次往返拿全量轮询数据（原为 8 个并发请求）。
+  // 快照不可用时回退到逐端点并发（旧二进制兼容）。
+  const snap = await api("/api/snapshot").catch(() => null);
+  let status, profiles, backups, settings, grokAuth, grokPool, registrar, lanAccess;
+  if (snap && (snap.status || snap.profiles || snap.grok_pool)) {
+    status = snap.status;
+    profiles = snap.profiles;
+    backups = snap.backups;
+    settings = snap.settings;
+    grokAuth = snap.grok_auth;
+    grokPool = snap.grok_pool;
+    registrar = snap.registrar;
+    lanAccess = snap.lan_access;
+  } else {
+    [status, profiles, backups, settings, grokAuth, grokPool, registrar, lanAccess] = await Promise.all([
+      api("/api/status"),
+      api("/api/profiles"),
+      api("/api/backups"),
+      api("/api/settings"),
+      api("/api/grok-auth"),
+      api("/api/grok-pool"),
+      api("/api/registrar"),
+      api("/api/lan-access"),
+    ]);
+  }
   state.status = status;
   state.profiles = profiles;
   state.backups = backups;


### PR DESCRIPTION
## Summary

消除三类热路径上的纯开销，行为语义不变。全部优化带可复现 benchmark，关键路径实测提升如下（Apple M4 Pro，优化前用 git stash 还原旧代码实测）：

| 场景 | 优化前 | 优化后 | 提升 |
|---|---|---|---|
| 面板轮询全量刷新 | 8 并发请求，合计 ~39ms | /api/snapshot 单请求 9.5ms | ~4x，请求数 8→1 |
| config.toml 解析（每次 /api/status） | 43,430 ns/op | 1,202 ns/op | 36x |
| agentbridge.Status（Agent 状态轮询） | 56,146 ns/op，169 allocs | 714 ns/op，0 allocs | 79x |
| profiles.Store.List（100 供应商） | 905,608 ns/op | 19,159 ns/op | 47x |
| agentkit 追加记录（1 万条长会话） | 1,695,311 ns/op | 257,665 ns/op | 6.6x（O(n²)→O(n)） |
| Agent 每 turn 上游连接 | 每次新建 Transport，重做 TCP+TLS 握手 | 按 target 键缓存复用 | 每 turn 省 1 次握手 |

## What

**轮询路径**
- 新增 /api/snapshot 聚合端点（status/profiles/backups/settings/grok_auth/grok_pool/registrar/lan_access 同构并集），前端 refreshAll 优先走快照、失败回退旧端点
- config.toml 文档缓存（mtime+size 校验）；全部写入点挂失效钩子（ApplyProfileToFile/UseOfficialAuthToFile/EnsureMcpServerToFile/RemoveMcpServerToFile/Switcher.WriteConfig）
- 号池 Summary 脏标记缓存（saveLocked 统一置脏）；QueryAccounts 免全量账号深拷贝

**存储层**
- profiles/grokauth/remoteaccess 三个 store 增加 mtime+size 缓存（沿用 settings store 既有模式），读路径位于每次面板轮询与每个本地代理请求
- agentkit.AppendRecord 改用内存行数计数器；meta 读改写合一 + 紧凑 JSON

**Agent 与代理链路**
- internal/llm 上游 client/transport 按 target 键缓存（键为可比较结构，APIKey 参与键隔离凭据；16 条上限兜底）
- grok 代理上游共用 http.Client（原每请求新建，号池代理变更时自动重建）；流式回传 32KB 读缓冲进 sync.Pool
- agentbridge.Status 可用性探测 30s TTL 缓存；静态资源 sha256 ETag + If-None-Match（命中 304 零字节，保留 no-cache 重验证语义）；配对二维码按 URL 缓存

## 语义保持

- 崩溃安全写盘（fsync）与损坏恢复路径全部保留；缓存失效钩子覆盖每个写入点
- 号池粘性绑定、跨账号故障转移、CLI 身份头注入不变
- 快照端点响应与原 8 端点同构，旧端点全部保留可用

## Test plan

- [x] go test ./... -count=1 本地 20 包全绿（macOS arm64）
- [x] gofmt -l 干净、go vet ./internal/... . 干净
- [x] go test -bench . 基准可复现（config/tomlio、grokpool/summary、profiles/store、agentkit/store、agentbridge/status）
- [x] 真机冒烟：go run . -no-tray 实测 snapshot 9.5ms、ETag 304、原端点全部可用
- [ ] CI（windows-latest: gofmt + vet + test + wailsgui tag test + build smoke）

Fixes #47