### PR TITLE
fix: 原生引擎系统提示词补回最小工具调用契约，修复生图等工具静默失效

### DIFF
--- a/internal/server/nativeagent_setup.go
+++ b/internal/server/nativeagent_setup.go
@@ -161,12 +161,22 @@ func (s *Server) agentDefaultCwd() string {
 
 // nativeSystemPrompt 组装原生引擎系统提示词。
 // 系统提示词只携带模型无法从对话推断的环境事实（工作目录、目录概貌、
-// 平台）；服务方式已由后训练写入权重，不再重复。环境块按会话现算：
-// cwd 是每会话状态，不能在服务构造时定死。
+// 平台）与最小工具调用契约；服务方式已由后训练写入权重，不再重复。
+// 环境块按会话现算：cwd 是每会话状态，不能在服务构造时定死。
+//
+// 工具契约必须保留：实测（2026-09）grok-4.6 在无工具指令的系统提示词下，
+// auto tool_choice 会把工具调用降级成文本描述（"用 generate_image 画…"）
+// 而不发真正的 function_call；强制 tool_choice 则一切正常。一行"动作要走
+// 工具调用"即可纠偏，删除会让生图等工具静默失效。
 func nativeSystemPrompt(env string) string {
 	var b strings.Builder
 	b.WriteString(`运行在用户的本机，直接读写用户的真实文件系统、执行真实命令。
 相对路径基于工作目录解析；沙箱外的路径会被拒绝。
+
+# 工具调用
+
+- 执行动作（读文件、执行命令、生成图片等）必须通过工具调用完成；不要在回复文本里描述调用，直接发起调用。
+- 生成/绘制图片时必须调用 generate_image 工具。
 `)
 	b.WriteString(env)
 	return b.String()


### PR DESCRIPTION
## Summary

原生引擎下模型回答"没有生成图片的工具"/把调用写成文字，generate_image 从未真正触发。根因是 6436e42 提示词重构删掉了工具使用章节后，grok-4.6 在 auto tool_choice 下把工具调用降级成文本描述。

## Evidence（本地号池实测复现）

| 场景 | 结果 |
|---|---|
| tools 声明 + auto tool_choice + 纯环境提示词 | 稳定输出文本 "用 generate_image 画…"（流式/非流式均复现，中英文指令均复现） |
| 同请求 + 强制 tool_choice | 正常返回 function_call 条目 → 上游与 wire 格式无问题 |
| 同请求 + 系统提示词补一行工具契约 | 恢复真实 function_call（本修复） |

## What

`nativeSystemPrompt` 补回最小契约（两行，注释里记录了实测依据防止再被当冗余删掉）：
- 执行动作必须通过工具调用完成，不要在回复文本里描述调用
- 生成图片必须调用 generate_image

其余行为指令（"能用专用工具就不要用 bash"等）保持 6436e42 的退役决策不变。

## Test plan

- [x] probe 脚本：auto 模式发出真实 function_call（修复前复现降级、修复后恢复）
- [x] go test ./... -count=1 本地 20 包全绿；gofmt/vet 干净
- [ ] CI（windows-latest 全量门禁）

Fixes #49