### PR TITLE
fix: generate_image 工具未注册——native 服务构造早于 Imagine 引擎初始化

### DIFF
--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -33,8 +33,10 @@ type EngineDeps struct {
 	ProviderFor func() (llm.Provider, error)
 	// SystemPrompt 组装系统提示词（每 turn 以当前会话的环境块调用）。
 	SystemPrompt func(env string) string
-	// ImageGen 为 nil 时不注册 generate_image。
-	ImageGen tools.ImageGenerator
+	// ImageGenAdapter 每 turn 调用一次，返回当前可用的生图适配（nil =
+	// 不注册 generate_image）。不能用静态值注入：服务构造早于 Imagine
+	// 引擎初始化（Listen 内），且生图开关需要即时生效。
+	ImageGenAdapter func() tools.ImageGenerator
 	// DefaultCwd 兜底工作目录。
 	DefaultCwd string
 }
@@ -366,8 +368,12 @@ func (n *nativeAgentService) Prompt(text string, attachments []agentbridge.Attac
 		Type: "user_message", SessionID: sessionID, Text: text,
 	})
 
-	// 工具注册表（每 turn 重建：生图开关即时生效）。
-	registry := tools.DefaultRegistry(func() agentfs.Env { return env }, n.deps.ImageGen, &nativePlanApprover{n: n}, &tools.TodoStore{})
+	// 工具注册表（每 turn 重建：生图开关与引擎就绪状态即时生效）。
+	var imageGen tools.ImageGenerator
+	if n.deps.ImageGenAdapter != nil {
+		imageGen = n.deps.ImageGenAdapter()
+	}
+	registry := tools.DefaultRegistry(func() agentfs.Env { return env }, imageGen, &nativePlanApprover{n: n}, &tools.TodoStore{})
 
 	// 引擎事件 → WS 事件翻译。usage 观测挂在服务上（跨 turn 保持）。
 	n.usageHolderOnce.Do(func() { n.usageHolder = &turnUsageHolder{} })

--- a/internal/server/nativeagent_setup.go
+++ b/internal/server/nativeagent_setup.go
@@ -23,8 +23,10 @@ func (s *Server) NewNativeAgentService() (AgentService, error) {
 		SessionsRoot: s.Paths.DataDir + "/agent2/sessions",
 		ProviderFor:  s.nativeProviderFor,
 		SystemPrompt: nativeSystemPrompt,
-		ImageGen:     s.nativeImageGen(),
-		DefaultCwd:   s.agentDefaultCwd(),
+		// 惰性取用：构造发生在 Listen() 初始化 Imagine 之前，这里只交出
+		// 读取器，每 turn 重建工具注册表时才真正判定生图可用性。
+		ImageGenAdapter: s.nativeImageGen,
+		DefaultCwd:      s.agentDefaultCwd(),
 	})
 }
 
@@ -117,7 +119,12 @@ func rewriteLoopbackPort(u string, port int) string {
 
 // nativeImageGen 返回生图工具适配；生图全局开关关闭或号池无账号时返回 nil
 // （工具不注册，模型回到无生图状态，与 acp 引擎的 MCP 移除语义一致）。
-// Registry 每 turn 重建，开关切换即时生效。
+// Registry 每 turn 重建，本函数也每 turn 调用一次，开关切换与引擎就绪
+// 都即时生效。
+//
+// 注意 s.Imagine 不能在构造期快照：main.go 在 Listen() 之前构造 native
+// 服务，而 Imagine 引擎在 Listen() 内才初始化——构造期它必为 nil，若在
+// 那时判定会把 generate_image 永久挤出工具列表（2026-09 实测回归）。
 func (s *Server) nativeImageGen() tools.ImageGenerator {
 	if s.Settings != nil {
 		if current, err := s.Settings.Get(); err != nil || !current.ImageGenEnabled {


### PR DESCRIPTION
## Summary

PR #50 解决了提示词降级，但端到端仍生不了图。本 PR 修掉第二个独立缺陷：**generate_image 从未出现在工具列表里**。

## 根因

装配时序陷阱（时序图）：

```
main.go:
  NewNativeAgentService()   ← 此处 s.Imagine == nil（还没初始化）
  appServer.Listen()        ← 此处 s.Imagine = NewImagineEngine(...)
```

`nativeImageGen()` 在构造期被求值一次，`nil` 被静态固化进 `EngineDeps.ImageGen`；每 turn 重建注册表时用的都是这个过期快照 → generate_image never 注册 → 模型只能用 glob/bash 翻文件找图片，最后回答没有生图能力（用户截图行为完全吻合）。

## What

- `EngineDeps.ImageGen`（静态值）→ `ImageGenAdapter func() tools.ImageGenerator`
- turn 循环里每 turn 调用一次适配器再建注册表（注册表本就每 turn 重建，无额外开销）
- 附带收益：生图开关切换、Imagine 账号冷加载完成都即时生效
- 注释里记录时序陷阱，防止回归

## Test plan

- [x] 重启真实实例后 probe：auto 模式发出 generate_image function_call（修复前复现无此工具）
- [x] go test ./... -count=1 20 包全绿；gofmt/vet 干净
- [ ] CI（windows-latest 全量门禁）

Fixes #51