### PR TITLE
fix: 工具结果 media 全链路接通，generate_image 出图后在对话中渲染

### DIFF
--- a/internal/agentloop/events.go
+++ b/internal/agentloop/events.go
@@ -66,6 +66,9 @@ type ToolResultEvent struct {
 	Output    string `json:"output,omitempty"`
 	IsError   bool   `json:"is_error,omitempty"`
 	Truncated bool   `json:"truncated,omitempty"`
+	// Media 携带工具产出的结构化媒体（如 generate_image 的图片引用），
+	// 供宿主直接渲染，避免从文本输出做不可靠的路径提取。
+	Media []llm.ContentPart `json:"-"`
 }
 
 // Dispatcher 是事件单出口。Dispatch 必须非阻塞且不 panic 外泄。

--- a/internal/agentloop/run_turn.go
+++ b/internal/agentloop/run_turn.go
@@ -245,6 +245,7 @@ func execToolBatch(ctx context.Context, in RunTurnInput, calls []llm.ToolCall, e
 			ToolResult: &ToolResultEvent{
 				ID: call.ID, Name: call.Name,
 				Output: result.Output, IsError: result.IsError, Truncated: result.Truncated,
+				Media: result.Media,
 			},
 		})
 	}

--- a/internal/server/nativeagent_events.go
+++ b/internal/server/nativeagent_events.go
@@ -67,12 +67,16 @@ func (t *nativeEventTranslator) Dispatch(ev agentloop.Event) {
 		}
 	case agentloop.EventToolResult:
 		if ev.ToolResult != nil {
+			// 结构化媒体（generate_image 等）直接随事件下发与落盘；
+			// UI 与历史回放都不必再从文本里猜路径。
+			media := mediaPartsToBridge(ev.ToolResult.Media)
 			t.svc.broadcast(agentbridge.Event{
 				Type: "tool_update", SessionID: t.sessionID,
 				Tool: &agentbridge.ToolEvent{
 					ID: ev.ToolResult.ID, Title: ev.ToolResult.Name, Kind: ev.ToolResult.Name,
 					Status:    toolEventStatus(ev.ToolResult.IsError),
 					RawOutput: ev.ToolResult.Output,
+					Media:     media,
 				},
 			})
 			// 工具结果落盘（含回显的 call 参数）。
@@ -94,9 +98,11 @@ func (t *nativeEventTranslator) Dispatch(ev agentloop.Event) {
 				})
 			}
 			t.svc.persist(t.sessionID, agentkit.Record{
-				Origin: agentkit.OriginTool, Role: llm.RoleTool,
+				Origin:     agentkit.OriginTool,
+				Role:       llm.RoleTool,
 				ToolCallID: ev.ToolResult.ID,
 				Text:       agentloop.ToolResult{Output: ev.ToolResult.Output, IsError: ev.ToolResult.IsError, Truncated: ev.ToolResult.Truncated}.ResultJSON(),
+				Media:      mediaRefsFromParts(ev.ToolResult.Media),
 				TurnID:     t.turnID,
 			})
 		}
@@ -126,6 +132,42 @@ func toolEventStatus(isErr bool) string {
 		return "failed"
 	}
 	return "completed"
+}
+
+// mediaPartsToBridge 把工具结果里的媒体部件转成 WS 协议的 MediaContent。
+// 只转发 URI 引用（generate_image 产出落盘后的 /imagine-output/... 路径）；
+// 内联 base64 数据走 ImagePart.Data，按引用语义不适用。
+func mediaPartsToBridge(parts []llm.ContentPart) []agentbridge.MediaContent {
+	if len(parts) == 0 {
+		return nil
+	}
+	out := make([]agentbridge.MediaContent, 0, len(parts))
+	for _, part := range parts {
+		if img, ok := part.(llm.ImagePart); ok && img.URI != "" {
+			out = append(out, agentbridge.MediaContent{Kind: "image", MimeType: img.MimeType, URI: img.URI})
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mediaRefsFromParts 把媒体部件转成 transcript 持久化引用（历史回放用）。
+func mediaRefsFromParts(parts []llm.ContentPart) []agentkit.MediaRef {
+	if len(parts) == 0 {
+		return nil
+	}
+	out := make([]agentkit.MediaRef, 0, len(parts))
+	for _, part := range parts {
+		if img, ok := part.(llm.ImagePart); ok && img.URI != "" {
+			out = append(out, agentkit.MediaRef{Kind: "image", MimeType: img.MimeType, URI: img.URI})
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // turnUsageHolder 记录本 turn 最近一步的真实 input tokens（D3：无状态重放下

--- a/internal/tools/agenttools.go
+++ b/internal/tools/agenttools.go
@@ -157,12 +157,14 @@ func (t GenerateImageTool) Execute(ctx context.Context, args json.RawMessage, en
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "已生成 %d 张图片:\n", len(paths))
+	media := make([]llm.ContentPart, 0, len(paths))
 	for _, p := range paths {
 		b.WriteString(p)
 		b.WriteString("\n")
+		media = append(media, llm.ImagePart{URI: p, MimeType: "image/jpeg"})
 	}
 	return ToolOutput{
 		Text:  b.String(),
-		Media: []llm.ContentPart{},
+		Media: media,
 	}
 }


### PR DESCRIPTION
## Summary

生图链路的最后一公里：图片实际生成并落盘成功（HTTP 200 可访问），但对话界面不渲染、模型续接也不引用。根因是工具结果的结构化媒体在事件出口被丢弃，前端只能从多行文本里猜路径（永远猜不中）。

## 断点位置

```
ToolOutput.Media（有值）→ ToolResult.Media（有值）
  → ToolResultEvent.Media（✗ 字段不存在，丢弃）
    → WS tool_update 无 media → 前端 extractMediaFromPayload(多行文本) = []
    → transcript 无 media → 历史回放也无图
```

## What

- `agentloop`: `ToolResultEvent` 增加 `Media []llm.ContentPart`（json:-，仅进程内），成功路径随事件携带
- `nativeagent_events`: `tool_update` 事件带 `Media`（复用前端既有渲染路径 renderAgentTool → structuredMedia）；tool 记录落盘写 `MediaRef`，历史回放同享
- `tools/agenttools`: `generate_image` 把每个产物路径作为 `llm.ImagePart{URI}` 填入 Media（引擎返回的 `/imagine-output/...` 已是可直接渲染的 URL）
- 新增 `mediaPartsToBridge` / `mediaRefsFromParts`，只转发 URI 引用部件

## Test plan

- [x] probe：工具结果后模型正确续接（不再降级成"再调一次/变文本"）
- [x] go test ./... -count=1 20 包全绿；gofmt/vet 干净
- [ ] CI（windows-latest 全量门禁）

Fixes #53