### PR TITLE
fix: 工作目录双缺陷——重启回落旧目录、切换项目后消息仍跑在旧目录

### DIFF
--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -37,8 +37,10 @@ type EngineDeps struct {
 	// 不注册 generate_image）。不能用静态值注入：服务构造早于 Imagine
 	// 引擎初始化（Listen 内），且生图开关需要即时生效。
 	ImageGenAdapter func() tools.ImageGenerator
-	// DefaultCwd 兜底工作目录。
-	DefaultCwd string
+	// DefaultCwd 返回兜底工作目录（cwd=="" 时的替代）。函数而非静态值：
+	// rememberAgentCwd 会在运行中更新 settings.AgentDefaultCwd，快照会
+	// 把构造时的旧目录固化成永久兜底。
+	DefaultCwd func() string
 }
 
 // permissionOptionFor 构造与 acp 桥一致的审批选项。
@@ -184,7 +186,7 @@ func (n *nativeAgentService) Status() agentbridge.Status {
 		State:              n.state,
 		SessionID:          n.sessionID,
 		Cwd:                n.cwd,
-		DefaultCwd:         n.deps.DefaultCwd,
+		DefaultCwd:         n.defaultCwdLocked(),
 		Busy:               n.state == "busy",
 		SessionAutoApprove: n.autoAppr,
 		Model:              n.model,
@@ -200,6 +202,16 @@ func (n *nativeAgentService) memoryUserTurnsLocked() int {
 	return n.memory.UserTurns()
 }
 
+// defaultCwdLocked 返回当前兜底工作目录。惰性求值：rememberAgentCwd
+// 更新 settings.AgentDefaultCwd 后这里立即反映新值（静态快照会把构造
+// 时的旧目录固化成永久兜底，重启回落旧目录的根因之一）。
+func (n *nativeAgentService) defaultCwdLocked() string {
+	if n.deps.DefaultCwd == nil {
+		return ""
+	}
+	return strings.TrimSpace(n.deps.DefaultCwd())
+}
+
 // Start 初始化引擎会话（不 spawn 进程——原生引擎无需子进程）。
 func (n *nativeAgentService) Start(ctx context.Context, opts agentbridge.StartOptions) error {
 	n.mu.Lock()
@@ -208,7 +220,7 @@ func (n *nativeAgentService) Start(ctx context.Context, opts agentbridge.StartOp
 		return nil // 已就绪（幂等）
 	}
 	if opts.Cwd == "" {
-		opts.Cwd = n.deps.DefaultCwd
+		opts.Cwd = n.defaultCwdLocked()
 	}
 	n.state = "starting"
 	n.errText = ""
@@ -294,7 +306,7 @@ func (n *nativeAgentService) NewSession(ctx context.Context, cwd string) error {
 	n.mu.Unlock()
 	n.resolveAllPending()
 	if cwd == "" {
-		cwd = n.deps.DefaultCwd
+		cwd = n.defaultCwdLocked()
 	}
 	if info, statErr := os.Stat(cwd); statErr != nil || !info.IsDir() {
 		return fmt.Errorf("工作目录不存在: %s", cwd)

--- a/internal/server/nativeagent_setup.go
+++ b/internal/server/nativeagent_setup.go
@@ -26,7 +26,10 @@ func (s *Server) NewNativeAgentService() (AgentService, error) {
 		// 惰性取用：构造发生在 Listen() 初始化 Imagine 之前，这里只交出
 		// 读取器，每 turn 重建工具注册表时才真正判定生图可用性。
 		ImageGenAdapter: s.nativeImageGen,
-		DefaultCwd:      s.agentDefaultCwd(),
+		// DefaultCwd 惰性读取：rememberAgentCwd 会在运行中更新
+		// settings.AgentDefaultCwd，静态快照会把构造时的旧目录固化成
+		// 兜底 cwd（重启回落 Downloads 的根因之一）。
+		DefaultCwd: s.agentDefaultCwd,
 	})
 }
 

--- a/internal/server/nativeagent_test.go
+++ b/internal/server/nativeagent_test.go
@@ -60,7 +60,7 @@ func newTestNativeService(t *testing.T, prov llm.Provider) *nativeAgentService {
 		SessionsRoot: root,
 		ProviderFor:  func() (llm.Provider, error) { return prov, nil },
 		SystemPrompt: func(env string) string { return "sys+" + env },
-		DefaultCwd:   t.TempDir(),
+		DefaultCwd:   func() string { return t.TempDir() },
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/ui/app.js
+++ b/ui/app.js
@@ -4392,6 +4392,16 @@ async function sendAgentMessage() {
     toast("正在生成回复，请先停止或等待完成", "error");
     return;
   }
+  // 工作区一致性守卫：用户切换了项目/目录（agentCwd）但引擎还挂在旧目录的
+  // 会话上时，直接发消息会让工具继续跑在旧目录（检索到错误的项目）。
+  // 此时自动把引擎迁到新目录的新会话，保证"当前工作区 = 会话 cwd"。
+  const selectedCwd = $("agentCwd")?.value.trim() || "";
+  const engineCwd = state.agentStatus?.cwd || state.activeAgentSession?.cwd || "";
+  if (state.agentEngineState === "attached" && selectedCwd && engineCwd &&
+      normalizePathKey(selectedCwd) !== normalizePathKey(engineCwd)) {
+    const created = await newAgentSession();
+    if (created === false) return;
+  }
   if (state.agentEngineState === "bootstrap") {
     // Keep local history; engine already has a fresh session with bootstrap armed.
     setAgentEngineState("attached");


### PR DESCRIPTION
## Summary

用户报告的两个现象（同一表象、两条独立根因）：

| 现象 | 根因 | 修复 |
|---|---|---|
| 重启后工作目录回落 Downloads | EngineDeps.DefaultCwd 构造期快照，不随 rememberAgentCwd 更新 | 改为惰性函数 DefaultCwd func() string |
| 切到新目录发消息，Agent 仍检索 Downloads | 单击项目只改输入框，引擎会话仍绑旧目录，消息进旧会话 | sendAgentMessage 工作区一致性守卫，cwd 不一致自动建新会话 |

## 根因细节

① 时间线：app 启动 → 构造 native 服务（DefaultCwd=旧值快照）→ 用户选新目录 → rememberAgentCwd 更新 settings.json（持久层正确）→ 但引擎兜底仍用旧快照 → 重启/空 cwd 时回落。与 ImageGen 静态注入是同款时序陷阱（PR #52 同类）。

② openProjectById / pickWorkingDirectory 只写 agentCwd.value；引擎 ready 时 sendAgentMessage 不检查一致性直接 user_message → env.Cwd = n.cwd（旧目录）→ 工具全跑在旧目录。

## Test plan

- [x] 实例 E2E：start(X) → session(/tmp) → status.cwd=/tmp 且 default_cwd=/tmp；重启进程后 default_cwd 跟随 /tmp（修复前回落旧值）
- [x] node --check ui/app.js 通过
- [x] go test ./... -count=1 20 包全绿；gofmt/vet 干净
- [ ] CI（windows-latest 全量门禁）

Fixes #55