### PR TITLE
fix: MCP 段替换不清子表，与 Grok CLI 规范化交错产生非法 config.toml

### DIFF
--- a/internal/config/mcp.go
+++ b/internal/config/mcp.go
@@ -79,6 +79,24 @@ func RemoveMcpServerText(data []byte, name string) []byte {
 	return []byte(result + "\n")
 }
 
+// skipSectionWithSubtables 返回 header 段及其全部子表（[a.b] 之下还有
+// [a.b.c]）的结束下标。skipSection 只认下一个 [header] 行，会把
+// [mcp_servers.x.env] 这类子表留在段外——替换主体后与段内 inline table
+// 同 key 共存，产生 TOML 解析错误（"key env should be a table, not a
+// value"）。
+func skipSectionWithSubtables(lines []string, start int, header string) int {
+	end := skipSection(lines, start)
+	prefix := header + "."
+	for end < len(lines) {
+		next := parseHeader(lines[end])
+		if !strings.HasPrefix(next, prefix) {
+			break
+		}
+		end = skipSection(lines, end+1)
+	}
+	return end
+}
+
 // EnsureMcpServerText 是 EnsureMcpServerToFile 的纯文本实现。
 // 幂等：已存在匹配段时更新它；重复段（异常情况）只保留第一个。
 // 同时清理 grok_switch 曾用过的旧服务器名（仅当命令指向同一可执行文件，
@@ -92,7 +110,7 @@ func EnsureMcpServerText(data []byte, cfg McpServerConfig) []byte {
 	for i := 0; i < len(lines); {
 		current := parseHeader(lines[i])
 		if current == header {
-			end := skipSection(lines, i+1)
+			end := skipSectionWithSubtables(lines, i+1, current)
 			// 已写入过（含重复段）则丢弃，保证最终只有一个。
 			if !replaced {
 				existing := strings.Join(lines[i:end], "\n")
@@ -107,7 +125,7 @@ func EnsureMcpServerText(data []byte, cfg McpServerConfig) []byte {
 			continue
 		}
 		if legacy != "" && legacy != header && current == legacy {
-			end := skipSection(lines, i+1)
+			end := skipSectionWithSubtables(lines, i+1, current)
 			existing := strings.Join(lines[i:end], "\n")
 			if mcpSectionCommandEquals(existing, cfg.Command) {
 				// 旧名残留且指向同一可执行文件：迁移清理。


### PR DESCRIPTION
## Summary

修复对话引擎报 `引擎未就绪: parse config.toml: toml: key env should be a table, not a value` 的根因：两个写入方（grok_switch 写 inline table、Grok CLI 保存时规范化成子表）交错后，`EnsureMcpServerText` 的段边界计算遗漏子表，产生 inline env + `[..env]` 子表同 key 共存的非法 TOML。

## What

新增 `skipSectionWithSubtables(lines, start, header)`：段结束计算覆盖所有 `<header>.` 前缀子表；MCP 段的替换（Ensure）与迁移清理（legacy）均改用它。

## 影响链

config.toml 解析失败 → ImportProfile/CurrentMatches 报错 → nativeProviderFor 失败 → 引擎"未就绪"，聊天工作台不可用。也影响 /api/status 的 config_matches_active 判断。

## Test plan

- [x] 复现用例：子表形态 config → Ensure 重写 → 修复后输出干净单段、go-toml 解析 OK
- [x] 线上已损坏的 config.toml 已修复并实测引擎恢复
- [x] go test ./... -count=1 20 包全绿；gofmt 干净
- [ ] CI（windows-latest 全量门禁）

Fixes #57