### PR TITLE
fix: 自研引擎上下文/工具/媒体链路加固

### DIFF
--- a/internal/agentkit/compaction.go
+++ b/internal/agentkit/compaction.go
@@ -9,6 +9,7 @@ package agentkit
 // PromptOrigin 是正确性根基：只有 OriginUser 是真实用户输入，其余可重建。
 
 import (
+	"encoding/json"
 	"strings"
 
 	"grok_switch/internal/llm"
@@ -24,18 +25,23 @@ type CompactionConfig struct {
 	KeptUserTokens int64
 	// HeadUserTokens head 段预算（最老的用户输入，通常是最初任务陈述）。
 	HeadUserTokens int64
+	// KeepRecentTokens 尾部完整保留预算（token，含 assistant/tool 不折叠）。
+	// 对齐 pi keepRecentTokens：近期上下文原样保留，只摘要更老部分。
+	// 0 表示禁用尾部保留（测试/兼容旧行为）。
+	KeepRecentTokens int64
 	// MaxOverflowAttempts 摘要请求本身溢出时的最大重试。
 	MaxOverflowAttempts int
 }
 
 // DefaultCompactionConfig 默认参数：85% 触发、50k 保留输出、
-// 20k 用户原话预算（head 2k）——与 Kimi DEFAULT_COMPACTION_CONFIG 一致。
+// 20k 用户原话预算（head 2k）+ 20k 尾部完整保留——与 Kimi DEFAULT_COMPACTION_CONFIG 一致。
 func DefaultCompactionConfig() CompactionConfig {
 	return CompactionConfig{
 		TriggerRatio:        0.85,
 		ReservedContextSize: 50_000,
 		KeptUserTokens:      20_000,
 		HeadUserTokens:      2_000,
+		KeepRecentTokens:    20_000,
 		MaxOverflowAttempts: 3,
 	}
 }
@@ -66,34 +72,64 @@ func (c CompactionConfig) ShouldCompact(usedTokens, maxContext int64) bool {
 //
 // 摘要生成器 summarizer 由宿主提供（调用一次 LLM，输入被折叠的消息文本）；
 // 它返回摘要文本。近似 token 用 EstimateTokens（字符/4）。
+//
+// 语义（对齐 pi/Kimi）：
+//   - KeepRecentTokens>0 时尾部按 token 完整保留（含 assistant/tool），只摘要更老部分，
+//     切点永不在 tool_result 处切断（保 toolCall-result 相邻）。
+//   - 头部在 KeptUserTokens/HeadUserTokens 内保留用户原话，形成 head/tail + 省略标记。
+//   - 摘要尾附 <read-files>/<modified-files> 文件操作清单，避免路径丢失。
 func Compact(msgs []llm.Message, origins []Origin, summarizer func(dropped []llm.Message) (string, error), cfg CompactionConfig) ([]llm.Message, []Origin, CompactionStats, error) {
 	stats := CompactionStats{}
 	if len(msgs) != len(origins) {
 		return nil, nil, stats, ErrOriginMismatch
 	}
 
-	// 1. 挑选保留的用户原话（OriginUser 且有文本）。
+	// 0. 尾部切点：从尾累加到 KeepRecentTokens，永不在 tool_result 处切。
+	cutIdx := 0
+	if cfg.KeepRecentTokens > 0 && len(msgs) > 0 {
+		cutIdx = findTailCut(msgs, cfg.KeepRecentTokens)
+	}
+	var tailMsgs []llm.Message
+	var tailOrigins []Origin
+	var headMsgs []llm.Message
+	var headOrigins []Origin
+	if cutIdx > 0 && cutIdx < len(msgs) {
+		headMsgs, headOrigins = msgs[:cutIdx], origins[:cutIdx]
+		tailMsgs, tailOrigins = msgs[cutIdx:], origins[cutIdx:]
+	} else {
+		// 无尾部保留（测试零值/小历史）：全量走旧路径。
+		headMsgs, headOrigins = msgs, origins
+	}
+
+	// 1. 在头部挑选保留的用户原话（OriginUser 且有文本）。
 	type keptUser struct{ idx int }
 	var userMsgs []keptUser
-	for i, o := range origins {
-		if o == OriginUser && msgs[i].Text() != "" {
+	for i, o := range headOrigins {
+		if o == OriginUser && headMsgs[i].Text() != "" {
 			userMsgs = append(userMsgs, keptUser{idx: i})
 		}
 	}
-	stats.UserMessagesTotal = len(userMsgs)
+	// UserMessagesTotal 统计全量（含尾部），与旧语义一致。
+	totalUsers := 0
+	for _, o := range origins {
+		if o == OriginUser {
+			totalUsers++
+		}
+	}
+	stats.UserMessagesTotal = totalUsers
 
 	// 2. 在预算内从最新往回保留（tail），再保证最老 HeadUserTokens（head）。
 	budget := cfg.KeptUserTokens
 	headBudget := cfg.HeadUserTokens
-	if headBudget >= budget {
+	if headBudget >= budget && budget > 0 {
 		headBudget = budget / 4
 	}
 	keptSet := map[int]bool{}
 	used := int64(0)
 	for i := len(userMsgs) - 1; i >= 0; i-- {
-		m := msgs[userMsgs[i].idx]
+		m := headMsgs[userMsgs[i].idx]
 		cost := llm.EstimateMessageTokens(m)
-		if used+cost > budget {
+		if budget > 0 && used+cost > budget {
 			continue // 超预算的单条跳过（继续尝试更老的小消息）
 		}
 		keptSet[userMsgs[i].idx] = true
@@ -107,7 +143,7 @@ func Compact(msgs []llm.Message, origins []Origin, summarizer func(dropped []llm
 			headCount++
 			continue
 		}
-		m := msgs[u.idx]
+		m := headMsgs[u.idx]
 		cost := llm.EstimateMessageTokens(m)
 		if headUsed+cost > headBudget {
 			break
@@ -122,46 +158,54 @@ func Compact(msgs []llm.Message, origins []Origin, summarizer func(dropped []llm
 	stats.KeptUserMessages = len(keptSet)
 	stats.KeptHeadUserMessages = headCount
 
-	// 3. 收集被折叠的消息（非保留用户消息 + 全部 assistant/tool）。
+	// 3. 收集被折叠的头部消息（非保留用户消息 + 全部 assistant/tool）。
 	var dropped []llm.Message
 	var droppedUserCount int
-	for i, m := range msgs {
-		if origins[i] == OriginUser && keptSet[i] {
+	for i, m := range headMsgs {
+		if headOrigins[i] == OriginUser && keptSet[i] {
 			continue
 		}
 		// 已有的摘要与省略标记不重复折叠（Kimi：markers never stack）。
-		if origins[i] == OriginSummary || origins[i] == OriginInjection {
+		if headOrigins[i] == OriginSummary || headOrigins[i] == OriginInjection {
 			continue
 		}
 		dropped = append(dropped, m)
-		if origins[i] == OriginUser {
+		if headOrigins[i] == OriginUser {
 			droppedUserCount++
 		}
 	}
 	stats.CompactedCount = len(dropped)
 	stats.DroppedUserMessages = droppedUserCount
+	stats.RetainedTailCount = len(tailMsgs)
+	stats.RetainedTailTokens = llm.EstimateHistoryTokens(tailMsgs)
 
 	if len(dropped) == 0 {
-		// 没有可折叠内容：原样返回。
+		// 没有可折叠内容：原样返回（尾部保留无意义，直接返回原序列）。
 		return msgs, origins, stats, nil
 	}
 
-	// 4. 生成摘要。
+	// 4. 生成摘要，尾附文件操作清单。
 	summary, err := summarizer(dropped)
 	if err != nil {
 		return nil, nil, stats, err
 	}
+	readFiles, modifiedFiles := extractFileOps(dropped)
+	stats.ReadFiles = readFiles
+	stats.ModifiedFiles = modifiedFiles
+	if fileOps := formatFileOps(readFiles, modifiedFiles); fileOps != "" {
+		summary = summary + "\n\n" + fileOps
+	}
 
-	// 5. 组装新序列：head 用户原话 → 省略标记（若有跳过）→ tail 用户原话 → 摘要。
+	// 5. 组装新序列：head 用户原话 → 省略标记 → 摘要 → 完整尾部。
 	var out []llm.Message
 	var outOrigins []Origin
 	lastKeptIdx := -1
 	needElision := false
-	for i, m := range msgs {
-		if origins[i] != OriginUser || !keptSet[i] {
+	for i, m := range headMsgs {
+		if headOrigins[i] != OriginUser || !keptSet[i] {
 			continue
 		}
-		if needElision && lastKeptIdx >= 0 && hasGapBetween(msgs, origins, lastKeptIdx, i) {
+		if needElision && lastKeptIdx >= 0 && hasGapBetween(headMsgs, headOrigins, lastKeptIdx, i) {
 			out = append(out, llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: COMPACTION_ELISION_MARKER}}})
 			outOrigins = append(outOrigins, OriginInjection)
 		}
@@ -173,10 +217,39 @@ func Compact(msgs []llm.Message, origins []Origin, summarizer func(dropped []llm
 	// 摘要消息（user 角色承载，但 Origin=summary；compaction 时不再重复折叠）。
 	out = append(out, llm.Message{Role: llm.RoleUser, Parts: []llm.ContentPart{llm.TextPart{Text: COMPACTION_SUMMARY_PREFIX + "\n\n" + summary}}})
 	outOrigins = append(outOrigins, OriginSummary)
+	// 尾部原样追加（保持 toolCall-result 相邻与近期完整性）。
+	out = append(out, tailMsgs...)
+	outOrigins = append(outOrigins, tailOrigins...)
 
 	stats.TokensBefore = llm.EstimateHistoryTokens(msgs)
 	stats.TokensAfter = llm.EstimateHistoryTokens(out)
 	return out, outOrigins, stats, nil
+}
+
+// findTailCut 从尾累加 token 到预算，返回头部/尾部分界下标。
+// 不变量：切点永不在 tool_result 处（若首条保留是 tool 结果则前移含其 assistant 调用）。
+func findTailCut(msgs []llm.Message, budget int64) int {
+	if budget <= 0 || len(msgs) == 0 {
+		return 0
+	}
+	var acc int64
+	cut := len(msgs)
+	for i := len(msgs) - 1; i >= 0; i-- {
+		acc += llm.EstimateMessageTokens(msgs[i])
+		if acc >= budget {
+			cut = i
+			break
+		}
+		// 全量不足预算：无需切分。
+		if i == 0 {
+			return 0
+		}
+	}
+	// 前移吞掉孤儿 tool_result 的配对 assistant（含多结果批次）。
+	for cut > 0 && msgs[cut].Role == llm.RoleTool {
+		cut--
+	}
+	return cut
 }
 
 // hasGapBetween 判断两个保留用户消息之间是否存在被省略的用户消息。
@@ -196,6 +269,10 @@ type CompactionStats struct {
 	KeptHeadUserMessages int
 	CompactedCount       int
 	DroppedUserMessages  int
+	RetainedTailCount    int
+	RetainedTailTokens   int64
+	ReadFiles            []string
+	ModifiedFiles        []string
 	TokensBefore         int64
 	TokensAfter          int64
 }
@@ -254,18 +331,96 @@ func CompactInputText(dropped []llm.Message, maxChars int) string {
 				b.WriteString("\n")
 			}
 			for _, tc := range m.ToolCalls {
-				b.WriteString("tool_call: " + tc.Name + "\n")
+				b.WriteString("tool_call: " + tc.Name + " " + truncateRunes(string(tc.Arguments), 500) + "\n")
 			}
 		case llm.RoleTool:
 			b.WriteString("tool_result: ")
-			b.WriteString(truncateRunes(m.Text(), 500))
+			b.WriteString(truncateRunes(m.Text(), 2000))
 			b.WriteString("\n")
 		}
 	}
 	if b.Len() > maxChars {
-		return b.String()[:maxChars] + "\n[输入过长已截断]"
+		return truncateRunes(b.String(), maxChars) + "\n[输入过长已截断]"
 	}
 	return b.String()
+}
+
+// --- 文件操作追踪（对齐 pi formatFileOperations） ---
+
+// extractFileOps 从被折叠消息的工具调用中提取读写文件清单。
+func extractFileOps(dropped []llm.Message) (readFiles, modifiedFiles []string) {
+	seenRead := map[string]bool{}
+	seenMod := map[string]bool{}
+	add := func(dst *[]string, seen map[string]bool, v string) {
+		v = strings.TrimSpace(v)
+		if v == "" || seen[v] {
+			return
+		}
+		seen[v] = true
+		*dst = append(*dst, v)
+	}
+	for _, m := range dropped {
+		for _, tc := range m.ToolCalls {
+			path := toolCallPath(tc.Name, tc.Arguments)
+			if path == "" {
+				continue
+			}
+			switch tc.Name {
+			case "write", "edit":
+				add(&modifiedFiles, seenMod, path)
+			default:
+				// read/glob/grep 等只读工具；未知工具按只读归类。
+				if !seenMod[path] {
+					add(&readFiles, seenRead, path)
+				}
+			}
+		}
+	}
+	// 读过又改过的文件只算 modified。
+	filtered := readFiles[:0]
+	for _, f := range readFiles {
+		if !seenMod[f] {
+			filtered = append(filtered, f)
+		}
+	}
+	return filtered, modifiedFiles
+}
+
+// toolCallPath 从工具参数中提取路径/模式字段。
+func toolCallPath(name string, args json.RawMessage) string {
+	var m map[string]any
+	if err := json.Unmarshal(args, &m); err != nil {
+		return ""
+	}
+	for _, k := range []string{"path", "pattern", "glob"} {
+		if v, ok := m[k].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// formatFileOps 把文件清单格式化为摘要尾部块。
+func formatFileOps(readFiles, modifiedFiles []string) string {
+	if len(readFiles) == 0 && len(modifiedFiles) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	if len(readFiles) > 0 {
+		b.WriteString("<read-files>\n")
+		for _, f := range readFiles {
+			b.WriteString("  " + f + "\n")
+		}
+		b.WriteString("</read-files>\n")
+	}
+	if len(modifiedFiles) > 0 {
+		b.WriteString("<modified-files>\n")
+		for _, f := range modifiedFiles {
+			b.WriteString("  " + f + "\n")
+		}
+		b.WriteString("</modified-files>")
+	}
+	return strings.TrimSpace(b.String())
 }
 
 func roleLabel(r llm.Role) string {

--- a/internal/agentkit/compaction_test.go
+++ b/internal/agentkit/compaction_test.go
@@ -220,9 +220,12 @@ func TestCompactInputText(t *testing.T) {
 	if !strings.Contains(text, "user: 用户的问题") || !strings.Contains(text, "tool_call: read") {
 		t.Fatalf("摘要输入缺关键内容:\n%s", text)
 	}
-	// 超长截断。
+	// 超长截断（按 rune 截断，CJK 按字节会更长，只断言实质截断）。
 	long := CompactInputText([]llm.Message{userMsg(strings.Repeat("长", 9000))}, 1000)
-	if len(long) > 1100 {
-		t.Fatalf("未截断: %d", len(long))
+	if !strings.Contains(long, "[输入过长已截断]") {
+		t.Fatalf("应标记截断:\n%s", long[:200])
+	}
+	if len([]rune(long)) > 1200 {
+		t.Fatalf("未截断: runes=%d", len([]rune(long)))
 	}
 }

--- a/internal/agentloop/run_turn.go
+++ b/internal/agentloop/run_turn.go
@@ -259,11 +259,57 @@ func appendToolResult(mem Memory, call llm.ToolCall, result ToolResult) {
 
 // shouldRetry 判断错误是否值得重试。
 func shouldRetry(err error) bool {
+	if IsContextOverflow(err) {
+		return false // 溢出走压实恢复而非退避重试
+	}
 	apiErr, ok := err.(*llm.APIError)
 	if !ok {
 		return false
 	}
 	return llm.RetryableKind(apiErr.Kind)
+}
+
+// IsContextOverflow 判断是否为上下文溢出（对齐 pi isContextOverflow）。
+// 413/too_large 直接判溢出；400 系 invalid_request 需消息含 context/length/token 关键词。
+func IsContextOverflow(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apiErr, ok := err.(*llm.APIError); ok {
+		if apiErr.Kind == "too_large" || apiErr.StatusCode == 413 {
+			return true
+		}
+		if apiErr.Kind == "invalid_request" || apiErr.Kind == "unknown" {
+			return containsOverflowHint(apiErr.Upstream)
+		}
+		return false
+	}
+	return containsOverflowHint(err.Error())
+}
+
+func containsOverflowHint(s string) bool {
+	lower := strings.ToLower(s)
+	if !strings.Contains(lower, "context") && !strings.Contains(lower, "token") && !strings.Contains(lower, "length") && !strings.Contains(lower, "too long") && !strings.Contains(lower, "maximum") {
+		return false
+	}
+	for _, hint := range []string{
+		"context", "maximum context", "context length", "too long", "too many tokens",
+		"token limit", "max tokens", "overflow", "exceed",
+	} {
+		if strings.Contains(lower, hint) {
+			// 必须同时与长度/上限语义相关，避免误伤普通 "context" 提及。
+			if hint == "context" {
+				for _, extra := range []string{"length", "long", "exceed", "limit", "maximum", "overflow", "token", "window"} {
+					if strings.Contains(lower, extra) {
+						return true
+					}
+				}
+				continue
+			}
+			return true
+		}
+	}
+	return false
 }
 
 // retryDelay 计算指数退避时长；限流尊重 Retry-After。

--- a/internal/llm/estimate.go
+++ b/internal/llm/estimate.go
@@ -33,8 +33,8 @@ func EstimateMessageTokens(m Message) int64 {
 		case ThinkPart:
 			total += EstimateTokens(part.Text)
 		case ImagePart:
-			// 图片按中等分辨率经验值计。
-			total += 800
+			// 图片按 pi ESTIMATED_IMAGE_CHARS=4800 经验值计（原 800 严重低估致晚压）。
+			total += 4800
 		}
 	}
 	for _, tc := range m.ToolCalls {

--- a/internal/server/native_prompt_context.go
+++ b/internal/server/native_prompt_context.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"grok_switch/internal/tools"
+)
+
+// loadProjectContext 加载项目上下文（对齐 pi resource-loader 语义的最小集）：
+// 从 cwd 向上到根收集 AGENTS.override.md > AGENTS.md > CLAUDE.md（去重），
+// 再叠 cwd/.pi/SYSTEM.md 自定义系统提示。单文件 8k、总量 16k 截断，避免撑爆上下文。
+func loadProjectContext(cwd string) string {
+	if strings.TrimSpace(cwd) == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return ""
+	}
+	// 祖先链：cwd → /，收集三类文件（override 优先）。
+	seenDir := map[string]bool{}
+	var files []string
+	cur := abs
+	for {
+		if !seenDir[cur] {
+			seenDir[cur] = true
+			for _, name := range []string{"AGENTS.override.md", "AGENTS.md", "CLAUDE.md"} {
+				p := filepath.Join(cur, name)
+				if st, err := os.Stat(p); err == nil && !st.IsDir() && st.Size() > 0 && st.Size() < 200<<10 {
+					files = append(files, p)
+					break // 同目录只取最高优先
+				}
+			}
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+		// 防止超深链：最多向上 12 层。
+		if len(seenDir) > 12 {
+			break
+		}
+	}
+	// 祖先在前、cwd 在后？pi 是全局 + 祖先链去重；此处按发现逆序（根→cwd）使 cwd 覆盖。
+	for i, j := 0, len(files)-1; i < j; i, j = i+1, j-1 {
+		files[i], files[j] = files[j], files[i]
+	}
+	var b strings.Builder
+	total := 0
+	const perFile = 8000
+	const totalBudget = 16000
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		text := strings.TrimSpace(string(data))
+		if text == "" {
+			continue
+		}
+		if len(text) > perFile {
+			text = text[:perFile] + "\n\n[…项目上下文单文件截断]"
+		}
+		if total+len(text) > totalBudget {
+			break
+		}
+		rel, _ := filepath.Rel(abs, f)
+		if rel == "" {
+			rel = f
+		}
+		b.WriteString("\n\n<project_context path=\"" + f + "\">\n")
+		b.WriteString(text)
+		b.WriteString("\n</project_context>")
+		total += len(text)
+	}
+	// cwd/.pi/SYSTEM.md 自定义系统提示（需在 cwd 内，天然可信）。
+	if sys := filepath.Join(abs, ".pi", "SYSTEM.md"); true {
+		if st, err := os.Stat(sys); err == nil && !st.IsDir() && st.Size() > 0 && st.Size() < 32<<10 {
+			if data, err := os.ReadFile(sys); err == nil {
+				text := strings.TrimSpace(string(data))
+				if text != "" {
+					if len(text) > perFile {
+						text = text[:perFile] + "\n[…SYSTEM.md 截断]"
+					}
+					b.WriteString("\n\n<custom_system_prompt>\n" + text + "\n</custom_system_prompt>")
+				}
+			}
+		}
+	}
+	return b.String()
+}
+
+// buildToolPromptSection 把注册表工具 Doc 拼成系统提示词段（对齐 pi toolSnippets）。
+// 只列当前 turn 激活工具；生图未注册时不提 generate_image，避免模型幻觉调用。
+func buildToolPromptSection(reg *tools.Registry) string {
+	if reg == nil {
+		return ""
+	}
+	names := reg.Names()
+	if len(names) == 0 {
+		return ""
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	b.WriteString("\n# 可用工具\n\n")
+	for _, n := range names {
+		doc := ""
+		for _, s := range reg.Schemas() {
+			if s.Name == n {
+				doc = s.Description
+				break
+			}
+		}
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			b.WriteString("- " + n + "\n")
+			continue
+		}
+		// 单工具多行 Doc 压成紧凑块，首行加粗。
+		lines := strings.Split(doc, "\n")
+		b.WriteString("- " + n + ": " + strings.TrimSpace(lines[0]) + "\n")
+		for _, ln := range lines[1:] {
+			if strings.TrimSpace(ln) != "" {
+				b.WriteString("  " + strings.TrimSpace(ln) + "\n")
+			}
+		}
+	}
+	b.WriteString("\n- 文件探索优先 glob/grep 定位，再 read 精读；修改优先 edit 多块批量，整文件重写才用 write。\n")
+	b.WriteString("- 回复简洁，涉及文件必须给相对工作目录的路径。\n")
+	return b.String()
+}

--- a/internal/server/nativeagent.go
+++ b/internal/server/nativeagent.go
@@ -409,21 +409,26 @@ func (n *nativeAgentService) Prompt(text string, attachments []agentbridge.Attac
 			return nil // 压实失败不终止 turn；下一步仍会重试
 		}
 		mem.CompactInPlace(out, outOrigins, stats)
+		// 压实后重置 usage 观测为新历史估算，避免 stale 大值导致每步重复压实（pi stale guard）。
+		n.usageHolder.reset(llm.EstimateHistoryTokens(out))
 		n.persist(sessionID, agentkit.Record{
 			Origin: agentkit.OriginInjection, Role: llm.RoleUser,
-			Text:   fmt.Sprintf("[上下文已压实: 折叠 %d 条，%d → %d tokens]", stats.CompactedCount, stats.TokensBefore, stats.TokensAfter),
+			Text:   fmt.Sprintf("[上下文已压实: 折叠 %d 条，保留尾部 %d 条，%d → %d tokens]", stats.CompactedCount, stats.RetainedTailCount, stats.TokensBefore, stats.TokensAfter),
 			TurnID: turnID,
 		})
-		n.broadcast(agentbridge.Event{Type: "notice", SessionID: sessionID, Text: fmt.Sprintf("长对话已自动压缩（折叠 %d 条消息）", stats.CompactedCount)})
+		n.broadcast(agentbridge.Event{Type: "notice", SessionID: sessionID, Text: fmt.Sprintf("长对话已自动压缩（折叠 %d 条消息，保留近期 %d 条）", stats.CompactedCount, stats.RetainedTailCount)})
 		return nil
 	}}
 
 	go func() {
 		defer cancel()
-		res, runErr := agentloop.RunTurn(turnCtx, agentloop.RunTurnInput{
+		// 系统提示词 = 基础契约 + 环境块 + 项目上下文 + 当 turn 工具表（对齐 pi _rebuildSystemPrompt）。
+		basePrompt := n.deps.SystemPrompt(buildEnvSection(n.cwd))
+		fullPrompt := basePrompt + loadProjectContext(n.cwd) + buildToolPromptSection(registry)
+		runInput := agentloop.RunTurnInput{
 			TurnID:       turnID,
 			Provider:     provider,
-			SystemPrompt: n.deps.SystemPrompt(buildEnvSection(n.cwd)),
+			SystemPrompt: fullPrompt,
 			Memory:       mem,
 			Tools:        &tools.ToolsAdapter{Registry: registry},
 			PermGate:     &nativePermGate{svc: n, registry: registry},
@@ -432,7 +437,15 @@ func (n *nativeAgentService) Prompt(text string, attachments []agentbridge.Attac
 			MaxRetries:   3,
 			Hooks:        hooks,
 			Effort:       effort,
-		})
+		}
+		res, runErr := agentloop.RunTurn(turnCtx, runInput)
+		// 溢出单次恢复（对齐 pi overflowRecoveryUsed）：压实后重跑一次，不递归。
+		if runErr != nil && agentloop.IsContextOverflow(runErr) {
+			if emergencyCompact(turnCtx, n, mem, sessionID, turnID, provider) {
+				n.broadcast(agentbridge.Event{Type: "notice", SessionID: sessionID, Text: "上下文溢出，已紧急压缩并重试"})
+				res, runErr = agentloop.RunTurn(turnCtx, runInput)
+			}
+		}
 		// turn 收尾。
 		n.mu.Lock()
 		n.turnCancel = nil
@@ -849,6 +862,7 @@ func (n *nativeAgentService) StoredSessionHistory(id string) (agentbridge.Sessio
 			msgs = append(msgs, agentbridge.HistoryMessage{
 				Role:    "tool_result",
 				Content: payload.Output,
+				Media:   mediaRefsToBridge(r.Media),
 				Tool:    &agentbridge.ToolEvent{ID: r.ToolCallID, Status: toolStatusFromPayload(payload.Error)},
 			})
 		}

--- a/internal/server/nativeagent_events.go
+++ b/internal/server/nativeagent_events.go
@@ -13,6 +13,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -187,6 +188,55 @@ func (h *turnUsageHolder) lastInputTokens() int64 {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.tokens
+}
+
+// reset 压实后以新历史估算覆盖 stale 大值，避免每步重复触发。
+func (h *turnUsageHolder) reset(tokens int64) {
+	h.mu.Lock()
+	h.tokens = tokens
+	h.mu.Unlock()
+}
+
+// emergencyCompact 溢出时的兜底压实：激进尾部预算 + 失败时 DropOldest。
+// 返回是否成功压缩（成功才值得重试一次）。
+func emergencyCompact(ctx context.Context, n *nativeAgentService, mem *agentkit.CtxMemory, sessionID, turnID string, provider llm.Provider) bool {
+	msgs, origins := mem.Snapshot()
+	if len(msgs) < 5 {
+		return false
+	}
+	cfg := agentkit.DefaultCompactionConfig()
+	cfg.KeepRecentTokens = 8000 // 溢出时只保近期 8k，其余全折叠
+	out, outOrigins, stats, err := agentkit.Compact(msgs, origins, func(dropped []llm.Message) (string, error) {
+		return compactViaLLM(ctx, provider, dropped)
+	}, cfg)
+	if err != nil || stats.CompactedCount == 0 {
+		// 摘要失败：按 token 直接砍最老 30%（诚实 blind spot）。
+		total := llm.EstimateHistoryTokens(msgs)
+		rest, dropped := agentkit.DropOldest(msgs, total/3)
+		if dropped == 0 || len(rest) == 0 {
+			return false
+		}
+		// origins 同步截断（按消息数对齐）。
+		_, allOrigins := mem.Snapshot()
+		keepFrom := len(allOrigins) - len(rest)
+		if keepFrom < 0 {
+			keepFrom = 0
+		}
+		mem.CompactInPlace(rest, allOrigins[keepFrom:], agentkit.CompactionStats{CompactedCount: dropped})
+		n.persist(sessionID, agentkit.Record{
+			Origin: agentkit.OriginInjection, Role: llm.RoleUser,
+			Text:   fmt.Sprintf("[上下文溢出兜底: 直接丢弃最老 %d 条]", dropped),
+			TurnID: turnID,
+		})
+		return true
+	}
+	mem.CompactInPlace(out, outOrigins, stats)
+	n.persist(sessionID, agentkit.Record{
+		Origin: agentkit.OriginInjection, Role: llm.RoleUser,
+		Text:   fmt.Sprintf("[上下文溢出已压实: 折叠 %d 条，保留尾部 %d 条]", stats.CompactedCount, stats.RetainedTailCount),
+		TurnID: turnID,
+	})
+	return true
 }
 
 // compactViaLLM 用当前 Provider 生成一次压实摘要（非流式单调用）。

--- a/internal/tools/agenttools.go
+++ b/internal/tools/agenttools.go
@@ -108,26 +108,34 @@ func (GenerateImageTool) Schema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"prompt": map[string]any{"type": "string", "description": "图像描述（提示词）"},
-			"aspect": map[string]any{"type": "string", "description": "宽高比: 1:1 | 16:9 | 9:16 | 4:3 | 3:4（默认 1:1）"},
+			"prompt": map[string]any{"type": "string", "description": "图像描述（提示词，含主体、风格、构图、光线；越具体越好）"},
+			"aspect": map[string]any{"type": "string", "description": "宽高比: 1:1 | 16:9 | 9:16 | 4:3 | 3:4 | 3:2 | 2:3 | 4:5 | 21:9（默认 1:1）"},
 			"count":  map[string]any{"type": "integer", "description": "生成数量 1-4（默认 1）"},
+			"model":  map[string]any{"type": "string", "description": "生图模型（可选，空用供应商默认）"},
 		},
 		"required": []string{"prompt"},
 	}
 }
 
 func (GenerateImageTool) Doc() string {
-	return `生成图片（走本地生图引擎与账号池）。为获得好结果，提示词应描述主体、
-风格、构图与光线。返回保存路径；结果同时出现在画廊。`
+	return `生成图片（走本地生图引擎与账号池，结果进画廊）。提示词应描述主体、
+风格、构图与光线；如用户只说"画只猫"，应扩写为具体画面再调用。
+宽高比按用途选（头像1:1、壁纸16:9、手机9:16、海报3:4/4:5、横幅21:9）。
+单轮最多调用 4 次：一次生成即应向用户展示结果，不要换 prompt 反复复调；
+返回保存路径与图片引用；失败时按错误提示调整后重试，不要臆造图片链接。`
 }
 
 type genImageArgs struct {
 	Prompt string `json:"prompt"`
 	Aspect string `json:"aspect"`
 	Count  int    `json:"count"`
+	Model  string `json:"model"`
 }
 
-var allowedAspects = map[string]bool{"1:1": true, "16:9": true, "9:16": true, "4:3": true, "3:4": true, "3:2": true, "2:3": true}
+var allowedAspects = map[string]bool{
+	"1:1": true, "16:9": true, "9:16": true, "4:3": true, "3:4": true,
+	"3:2": true, "2:3": true, "4:5": true, "21:9": true,
+}
 
 func (t GenerateImageTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
 	var a genImageArgs
@@ -137,12 +145,16 @@ func (t GenerateImageTool) Execute(ctx context.Context, args json.RawMessage, en
 	if t.Engine == nil {
 		return ToolOutput{Text: "生图引擎未启用（设置中可开启生图）", IsError: true}
 	}
+	prompt := strings.TrimSpace(a.Prompt)
+	if len(prompt) > 2000 {
+		return ToolOutput{Text: "提示词过长（>2000 字符），请精简主体、风格、构图与光线后重试。", IsError: true}
+	}
 	aspect := a.Aspect
 	if aspect == "" {
 		aspect = "1:1"
 	}
 	if !allowedAspects[aspect] {
-		return ToolOutput{Text: fmt.Sprintf("不支持的宽高比 %q，可选: 1:1 16:9 9:16 4:3 3:4 3:2 2:3", aspect), IsError: true}
+		return ToolOutput{Text: fmt.Sprintf("不支持的宽高比 %q，可选: 1:1 16:9 9:16 4:3 3:4 3:2 2:3 4:5 21:9", aspect), IsError: true}
 	}
 	count := a.Count
 	if count <= 0 {
@@ -151,18 +163,22 @@ func (t GenerateImageTool) Execute(ctx context.Context, args json.RawMessage, en
 	if count > 4 {
 		count = 4
 	}
-	paths, err := t.Engine.Generate(ctx, a.Prompt, "", aspect, count)
+	paths, err := t.Engine.Generate(ctx, prompt, strings.TrimSpace(a.Model), aspect, count)
 	if err != nil {
-		return ToolOutput{Text: fmt.Sprintf("生图失败: %v", err), IsError: true}
+		return ToolOutput{Text: fmt.Sprintf("生图失败: %v（可换 prompt/宽高比后重试）", err), IsError: true}
+	}
+	if len(paths) == 0 {
+		return ToolOutput{Text: "生图引擎未返回图片，请重试。", IsError: true}
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "已生成 %d 张图片:\n", len(paths))
+	fmt.Fprintf(&b, "已生成 %d 张图片（%s，已进画廊）:\n", len(paths), aspect)
 	media := make([]llm.ContentPart, 0, len(paths))
 	for _, p := range paths {
 		b.WriteString(p)
 		b.WriteString("\n")
 		media = append(media, llm.ImagePart{URI: p, MimeType: "image/jpeg"})
 	}
+	b.WriteString("如已满足用户要求，请直接用文字回复用户并展示图片，不要重复调用本工具（除非用户要求更多）。")
 	return ToolOutput{
 		Text:  b.String(),
 		Media: media,

--- a/internal/tools/defaults.go
+++ b/internal/tools/defaults.go
@@ -19,6 +19,9 @@ func DefaultRegistry(getEnv func() agentfs.Env, imageGen ImageGenerator, approve
 	reg.Register(ExitPlanModeTool{Approver: approver})
 	if imageGen != nil {
 		reg.Register(GenerateImageTool{Engine: imageGen})
+		// 单轮调用上限：防模型成功后不停换 prompt 复调烧额度（实测连调 28 次）。
+		// 注册表按 turn 重建，计数按 turn 清零；正常多图需求（count≤4/轮内少量复调）不受影响。
+		reg.SetCallLimit("generate_image", 4)
 	}
 	return reg
 }

--- a/internal/tools/filetools.go
+++ b/internal/tools/filetools.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"grok_switch/internal/agentfs"
+	"grok_switch/internal/llm"
 )
 
 // --- read ---
@@ -28,8 +30,9 @@ func (ReadTool) Schema() map[string]any {
 }
 
 func (ReadTool) Doc() string {
-	return `读取文本文件内容，带行号返回。支持 offset/limit 分页读取大文件。
-读图片请用 read_media。cat/head/tail 一律用本工具代替。`
+	return `读取文件内容，带行号返回。支持 offset/limit 分页读取大文件。
+图片（png/jpg/gif/webp/bmp）直接返回画廊引用与 Media，不做 base64。
+cat/head/tail 一律用本工具代替。`
 }
 
 type readArgs struct {
@@ -52,6 +55,20 @@ func (ReadTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.E
 	abs, err := env.Guard(a.Path)
 	if err != nil {
 		return ToolOutput{Text: err.Error(), IsError: true}
+	}
+	// 图片分支：按扩展名判定，先 Stat 校验存在性，直接回 URI 引用（对齐 pi processImage）。
+	if isImagePath(abs) {
+		st := env.Stat(abs)
+		if !st.Exists {
+			return ToolOutput{Text: fmt.Sprintf("读取失败: 文件不存在 %s", abs), IsError: true}
+		}
+		if st.IsDir {
+			return ToolOutput{Text: fmt.Sprintf("读取失败: %s 是目录", abs), IsError: true}
+		}
+		return ToolOutput{
+			Text:  fmt.Sprintf("[图片: %s（%d 字节，直接在画廊查看）]", abs, st.Size),
+			Media: []llm.ContentPart{llm.ImagePart{URI: abs, MimeType: imageMime(abs)}},
+		}
 	}
 	content, err := env.ReadText(abs, readMaxBytes)
 	if err != nil {
@@ -145,37 +162,48 @@ func (EditTool) Schema() map[string]any {
 		"type": "object",
 		"properties": map[string]any{
 			"path":       map[string]any{"type": "string", "description": "目标文件路径"},
-			"old_string": map[string]any{"type": "string", "description": "要替换的原文（必须与文件内容精确匹配且唯一）"},
-			"new_string": map[string]any{"type": "string", "description": "替换后的新文本"},
+			"old_string": map[string]any{"type": "string", "description": "要替换的原文（单块模式，必须精确匹配且唯一）"},
+			"new_string": map[string]any{"type": "string", "description": "替换后的新文本（单块模式）"},
+			"edits": map[string]any{
+				"type": "array", "description": "多块批量替换（与 old_string/new_string 二选一，每块需唯一非重叠）",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"old_string": map[string]any{"type": "string"},
+						"new_string": map[string]any{"type": "string"},
+					},
+					"required": []string{"old_string", "new_string"},
+				},
+			},
 		},
-		"required": []string{"path", "old_string", "new_string"},
+		"required": []string{"path"},
 	}
 }
 
 func (EditTool) Doc() string {
-	return `在文件中做精确字符串替换。old_string 必须与文件内容完全一致且唯一命中；
-命中多处时工具会拒绝并提示补充上下文（把 old_string 写长一点以唯一定位）。
-创建新文件用 write。`
+	return `在文件中做精确字符串替换。单块用 old_string/new_string（必须唯一命中）；
+多块用 edits 数组一次提交多处不重叠替换，原子写回。old_string 命中多处时
+拒绝并提示补充上下文。创建新文件用 write。`
 }
 
-type editArgs struct {
-	Path      string `json:"path"`
+type editBlock struct {
 	OldString string `json:"old_string"`
 	NewString string `json:"new_string"`
 }
 
+type editArgs struct {
+	Path      string          `json:"path"`
+	OldString string          `json:"old_string"`
+	NewString string          `json:"new_string"`
+	Edits     json.RawMessage `json:"edits"`
+}
+
 func (EditTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.Env) ToolOutput {
-	var a editArgs
-	if err := json.Unmarshal(args, &a); err != nil || a.Path == "" {
-		return argHelp("edit", err, `{"path": "...", "old_string": "...", "new_string": "..."}`)
+	blocks, path, errText, isErr := normalizeEditArgs(args)
+	if isErr {
+		return ToolOutput{Text: errText, IsError: true}
 	}
-	if a.OldString == "" {
-		return ToolOutput{Text: "old_string 不能为空（清空文件请用 write）", IsError: true}
-	}
-	if a.OldString == a.NewString {
-		return ToolOutput{Text: "old_string 与 new_string 相同，无需编辑", IsError: true}
-	}
-	abs, err := env.Guard(a.Path)
+	abs, err := env.Guard(path)
 	if err != nil {
 		return ToolOutput{Text: err.Error(), IsError: true}
 	}
@@ -183,17 +211,145 @@ func (EditTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.E
 	if err != nil {
 		return ToolOutput{Text: fmt.Sprintf("读取失败: %v", err), IsError: true}
 	}
-	count := strings.Count(content, a.OldString)
-	switch count {
-	case 0:
-		return ToolOutput{Text: "old_string 在文件中未命中。请用 read 确认精确内容（注意缩进与换行）后再试。", IsError: true}
-	case 1:
-		updated := strings.Replace(content, a.OldString, a.NewString, 1)
-		if err := env.WriteText(abs, updated); err != nil {
-			return ToolOutput{Text: fmt.Sprintf("写回失败: %v", err), IsError: true}
+	// BOM 与换行归一：匹配在 \n 上做，写回时还原。
+	bom := ""
+	if strings.HasPrefix(content, "\xef\xbb\xbf") {
+		bom = "\xef\xbb\xbf"
+		content = strings.TrimPrefix(content, bom)
+	}
+	lineEnding := "\n"
+	if strings.Contains(content, "\r\n") {
+		lineEnding = "\r\n"
+		content = strings.ReplaceAll(content, "\r\n", "\n")
+	}
+	// 归一 blocks 的换行（模型可能用 \n 而文件是 \r\n，已在上步统一）。
+	updated := content
+	totalReplaced := 0
+	firstLine := 0
+	for i, b := range blocks {
+		oldN := strings.ReplaceAll(b.OldString, "\r\n", "\n")
+		newN := strings.ReplaceAll(b.NewString, "\r\n", "\n")
+		count := strings.Count(updated, oldN)
+		switch count {
+		case 0:
+			return ToolOutput{Text: fmt.Sprintf("第 %d 块 old_string 在文件中未命中。请用 read 确认精确内容（注意缩进与换行）后再试。", i+1), IsError: true}
+		case 1:
+			// 定位首改行号用于回显。
+			if idx := strings.Index(updated, oldN); idx >= 0 && firstLine == 0 {
+				firstLine = strings.Count(updated[:idx], "\n") + 1
+			}
+			updated = strings.Replace(updated, oldN, newN, 1)
+			totalReplaced++
+		default:
+			return ToolOutput{Text: fmt.Sprintf("第 %d 块 old_string 命中 %d 处，无法唯一定位。请在 old_string 中包含更多上下文使其唯一。", i+1, count), IsError: true}
 		}
-		return ToolOutput{Text: fmt.Sprintf("已编辑 %s（替换 1 处）", abs)}
+	}
+	// 写回时还原换行与 BOM。
+	if lineEnding != "\n" {
+		updated = strings.ReplaceAll(updated, "\n", lineEnding)
+	}
+	updated = bom + updated
+	if err := env.WriteText(abs, updated); err != nil {
+		return ToolOutput{Text: fmt.Sprintf("写回失败: %v", err), IsError: true}
+	}
+	if firstLine > 0 {
+		return ToolOutput{Text: fmt.Sprintf("已编辑 %s（替换 %d 处，首改第 %d 行）", abs, totalReplaced, firstLine)}
+	}
+	return ToolOutput{Text: fmt.Sprintf("已编辑 %s（替换 %d 处）", abs, totalReplaced)}
+}
+
+// normalizeEditArgs 兼容三种形态：
+//  1. {path, old_string, new_string} 单块（legacy）
+//  2. {path, edits: [{old_string,new_string}]} 多块
+//  3. edits 为 JSON 字符串（模型偶发 stringified）或单对象
+func normalizeEditArgs(args json.RawMessage) ([]editBlock, string, string, bool) {
+	var a editArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, "", fmt.Sprintf("参数解析失败: %v。期望 {\"path\": \"...\", \"old_string\": \"...\", \"new_string\": \"...\"} 或 {\"path\":..., \"edits\":[...]}", err), true
+	}
+	if strings.TrimSpace(a.Path) == "" {
+		return nil, "", "参数解析失败: 缺少 path。期望 JSON 对象字段: {\"path\": \"...\", \"old_string\": \"...\", \"new_string\": \"...\"}", true
+	}
+	// edits 优先（多块模式）。
+	if len(bytesTrimSpace(a.Edits)) > 0 && string(bytesTrimSpace(a.Edits)) != "null" {
+		blocks, err := parseEditBlocks(a.Edits)
+		if err != nil {
+			return nil, "", fmt.Sprintf("参数解析失败: %v。期望 edits 为 [{old_string,new_string}]", err), true
+		}
+		if len(blocks) == 0 {
+			return nil, "", "edits 不能为空（至少一块）。", true
+		}
+		for i, b := range blocks {
+			if b.OldString == "" {
+				return nil, "", fmt.Sprintf("第 %d 块 old_string 不能为空。", i+1), true
+			}
+		}
+		return blocks, a.Path, "", false
+	}
+	// 单块 legacy。
+	if a.OldString == "" {
+		return nil, "", "old_string 不能为空（清空文件请用 write；多块请用 edits）。", true
+	}
+	if a.OldString == a.NewString {
+		return nil, "", "old_string 与 new_string 相同，无需编辑", true
+	}
+	return []editBlock{{OldString: a.OldString, NewString: a.NewString}}, a.Path, "", false
+}
+
+// parseEditBlocks 兼容数组 / 单对象 / JSON 字符串三形态。
+func parseEditBlocks(raw json.RawMessage) ([]editBlock, error) {
+	trimmed := bytesTrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("edits 为空")
+	}
+	// JSON 字符串内嵌数组/对象：先解一层 string。
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var inner string
+		if err := json.Unmarshal(trimmed, &inner); err == nil {
+			trimmed = bytesTrimSpace(json.RawMessage(inner))
+		}
+	}
+	// 单对象 → 包一层数组。
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var single editBlock
+		if err := json.Unmarshal(trimmed, &single); err != nil {
+			return nil, err
+		}
+		return []editBlock{single}, nil
+	}
+	var blocks []editBlock
+	if err := json.Unmarshal(trimmed, &blocks); err != nil {
+		return nil, err
+	}
+	return blocks, nil
+}
+
+func bytesTrimSpace(b json.RawMessage) json.RawMessage {
+	return json.RawMessage(strings.TrimSpace(string(b)))
+}
+
+func isImagePath(p string) bool {
+	switch strings.ToLower(filepath.Ext(p)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp":
+		return true
 	default:
-		return ToolOutput{Text: fmt.Sprintf("old_string 命中 %d 处，无法唯一定位。请在 old_string 中包含更多上下文使其唯一。", count), IsError: true}
+		return false
+	}
+}
+
+func imageMime(p string) string {
+	switch strings.ToLower(filepath.Ext(p)) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".bmp":
+		return "image/bmp"
+	default:
+		return "image/jpeg"
 	}
 }

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -25,6 +25,10 @@ type Registry struct {
 	tools map[string]Tool
 	// ExtraHeaders 允许 server 层注入请求头（生图引擎等）。
 	getEnv func() agentfs.Env
+	// callLimits 单轮（本注册表实例生命周期内）各工具最大调用次数；
+	// 0/缺省表示不限。注册表按 turn 重建，计数天然按 turn 清零。
+	callLimits map[string]int
+	callCounts map[string]int
 }
 
 // Tool 是单个工具的接口。
@@ -46,7 +50,18 @@ type ToolOutput struct {
 
 // NewRegistry 构造注册表。getEnv 提供当前会话的沙箱环境（工作目录可变）。
 func NewRegistry(getEnv func() agentfs.Env) *Registry {
-	return &Registry{tools: map[string]Tool{}, getEnv: getEnv}
+	return &Registry{tools: map[string]Tool{}, getEnv: getEnv, callLimits: map[string]int{}, callCounts: map[string]int{}}
+}
+
+// SetCallLimit 设置某工具在本轮内的最大调用次数（防模型循环调用烧额度，
+// 如 generate_image 连调 28 次）。超限后不再执行，直接回 IsError 结果让模型收敛。
+func (r *Registry) SetCallLimit(name string, max int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.callLimits == nil {
+		r.callLimits = map[string]int{}
+	}
+	r.callLimits[name] = max
 }
 
 // Register 注册工具；同名覆盖（便于测试）。
@@ -99,9 +114,20 @@ func (r *Registry) Schemas() []llm.Tool {
 // Execute 实现 agentloop.ToolExecutor：参数解析 + 沙箱 + 预算截断。
 // 返回值通过 ToAgentloopResult 适配 agentloop.ToolExecutor 的签名（见 adapter.go）。
 func (r *Registry) ExecuteTool(ctx context.Context, call llm.ToolCall) ToolOutput {
-	r.mu.RLock()
+	r.mu.Lock()
 	t, ok := r.tools[call.Name]
-	r.mu.RUnlock()
+	limit := r.callLimits[call.Name]
+	if ok && limit > 0 {
+		if r.callCounts == nil {
+			r.callCounts = map[string]int{}
+		}
+		r.callCounts[call.Name]++
+		if r.callCounts[call.Name] > limit {
+			r.mu.Unlock()
+			return ToolOutput{Text: fmt.Sprintf("本轮 %s 已调用 %d 次达到上限（不再执行，不消耗额度）。请先向用户展示已有结果；如需更多，请向用户确认后再分轮生成。", call.Name, limit), IsError: true}
+		}
+	}
+	r.mu.Unlock()
 	if !ok {
 		return ToolOutput{Text: fmt.Sprintf("未知工具 %q", call.Name), IsError: true}
 	}

--- a/internal/tools/searchtools.go
+++ b/internal/tools/searchtools.go
@@ -24,6 +24,7 @@ func (GlobTool) Schema() map[string]any {
 		"properties": map[string]any{
 			"pattern": map[string]any{"type": "string", "description": "glob 模式，如 \"**/*.go\"、\"internal/**/*.md\""},
 			"path":    map[string]any{"type": "string", "description": "起始目录（默认工作目录）"},
+			"limit":   map[string]any{"type": "integer", "description": "最多返回条数（默认 200，上限 1000）"},
 		},
 		"required": []string{"pattern"},
 	}
@@ -31,12 +32,13 @@ func (GlobTool) Schema() map[string]any {
 
 func (GlobTool) Doc() string {
 	return `按 glob 模式列出文件路径（支持 ** 跨目录）。按文件名找文件用本工具，
-按内容搜索用 grep。结果按修改时间排序（最新在前），上限 200 条。`
+按内容搜索用 grep。结果字母序，上限 200 条；超限请收窄 pattern。`
 }
 
 type globArgs struct {
 	Pattern string `json:"pattern"`
 	Path    string `json:"path"`
+	Limit   int    `json:"limit"`
 }
 
 const globMaxResults = 200
@@ -71,18 +73,22 @@ func (GlobTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.E
 		return ToolOutput{Text: "(无匹配文件)"}
 	}
 	sort.Strings(matches)
+	maxResults := a.Limit
+	if maxResults <= 0 || maxResults > 1000 {
+		maxResults = globMaxResults
+	}
 	var b strings.Builder
 	shown := len(matches)
-	if shown > globMaxResults {
-		shown = globMaxResults
+	if shown > maxResults {
+		shown = maxResults
 	}
 	for i := 0; i < shown; i++ {
 		rel, _ := filepath.Rel(env.Cwd, matches[i])
 		b.WriteString(rel)
 		b.WriteString("\n")
 	}
-	if len(matches) > globMaxResults {
-		fmt.Fprintf(&b, "... (共 %d 个匹配，仅显示前 %d 个；请收窄 pattern)\n", len(matches), globMaxResults)
+	if len(matches) > maxResults {
+		fmt.Fprintf(&b, "... (共 %d 个匹配，仅显示前 %d 个；请收窄 pattern)\n", len(matches), maxResults)
 	}
 	return ToolOutput{Text: b.String()}
 }
@@ -165,10 +171,14 @@ func (GrepTool) Schema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"pattern":   map[string]any{"type": "string", "description": "正则表达式（RE2 语法）"},
-			"path":      map[string]any{"type": "string", "description": "搜索的文件或目录（默认工作目录）"},
-			"glob":      map[string]any{"type": "string", "description": "文件名过滤，如 \"*.go\""},
-			"max_items": map[string]any{"type": "integer", "description": "最多返回的匹配条数（默认 100）"},
+			"pattern":     map[string]any{"type": "string", "description": "正则表达式（RE2 语法；literal=true 时按字面匹配）"},
+			"path":        map[string]any{"type": "string", "description": "搜索的文件或目录（默认工作目录）"},
+			"glob":        map[string]any{"type": "string", "description": "文件名过滤，如 \"*.go\""},
+			"max_items":   map[string]any{"type": "integer", "description": "最多返回的匹配条数（默认 100，上限 1000）"},
+			"limit":       map[string]any{"type": "integer", "description": "max_items 别名"},
+			"ignore_case": map[string]any{"type": "boolean", "description": "忽略大小写（默认 false）"},
+			"literal":     map[string]any{"type": "boolean", "description": "按字面字符串匹配而非正则（默认 false）"},
+			"context":     map[string]any{"type": "integer", "description": "每条命中附带上下文行数（默认 0）"},
 		},
 		"required": []string{"pattern"},
 	}
@@ -176,14 +186,19 @@ func (GrepTool) Schema() map[string]any {
 
 func (GrepTool) Doc() string {
 	return `按正则搜索文件内容，返回命中文件、行号与行内容（截断到 500 字符）。
-搜索会跳过 .git、node_modules、二进制文件与超大文件（>2MB）。`
+支持 ignore_case/literal/context；搜索会跳过 .git、node_modules、二进制文件
+与超大文件（>2MB）。达到上限时提示收窄或 limit=2x。`
 }
 
 type grepArgs struct {
-	Pattern  string `json:"pattern"`
-	Path     string `json:"path"`
-	Glob     string `json:"glob"`
-	MaxItems int    `json:"max_items"`
+	Pattern    string `json:"pattern"`
+	Path       string `json:"path"`
+	Glob       string `json:"glob"`
+	MaxItems   int    `json:"max_items"`
+	Limit      int    `json:"limit"`
+	IgnoreCase bool   `json:"ignore_case"`
+	Literal    bool   `json:"literal"`
+	Context    int    `json:"context"`
 }
 
 const (
@@ -198,13 +213,30 @@ func (GrepTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.E
 	if err := json.Unmarshal(args, &a); err != nil || strings.TrimSpace(a.Pattern) == "" {
 		return argHelp("grep", err, `{"pattern": "regex", "path"?: ".", "glob"?: "*.go"}`)
 	}
-	re, err := regexp.Compile(a.Pattern)
+	pattern := a.Pattern
+	if a.Literal {
+		pattern = regexp.QuoteMeta(pattern)
+	}
+	if a.IgnoreCase {
+		pattern = "(?i)" + pattern
+	}
+	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return ToolOutput{Text: fmt.Sprintf("正则无效: %v", err), IsError: true}
 	}
 	max := a.MaxItems
+	if a.Limit > 0 {
+		max = a.Limit
+	}
 	if max <= 0 || max > 1000 {
 		max = grepDefaultItems
+	}
+	ctxLines := a.Context
+	if ctxLines < 0 {
+		ctxLines = 0
+	}
+	if ctxLines > 5 {
+		ctxLines = 5
 	}
 	base := env.Cwd
 	if a.Path != "" {
@@ -219,7 +251,7 @@ func (GrepTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.E
 		return ToolOutput{Text: fmt.Sprintf("路径不存在: %s", base), IsError: true}
 	}
 
-	grepState := &grepRun{re: re, env: env, glob: a.Glob, max: max}
+	grepState := &grepRun{re: re, env: env, glob: a.Glob, max: max, context: ctxLines}
 	if !st.IsDir {
 		grepState.searchFile(base)
 	} else {
@@ -232,16 +264,20 @@ type grepHit struct {
 	Path string
 	Line int
 	Text string
+	// ContextLines 命中行的上下文（context>0 时填充，不含命中行本身）。
+	Before []string
+	After  []string
 }
 
 type grepRun struct {
-	re     *regexp.Regexp
-	env    agentfs.Env
-	glob   string
-	max    int
-	hits   []grepHit
-	files  map[string]bool
-	capped bool
+	re      *regexp.Regexp
+	env     agentfs.Env
+	glob    string
+	max     int
+	context int
+	hits    []grepHit
+	files   map[string]bool
+	capped  bool
 }
 
 func (g *grepRun) walk(dir string, depth int) {
@@ -293,7 +329,8 @@ func (g *grepRun) searchFile(path string) {
 		g.files = map[string]bool{}
 	}
 	g.files[path] = true
-	for i, line := range strings.Split(content, "\n") {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
 		if len(g.hits) >= g.max {
 			g.capped = true
 			return
@@ -301,11 +338,34 @@ func (g *grepRun) searchFile(path string) {
 		if g.re.MatchString(line) {
 			text := line
 			if len(text) > grepMaxLineLen {
-				text = text[:grepMaxLineLen] + "…"
+				text = text[:grepMaxLineLen] + "…[行截断，用 read 看全行]"
 			}
-			g.hits = append(g.hits, grepHit{Path: path, Line: i + 1, Text: text})
+			hit := grepHit{Path: path, Line: i + 1, Text: text}
+			if g.context > 0 {
+				for k := maxInt(0, i-g.context); k < i; k++ {
+					hit.Before = append(hit.Before, truncateGrepLine(lines[k]))
+				}
+				for k := i + 1; k < len(lines) && k <= i+g.context; k++ {
+					hit.After = append(hit.After, truncateGrepLine(lines[k]))
+				}
+			}
+			g.hits = append(g.hits, hit)
 		}
 	}
+}
+
+func truncateGrepLine(s string) string {
+	if len(s) > grepMaxLineLen {
+		return s[:grepMaxLineLen] + "…"
+	}
+	return s
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func (g *grepRun) render(pattern string) ToolOutput {
@@ -320,10 +380,16 @@ func (g *grepRun) render(pattern string) ToolOutput {
 			curFile = rel
 			fmt.Fprintf(&b, "%s:\n", rel)
 		}
+		for j, before := range h.Before {
+			fmt.Fprintf(&b, "  %d- %s\n", h.Line-len(h.Before)+j, before)
+		}
 		fmt.Fprintf(&b, "  %d: %s\n", h.Line, h.Text)
+		for j, after := range h.After {
+			fmt.Fprintf(&b, "  %d+ %s\n", h.Line+1+j, after)
+		}
 	}
 	if g.capped {
-		fmt.Fprintf(&b, "... (达到 %d 条上限，结果已截断；请收窄 pattern)\n", g.max)
+		fmt.Fprintf(&b, "... (达到 %d 条上限，结果已截断；请收窄 pattern 或 limit=%d 再查)\n", g.max, g.max*2)
 	}
 	return ToolOutput{Text: b.String()}
 }

--- a/internal/tools/shelltools.go
+++ b/internal/tools/shelltools.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -32,7 +34,8 @@ func (BashTool) Schema() map[string]any {
 func (BashTool) Doc() string {
 	return `在 shell 中执行命令（git、构建、测试、包管理等）。每次调用独立 shell：
 变量与 cd 不跨调用保留，请在 command 内组合（&& / ; / 管道）或用 dir 参数。
-cat/sed/grep 等文件操作优先用专用工具。输出超长会被截断。`
+cat/sed/grep 等文件操作优先用专用工具。输出保尾截断：超长时保留尾部并落盘，
+提示 Full output 路径，模型可用 read 分段查看。`
 }
 
 type bashArgs struct {
@@ -74,16 +77,72 @@ func (BashTool) Execute(ctx context.Context, args json.RawMessage, env agentfs.E
 	}
 	if res.TimedOut {
 		fmt.Fprintf(&b, "[命令超时（%s），已终止]\n", timeout)
-		return ToolOutput{Text: b.String(), IsError: true}
+		return ToolOutput{Text: truncateBashTailWithEnv(b.String(), env), IsError: true}
 	}
 	if res.ExitCode != 0 {
 		fmt.Fprintf(&b, "[退出码: %d]\n", res.ExitCode)
-		return ToolOutput{Text: b.String(), IsError: true}
+		return ToolOutput{Text: truncateBashTailWithEnv(b.String(), env), IsError: true}
 	}
 	if b.Len() == 0 {
 		return ToolOutput{Text: "(命令成功，无输出)"}
 	}
-	return ToolOutput{Text: strings.TrimRight(b.String(), "\n")}
+	text := strings.TrimRight(b.String(), "\n")
+	if truncated, out := spillBashOutputWithEnv(text, env); truncated {
+		return ToolOutput{Text: out, Truncated: true}
+	}
+	return ToolOutput{Text: text}
+}
+
+// bashOutputBudget 保尾截断预算（对齐 pi truncateTail + 50KB）。
+const bashOutputBudget = 30000
+
+// truncateBashTailWithEnv 错误路径同样保尾截断，避免超长错误刷屏。
+func truncateBashTailWithEnv(s string, env agentfs.Env) string {
+	if len(s) <= bashOutputBudget {
+		return s
+	}
+	if spilled, out := spillBashOutputWithEnv(s, env); spilled {
+		_ = spilled
+		return out
+	}
+	return s[len(s)-bashOutputBudget:] + "\n\n[输出超长已截断，保留尾部]"
+}
+
+// truncateBashTail 兼容旧调用（无 env 时落 /tmp，模型不可读，仅保尾）。
+func truncateBashTail(s string) string {
+	return truncateBashTailWithEnv(s, agentfs.Env{})
+}
+
+// spillBashOutputWithEnv 超预算时落盘全量到沙箱内 .agent_tmp 并返回尾部 + 相对路径（供 read 分段查看）。
+func spillBashOutputWithEnv(s string, env agentfs.Env) (bool, string) {
+	if len(s) <= bashOutputBudget {
+		return false, s
+	}
+	tail := s[len(s)-25000:]
+	// 按行边界对齐，避免半行。
+	if idx := strings.Index(tail, "\n"); idx >= 0 && idx < 500 {
+		tail = tail[idx+1:]
+	}
+	// 沙箱内落盘：cwd/.agent_tmp/pi-bash-*.log，模型可用 read 查看。
+	if env.Cwd != "" {
+		tmpDir := filepath.Join(env.Cwd, ".agent_tmp")
+		if err := os.MkdirAll(tmpDir, 0o755); err == nil {
+			if f, err := os.CreateTemp(tmpDir, "pi-bash-*.log"); err == nil {
+				_, _ = f.WriteString(s)
+				_ = f.Close()
+				if rel, err := filepath.Rel(env.Cwd, f.Name()); err == nil {
+					return true, tail + fmt.Sprintf("\n\n[输出超长已截断，保留尾部。完整输出: %s，可用 read 分段查看]", rel)
+				}
+				return true, tail + fmt.Sprintf("\n\n[输出超长已截断，保留尾部。完整输出: %s]", f.Name())
+			}
+		}
+	}
+	return true, tail + "\n\n[输出超长已截断，保留尾部；可用更精确的命令（如 grep/head/tail/read）缩小范围]"
+}
+
+// spillBashOutput 兼容旧调用。
+func spillBashOutput(s string) (bool, string) {
+	return spillBashOutputWithEnv(s, agentfs.Env{})
 }
 
 // --- todo_list ---

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -251,9 +251,14 @@ func TestGenerateImageTool(t *testing.T) {
 		t.Fatalf("生图失败: %+v", out)
 	}
 
-	out = runTool(t, tool, `{"prompt": "x", "aspect": "21:9"}`, env)
+	out = runTool(t, tool, `{"prompt": "x", "aspect": "99:99"}`, env)
 	if !out.IsError {
 		t.Fatal("非法宽高比应拒绝")
+	}
+	// 新增比例 21:9 / 4:5 应合法（对齐 README）。
+	out = runTool(t, tool, `{"prompt": "x", "aspect": "21:9"}`, env)
+	if out.IsError {
+		t.Fatalf("21:9 应合法: %+v", out)
 	}
 
 	// 引擎未启用。
@@ -342,4 +347,25 @@ func TestAdapterBudgetTruncation(t *testing.T) {
 
 func mustCall(name, args string) llm.ToolCall {
 	return llm.ToolCall{ID: "t-" + name, Name: name, Arguments: json.RawMessage(args)}
+}
+
+func TestRegistryCallLimit(t *testing.T) {
+	env := testEnv(t)
+	reg := DefaultRegistry(func() agentfs.Env { return env }, fakeImageGen{}, nil, &TodoStore{})
+	// 前 4 次正常执行，第 5 次起被上限拦截且不再调引擎。
+	for i := 0; i < 4; i++ {
+		out := reg.ExecuteTool(context.Background(), mustCall("generate_image", `{"prompt":"cat"}`))
+		if out.IsError {
+			t.Fatalf("第 %d 次应成功: %+v", i+1, out)
+		}
+	}
+	out := reg.ExecuteTool(context.Background(), mustCall("generate_image", `{"prompt":"cat"}`))
+	if !out.IsError || !strings.Contains(out.Text, "达到上限") {
+		t.Fatalf("超限应拦截: %+v", out)
+	}
+	// 不相关工具不受影响。
+	out = reg.ExecuteTool(context.Background(), mustCall("read", `{"path":"nope.txt"}`))
+	if !out.IsError || strings.Contains(out.Text, "达到上限") {
+		t.Fatalf("其它工具不应被连带限流: %+v", out)
+	}
 }

--- a/ui/app.js
+++ b/ui/app.js
@@ -1842,7 +1842,17 @@ function updateConversationIdentity() {
   const session = state.activeAgentSession;
   if ($("activeChatTitle")) $("activeChatTitle").textContent = session?.title || "新对话";
   const cwd = session?.cwd || state.agentStatus?.cwd || $("agentCwd")?.value || "";
-  if ($("activeChatPath")) $("activeChatPath").textContent = cwd || "尚未选择工作目录";
+  const pathEl = $("activeChatPath");
+  if (pathEl) {
+    pathEl.textContent = cwd || "尚未选择工作目录";
+    // 修复：旧逻辑只写 textContent 从不移除 hidden，路径恒不可见。
+    pathEl.hidden = false;
+    pathEl.title = cwd || "";
+  }
+  if ($("openLocationLabel")) {
+    const name = cwd ? cwd.split(/[/\\]/).filter(Boolean).pop() : "";
+    $("openLocationLabel").textContent = name ? `打开 ${name}` : "打开位置";
+  }
   if ($("contextSessionId")) $("contextSessionId").textContent = session?.id || state.agentStatus?.session_id || "—";
   // Keep active project in sync with current workspace path.
   const matched = projectPathKeys().get(normalizePathKey(cwd));
@@ -2093,12 +2103,21 @@ function renderAgentStatus(status) {
   if (model && state.activeAgentSession && (!status.session_id || status.session_id === state.activeAgentSession.id)) {
     state.activeAgentSession.model = model;
   }
-  if ($("agentModelBadge")) $("agentModelBadge").textContent = model ? `MODEL ${model}` : "MODEL —";
+  if ($("agentModelBadge")) {
+    $("agentModelBadge").textContent = model ? `MODEL ${model}` : "MODEL —";
+    $("agentModelBadge").hidden = false;
+    $("agentModelBadge").title = model || "";
+  }
   if ($("contextModel")) $("contextModel").textContent = model || "—";
   populateComposerModelSelect();
   populateComposerStrengthSelect();
   if ($("contextSessionId")) $("contextSessionId").textContent = status.session_id || state.activeAgentSession?.id || "—";
-  if ($("activeChatPath")) $("activeChatPath").textContent = status.cwd || state.activeAgentSession?.cwd || $("agentCwd")?.value || "尚未选择工作目录";
+  const statusCwd = status.cwd || state.activeAgentSession?.cwd || $("agentCwd")?.value || "尚未选择工作目录";
+  if ($("activeChatPath")) {
+    $("activeChatPath").textContent = statusCwd;
+    $("activeChatPath").hidden = false;
+    $("activeChatPath").title = statusCwd;
+  }
   const running = agentIsRunning(status);
   const busy = stateName === "busy" || !!status.busy;
   if ($("agentStartBtn")) {
@@ -3564,32 +3583,156 @@ function bindToolPayloadLazyLoad(details) {
   details.dataset.lazyBound = "1";
   details.addEventListener("toggle", () => {
     if (!details.open) return;
-    const pre = details.querySelector("pre.agentToolDetail");
-    if (!pre || details.dataset.payloadReady === "1") return;
-    pre.textContent = details._toolPayload || "（无内容）";
-    pre.classList.remove("agentToolDetailPlaceholder");
+    if (details.dataset.payloadReady === "1") return;
+    renderToolPayloadBody(details);
     details.dataset.payloadReady = "1";
   });
 }
 
 function setToolPayloadLazy(details, payload) {
-  const pre = details.querySelector("pre.agentToolDetail");
-  if (!pre) return;
-  const formatted = payload == null ? "" : formatAgentPayload(payload);
-  details._toolPayload = formatted;
-  // Never auto-expand. While closed, keep a short placeholder so long histories
-  // do not pay for multi-KB tool text in the layout until the user opens them.
-  if (details.open) {
-    pre.textContent = formatted || "（无内容）";
-    pre.classList.remove("agentToolDetailPlaceholder");
-    details.dataset.payloadReady = "1";
-  } else {
-    pre.textContent = formatted ? "点击展开查看输入/输出" : "（无内容）";
-    pre.classList.add("agentToolDetailPlaceholder");
-    details.dataset.payloadReady = "0";
+  // 兼容旧单载荷入口：存为 output，input 保留。
+  if (payload != null && details._toolInput == null && details._toolOutput == null) {
+    details._toolOutput = formatAgentPayload(payload);
+  } else if (payload != null && details._toolOutput == null) {
+    details._toolOutput = formatAgentPayload(payload);
   }
-  pre.hidden = false;
+  renderToolPayloadBody(details, true);
   bindToolPayloadLazyLoad(details);
+}
+
+// 新双栏渲染：input/output 分区 + 复制 + 特殊类型（todo/diff/plan）。
+function renderToolPayloadBody(details, lazy = false) {
+  const wrap = details.querySelector(".agentToolBody");
+  if (!wrap) return;
+  const input = details._toolInput || "";
+  const output = details._toolOutput || "";
+  const kind = details.dataset.toolKind || "";
+  wrap.innerHTML = "";
+  const buildSection = (label, text, cls) => {
+    if (!text) return;
+    const sec = document.createElement("div");
+    sec.className = "agentToolSection " + cls;
+    const head = document.createElement("div");
+    head.className = "agentToolSectionHead";
+    const span = document.createElement("span");
+    span.textContent = label;
+    const copy = document.createElement("button");
+    copy.type = "button";
+    copy.className = "codeCopyBtn agentToolCopyBtn";
+    copy.textContent = "复制";
+    copy.addEventListener("click", (e) => {
+      e.stopPropagation();
+      copyText(text);
+      copy.textContent = "已复制";
+      setTimeout(() => { copy.textContent = "复制"; }, 1200);
+    });
+    head.append(span, copy);
+    const pre = document.createElement("pre");
+    pre.className = "agentToolDetail";
+    pre.textContent = text;
+    sec.append(head, pre);
+    wrap.append(sec);
+  };
+  // 输入区（折叠时占位，展开后懒填）。
+  if (input) {
+    if (!details.open && lazy && !details.dataset.userOpened) {
+      const ph = document.createElement("div");
+      ph.className = "agentToolDetailPlaceholder";
+      ph.textContent = "点击展开查看输入/输出";
+      wrap.append(ph);
+      details.dataset.payloadReady = "0";
+      return;
+    }
+    buildSection("输入", input, "agentToolInput");
+  }
+  // 特殊渲染：todo 清单 / edit diff 着色。
+  const special = renderToolSpecial(wrap, kind, input, output);
+  if (!special && output) buildSection(kind ? "输出" : "内容", output, "agentToolOutput");
+  else if (!special && !input && !output) {
+    const ph = document.createElement("div");
+    ph.className = "agentToolDetailPlaceholder";
+    ph.textContent = "（无内容）";
+    wrap.append(ph);
+  }
+  // bash 落盘文件链接：完整输出: path → 点击插入 read 提示。
+  if (output && /完整输出:\s*(\S+)/.test(output)) {
+    const m = output.match(/完整输出:\s*(\S+)/);
+    if (m && m[1]) {
+      const link = document.createElement("button");
+      link.type = "button";
+      link.className = "btn sm ghost agentToolFileLink";
+      link.textContent = `用 read 查看完整输出 (${m[1]})`;
+      link.addEventListener("click", () => {
+        const input = $("chatInput");
+        if (input) {
+          input.value = (input.value ? input.value + "\n" : "") + `请用 read 工具分段查看 ${m[1]} 的关键错误`;
+          input.focus();
+        }
+      });
+      wrap.append(link);
+    }
+  }
+  details.dataset.payloadReady = details.open || details.dataset.userOpened ? "1" : "0";
+  if (!details.open && !details.dataset.userOpened) {
+    // 保持折叠占位语义：已渲染但隐藏，toggle 时直接显示。
+    details.dataset.payloadReady = "1";
+  }
+}
+
+// 特殊工具富渲染：todo 清单 / edit 多块 / plan entries。返回 true 表示已处理输出区。
+function renderToolSpecial(wrap, kind, input, output) {
+  try {
+    // todo_list：从输入 items 渲染勾选清单。
+    if (kind === "todo_list" && input) {
+      const obj = tryParseToolJson(input);
+      const items = obj && Array.isArray(obj.items) ? obj.items : null;
+      if (items) {
+        const ul = document.createElement("ul");
+        ul.className = "agentTodoList";
+        for (const it of items) {
+          const li = document.createElement("li");
+          li.className = "agentTodoItem " + (it.status || "pending");
+          const box = document.createElement("span");
+          box.className = "agentTodoBox";
+          box.textContent = it.status === "completed" ? "☑" : it.status === "in_progress" ? "◐" : "☐";
+          const txt = document.createElement("span");
+          txt.textContent = it.content || "";
+          li.append(box, txt);
+          ul.append(li);
+        }
+        const sec = document.createElement("div");
+        sec.className = "agentToolSection agentToolOutput";
+        const head = document.createElement("div");
+        head.className = "agentToolSectionHead";
+        head.innerHTML = "<span>任务清单</span>";
+        sec.append(head, ul);
+        if (output) {
+          const pre = document.createElement("pre");
+          pre.className = "agentToolDetail";
+          pre.textContent = output;
+          sec.append(pre);
+        }
+        wrap.append(sec);
+        return true;
+      }
+    }
+    // edit：输出含“替换 N 处”时给成功态；输入含 edits 数组时逐块摘要。
+    if (kind === "edit" && input) {
+      const obj = tryParseToolJson(input);
+      if (obj && Array.isArray(obj.edits) && obj.edits.length > 1) {
+        const div = document.createElement("div");
+        div.className = "agentToolEditSummary";
+        div.textContent = `多块编辑 ${obj.edits.length} 处 · ${obj.path || ""}`;
+        wrap.append(div);
+      }
+    }
+  } catch { /* 富渲染失败回退纯文本 */ }
+  return false;
+}
+
+function tryParseToolJson(text) {
+  if (!text || typeof text !== "string") return null;
+  try { return JSON.parse(text); } catch { return null; }
 }
 
 function renderAgentTool(tool, isUpdate, sessionID = "") {
@@ -3600,28 +3743,52 @@ function renderAgentTool(tool, isUpdate, sessionID = "") {
     details = document.createElement("details");
     details.className = "agentTool";
     details.open = false;
-    details.innerHTML = `<summary><span class="agentToolSummaryMain"><span class="agentToolTitle"></span><span class="agentToolStatus"></span></span></summary><pre class="agentToolDetail agentToolDetailPlaceholder"></pre>`;
+    details.innerHTML = `<summary><span class="agentToolSummaryMain"><span class="agentToolTitle"></span><span class="agentToolStatus"></span></span><span class="agentToolElapsed"></span></summary><div class="agentToolBody"></div>`;
     chatMessagesRoot().append(details);
     agentTools.set(id, details);
+    details.dataset.toolStart = String(Date.now());
     bindToolPayloadLazyLoad(details);
   }
   // Always force collapsed during history mount / streaming updates unless user opened it.
-  if (!details.dataset.userOpened) details.open = false;
+  // 已出图的卡片不再强制折叠：图片是交付物，默认展开；用户仍可手动折叠。
+  if (!details.dataset.userOpened && !details.dataset.hasMedia) details.open = false;
   if (!details.dataset.userOpenedBound) {
     details.dataset.userOpenedBound = "1";
     details.addEventListener("toggle", () => {
-      if (details.open) details.dataset.userOpened = "1";
+      if (details.open) {
+        details.dataset.userOpened = "1";
+        renderToolPayloadBody(details);
+      }
     });
   }
 
   const title = tool.title || details.querySelector(".agentToolTitle").textContent || "工具调用";
   const status = tool.status || details.dataset.status || (isUpdate ? "更新" : "等待");
   details.dataset.status = status;
+  details.dataset.toolKind = tool.kind || details.dataset.toolKind || "";
   details.querySelector(".agentToolTitle").textContent = title;
-  details.querySelector(".agentToolStatus").textContent = agentToolStatusLabel(status);
-  const payload = tool.raw_output ?? tool.raw_input;
-  if (payload != null) setToolPayloadLazy(details, payload);
-  else if (!details._toolPayload) setToolPayloadLazy(details, null);
+  const statusEl = details.querySelector(".agentToolStatus");
+  statusEl.textContent = agentToolStatusLabel(status);
+  statusEl.dataset.status = status;
+  // 耗时：in_progress 记 start，完成时算秒数。
+  const elapsedEl = details.querySelector(".agentToolElapsed");
+  if (elapsedEl) {
+    if (status === "in_progress" && !details.dataset.toolStart) details.dataset.toolStart = String(Date.now());
+    if ((status === "completed" || status === "failed") && details.dataset.toolStart) {
+      const secs = Math.max(0, (Date.now() - Number(details.dataset.toolStart)) / 1000);
+      elapsedEl.textContent = secs >= 0.5 ? `${secs.toFixed(1)}s` : "";
+    } else if (status === "in_progress") {
+      elapsedEl.textContent = "…";
+    }
+  }
+  // 双栏存储：输入输出分别保留，有输出不再丢输入。
+  if (tool.raw_input != null) details._toolInput = formatAgentPayload(tool.raw_input);
+  if (tool.raw_output != null) details._toolOutput = formatAgentPayload(tool.raw_output);
+  else if (tool.raw_input == null && !details._toolInput && !details._toolOutput) {
+    details._toolInput = "";
+    details._toolOutput = "";
+  }
+  renderToolPayloadBody(details, true);
 
   if (!historyMountSilent) renderToolActivity(tool, id, title, status);
   const toolHint = `${tool.kind || ""} ${title}`;
@@ -3633,7 +3800,12 @@ function renderAgentTool(tool, isUpdate, sessionID = "") {
   const media = structuredMedia.length
     ? structuredMedia
     : (historyMountSilent ? [] : extractMediaFromPayload(tool.raw_output, toolHint));
-  if (media.length) appendAssistantMedia(media, sessionID);
+  // 工具产出的媒体渲染进各自卡片（不再堆到 assistant 气泡，避免多图错位到首个调用下）。
+  if (media.length) {
+    details.dataset.hasMedia = "1";
+    renderMessageMedia(details, media, sessionID);
+    if (!details.dataset.userOpened) details.open = true;
+  }
   if (!historyMountSilent) scrollChatToBottom();
 }
 
@@ -3686,8 +3858,15 @@ function formatAgentPayload(payload) {
 // 工具参数摘要：把「模型可读」的 JSON 转成「人可读」的关键行。
 // 常见字段（路径/命令/模式等）单行展示，长文本截断，其余字段收尾列出。
 function formatAgentPayloadObject(obj) {
-  const PRIORITY = ["path", "file_path", "command", "pattern", "query", "url", "description", "content", "old_string", "new_string"];
+  const PRIORITY = ["path", "file_path", "command", "pattern", "query", "url", "description", "content", "prompt", "aspect", "count", "model", "old_string", "new_string", "edits", "items", "limit", "glob", "ignore_case", "literal", "context", "timeout", "dir"];
   const summarizeValue = (value) => {
+    if (Array.isArray(value)) {
+      if (value.length === 0) return "[]";
+      // edits/items 数组给计数+首项预览，避免刷屏。
+      const first = typeof value[0] === "object" ? JSON.stringify(value[0]) : String(value[0]);
+      const oneLine = first.replace(/\s+/g, " ").trim();
+      return `[${value.length} 项] ${oneLine.length > 80 ? oneLine.slice(0, 77) + "…" : oneLine}`;
+    }
     const text = typeof value === "string" ? value : JSON.stringify(value);
     if (text == null) return "";
     const oneLine = text.replace(/\s+/g, " ").trim();
@@ -3735,8 +3914,14 @@ function showAgentPermission(permission) {
   if ($("permissionRejectBtn")) {
     $("permissionRejectBtn").dataset.optionId = reject?.id || "";
   }
-  $("permissionBar").hidden = false;
+  const bar = $("permissionBar");
+  bar.hidden = false;
+  bar.setAttribute("role", "alertdialog");
+  bar.setAttribute("aria-live", "assertive");
+  bar.setAttribute("aria-label", "工具权限确认");
   scrollChatToBottom(true);
+  // 可达性：出现即聚焦首要动作，支持 Enter/Esc。
+  setTimeout(() => { $("permissionAllowBtn")?.focus(); }, 60);
 }
 
 function showAgentPlan(plan, waiting) {
@@ -3744,21 +3929,64 @@ function showAgentPlan(plan, waiting) {
   state.agentPlan = { ...plan, waiting: waiting || plan.waiting };
   if ($("planSummary")) $("planSummary").textContent = waiting ? "需要确认执行计划" : "计划更新";
   if ($("planBody")) {
-    if (plan.body) {
+    // 富渲染：entries 按状态 pill 展示，body 保留 pre。
+    if (Array.isArray(plan.entries) && plan.entries.length) {
+      $("planBody").innerHTML = "";
+      const ul = document.createElement("ul");
+      ul.className = "agentPlanList";
+      plan.entries.forEach((e, i) => {
+        const li = document.createElement("li");
+        li.className = "agentPlanItem " + (e.status || "pending");
+        const num = document.createElement("span");
+        num.className = "agentPlanNum";
+        num.textContent = `${i + 1}.`;
+        const txt = document.createElement("span");
+        txt.className = "agentPlanText";
+        txt.textContent = e.content || "";
+        const pill = document.createElement("span");
+        pill.className = "agentPlanPill";
+        pill.textContent = e.status || "pending";
+        li.append(num, txt, pill);
+        ul.append(li);
+      });
+      $("planBody").append(ul);
+      if (plan.body) {
+        const pre = document.createElement("pre");
+        pre.className = "agentPlanRaw";
+        pre.textContent = plan.body;
+        $("planBody").append(pre);
+      }
+    } else if (plan.body) {
       $("planBody").textContent = plan.body;
-    } else if (Array.isArray(plan.entries) && plan.entries.length) {
-      $("planBody").textContent = plan.entries.map((e, i) =>
-        `${i + 1}. ${e.content || ""}${e.status ? ` [${e.status}]` : ""}`).join("\n");
     } else {
       $("planBody").textContent = "（无计划正文）";
+    }
+    // 复制按钮。
+    if (!$("planBody").querySelector(".agentPlanCopyBtn")) {
+      const copy = document.createElement("button");
+      copy.type = "button";
+      copy.className = "btn sm ghost agentPlanCopyBtn";
+      copy.textContent = "复制计划";
+      copy.addEventListener("click", () => {
+        copyText($("planBody").innerText || "");
+        copy.textContent = "已复制";
+        setTimeout(() => { copy.textContent = "复制计划"; }, 1200);
+      });
+      $("planBody").append(copy);
     }
   }
   const showActions = !!(plan.request_id && (waiting || plan.waiting));
   ["planApproveBtn", "planReviseBtn", "planDismissBtn"].forEach((id) => {
     if ($(id)) $(id).hidden = !showActions;
   });
-  if ($("planBar")) $("planBar").hidden = false;
+  const bar = $("planBar");
+  if (bar) {
+    bar.hidden = false;
+    bar.setAttribute("role", "alertdialog");
+    bar.setAttribute("aria-live", "assertive");
+  }
   scrollChatToBottom(true);
+  if (showActions) setTimeout(() => { $("planApproveBtn")?.focus(); }, 60);
 }
 
 async function respondAgentPlan(outcome) {
@@ -4217,8 +4445,11 @@ function normalizeStructuredMedia(media, sessionID = "") {
   const uri = String(media.uri || media.url || "").trim();
   const kind = inferMediaKind(media.kind || media.type || "", mimeType, uri);
   const rawData = typeof media.data === "string" ? media.data.replace(/\s+/g, "") : "";
-  const localSrc = localSessionMediaURL(uri, sessionID);
-  const referenceSrc = localSrc || safeMediaURL(uri);
+  // 本机服务端直出的文件路由（/imagine-output/ 等）直接同源加载，
+  // 不得走 /api/agent/media 会话代理（该代理只认会话目录内的文件，会 404）。
+  const directSrc = directServerFileURL(uri);
+  const localSrc = directSrc ? "" : localSessionMediaURL(uri, sessionID);
+  const referenceSrc = directSrc || localSrc || safeMediaURL(uri);
   let src = "";
   if (rawData && /^[A-Za-z0-9+/_-]+={0,2}$/.test(rawData)) {
     const dataMime = mimeType || ({ image: "image/png", video: "video/mp4", audio: "audio/mpeg" })[kind];
@@ -4236,6 +4467,8 @@ function localSessionMediaURL(value, sessionID) {
   value = String(value || "").trim();
   sessionID = String(sessionID || "").trim();
   if (!value || !sessionID || value.startsWith("/api/agent/media?")) return "";
+  // 服务端直出文件路由走同源直连，不进会话代理。
+  if (directServerFileURL(value)) return "";
   const windowsPath = /^[a-z]:[\\/]/i.test(value);
   let local = windowsPath || /^file:/i.test(value) || !/^[a-z][a-z0-9+.-]*:/i.test(value);
   if (!local) {
@@ -4255,6 +4488,21 @@ function localSessionMediaURL(value, sessionID) {
 function safeMediaMime(value) {
   const mimeType = String(value || "").trim().toLowerCase();
   return /^[a-z0-9][a-z0-9.+-]*\/[a-z0-9][a-z0-9.+-]*$/.test(mimeType) ? mimeType : "";
+}
+
+// directServerFileURL 服务端同源直出的文件路由（如 /imagine-output/a.jpg）。
+// 这类 URI 本就由本机 HTTP 服务公开提供，无需会话鉴权，直接加载即可。
+function directServerFileURL(value) {
+  const v = String(value || "").trim();
+  if (!v.startsWith("/") || v.startsWith("//") || v.startsWith("/api/agent/media")) return "";
+  const path = v.split(/[?#]/, 1)[0];
+  if (!/\.[a-z0-9]{2,5}$/i.test(path)) return "";
+  if (path.includes("..")) return "";
+  try {
+    return new URL(v, location.href).href;
+  } catch {
+    return "";
+  }
 }
 
 function safeMediaURL(value) {
@@ -7051,6 +7299,24 @@ document.addEventListener("keydown", (event) => {
     return;
   }
   if (event.key === "Escape" && $("chatThemeDialog")?.open) {
+    return;
+  }
+  // 审批优先：Esc 拒绝当前权限/计划，避免误停生成。
+  if (event.key === "Escape" && state.view === "chat" && !$("permissionBar")?.hidden) {
+    event.preventDefault();
+    respondAgentPermission(false, false);
+    return;
+  }
+  if (event.key === "Escape" && state.view === "chat" && !$("planBar")?.hidden && state.agentPlan?.request_id) {
+    event.preventDefault();
+    respondAgentPlan("abandoned");
+    return;
+  }
+  // 抽屉优先关闭，再停生成。
+  if (event.key === "Escape" && state.view === "chat" &&
+    ($("sessionSidebar")?.classList.contains("open") || $("contextRail")?.classList.contains("open"))) {
+    event.preventDefault();
+    closeNativeChatPanels();
     return;
   }
   if (event.key === "Escape" && state.view === "chat" && (state.agentStatus?.state === "busy" || state.agentStatus?.busy)) {

--- a/ui/style.css
+++ b/ui/style.css
@@ -3289,7 +3289,22 @@ html[data-chat-theme="custom"] .chatEmpty {
   font-size: 13px;
   font-weight: 600;
 }
-.conversationSignals .modelBadge { display: none; }
+.activeChatPath {
+  display: block;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--muted);
+}
+.conversationSignals .modelBadge {
+  display: inline-flex;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .agentStatusBadge {
   min-height: 26px;
   padding: 0 8px;
@@ -4186,6 +4201,45 @@ body.resizingChatPanels * {
   cursor: pointer;
   user-select: none;
 }
+.agentToolBody { display: grid; gap: 8px; padding: 0 10px 10px; }
+.agentTool:not([open]) .agentToolBody { display: none; }
+.agentToolSectionHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+.agentToolSection pre.agentToolDetail { margin: 0; max-height: 260px; }
+.agentToolCopyBtn { font-size: 11px; padding: 2px 8px; }
+.agentToolElapsed { font-size: 11px; color: var(--muted); margin-left: 8px; }
+.agentToolStatus[data-status="failed"] { color: var(--danger, #c00); }
+.agentToolStatus[data-status="completed"] { color: var(--ok, #1a7f37); }
+.agentTodoList { list-style: none; margin: 0; padding: 0; display: grid; gap: 4px; }
+.agentTodoItem { display: flex; gap: 8px; align-items: baseline; font-size: 12px; }
+.agentTodoItem.completed { color: var(--muted); text-decoration: line-through; }
+.agentTodoItem.in_progress { font-weight: 600; }
+.agentTodoBox { width: 18px; flex: none; }
+.agentToolEditSummary { font-size: 12px; color: var(--muted); }
+.agentToolFileLink { justify-self: start; }
+.agentTool .chatMessageMedia { padding: 0 10px 10px; }
+.agentTool:not([open]) .chatMessageMedia { display: none; }
+.agentPlanList { list-style: none; margin: 0 0 8px; padding: 0; display: grid; gap: 6px; }
+.agentPlanItem { display: flex; gap: 8px; align-items: baseline; font-size: 12px; }
+.agentPlanNum { color: var(--muted); flex: none; }
+.agentPlanPill {
+  margin-left: auto;
+  font-size: 10px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+.agentPlanItem.completed .agentPlanPill { color: var(--ok, #1a7f37); border-color: currentColor; }
+.agentPlanItem.in_progress .agentPlanPill { color: var(--accent); border-color: currentColor; }
+.agentPlanRaw { margin-top: 8px; }
+.agentPlanCopyBtn { margin-top: 8px; }
 .agentTool:not([open]) pre.agentToolDetail {
   max-height: 0;
   margin: 0;


### PR DESCRIPTION
对标 pi-main 审计后的借鉴落地（只读分析见会话记录）。

## 上下文工程
- 压实新增尾部完整保留（KeepRecentTokens 20k，切点永不在 tool_result 处）+ 文件操作清单（read/modified）+ 图片 token 800→4800
- 溢出单次恢复（emergencyCompact）+ 压实后 usage 重置防 stale 重复触发

## 工具调用
- edit 多块 edits[]/JSON串/单对象兼容 + BOM/CRLF 归一还原
- read 图片分支（URI 引用）、bash 保尾截断 + 沙箱内 .agent_tmp 落盘
- grep 新增 ignore_case/literal/context/limit、glob 新增 limit
- generate_image 单轮 4 次上限（防连调 28 次烧额度）+ 结果 stop 指引

## 提示词 / 循环
- 每 turn 注入工具表 + AGENTS/SYSTEM 项目上下文
- agentloop IsContextOverflow，溢出走压实恢复而非退避重试

## 前端
- 工具输入/输出双栏 + 复制、todo/plan 富渲染、耗时显示
- /imagine-output/ 同源直连（修媒体 404）、历史 tool_result 补 Media、媒体渲染进各自卡片并自动展开
- 顶栏路径/模型可见性修复、审批焦点与 Esc 优先级

验证：gofmt/vet clean；agentkit/agentloop/tools/llm/server（Native）测试全绿。